### PR TITLE
httplib.IncompleteRead exception handling

### DIFF
--- a/reddit/__init__.py
+++ b/reddit/__init__.py
@@ -19,6 +19,7 @@ import warnings
 import urllib2
 import urlparse
 import json
+import httplib
 
 import reddit.decorators
 import reddit.errors
@@ -167,6 +168,10 @@ class BaseReddit(object):
                 remaining_attempts -= 1
                 if (error.code not in self.RETRY_CODES or
                     remaining_attempts == 0):
+                    raise
+            except httplib.IncompleteRead:
+                remaining_attempts -=1
+                if remaining_attempts == 0:
                     raise
 
     def _json_reddit_objecter(self, json_data):


### PR DESCRIPTION
While crawling comments, every hour or two I would get an exception with a traceback ending with:
httplib.IncompleteRead: IncompleteRead(1555 bytes read)

This may be an problem on my end, or an issue with Reddit. Regardless, the library should probably be able to work through this hiccup without ending the whole program.

So I added exception handling for http.IncompleteRead to response.read() in helpers._request. If the connection is terminated before read is complete, the response will be read again until successful or a different error is raised.  Repeating the whole read operation does not seem to be an issue since the amount of data lost was relatively small.
