### PR TITLE
It seems not to require setuptools.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include reddit/*.cfg

--- a/setup.py
+++ b/setup.py
@@ -8,6 +8,7 @@ setup(
     name='reddit',
     version='1.0',
     packages=['reddit'],
+    package_data={'reddit': ['*.cfg']},
     author='mellort',
     author_email='timothy.mellor+pip@gmail.com',
     description='A Python wrapper for the Reddit API',


### PR DESCRIPTION
It seems not to require `setuptools`.  Added a common fallback for `setuptools` (`distutils` is a part of Python standard library).  This patch make the package able to be installed under system that doesn’t have `setuptools`, like:

``` console
$ python setup.py install
```
