### PR TITLE
r.login() parameters in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A Few Short Examples
 0. Logging in:
 
     ```python
-r.login(user='username', password='password')
+r.login('username', 'password')
 ```
 
 0. Send a message (requires login):


### PR DESCRIPTION
Bboe changed the login parameter names from user/password to username/password in commit b57d14887490c2d1f4711df8bf4cd16fd9ba2166, breaking the example in the README.md file. My commit simply does away with the named parameter use in the readme alltogether. It does not touch any code of the project.
