### PR TITLE
Add timeout flag to Reddit._request

### DIFF
--- a/reddit/__init__.py
+++ b/reddit/__init__.py
@@ -106,6 +106,7 @@ class Config(object):  # pylint: disable-msg=R0903
                               self.by_kind.items())
         self.by_object[reddit.objects.LoggedInRedditor] = obj['redditor_kind']
         self.cache_timeout = float(obj['cache_timeout'])
+        self.timeout = float(obj['timeout'])
         self.default_content_limit = int(obj['default_content_limit'])
         self.domain = obj['domain']
         try:
@@ -150,7 +151,7 @@ class BaseReddit(object):
     def __str__(self):
         return 'Open Session (%s)' % (self.user or 'Unauthenticated')
 
-    def _request(self, page_url, params=None, url_data=None):
+    def _request(self, page_url, params=None, url_data=None, timeout=None):
         """Given a page url and a dict of params, opens and returns the page.
 
         :param page_url: the url to grab content from.
@@ -159,11 +160,12 @@ class BaseReddit(object):
         :returns: the open page
         """
         # pylint: disable-msg=W0212
+        timeout = self.config.timeout if timeout is None else timeout
         remaining_attempts = 3
         while True:
             try:
                 return reddit.helpers._request(self, page_url, params,
-                                               url_data)
+                                               url_data, timeout)
             except urllib2.HTTPError, error:
                 remaining_attempts -= 1
                 if (error.code not in self.RETRY_CODES or

--- a/reddit/helpers.py
+++ b/reddit/helpers.py
@@ -82,7 +82,11 @@ def _modify_relationship(relationship, unlink=False, is_sub=False):
 
 @Memoize
 @SleepAfter
-def _request(reddit_session, page_url, params=None, url_data=None):
+def _request(
+        reddit_session, page_url,
+        params=None, url_data=None,
+        timeout=45
+        ):
     if isinstance(page_url, unicode):
         page_url = urllib.quote(page_url.encode('utf-8'), ':/')
     if url_data:
@@ -94,5 +98,5 @@ def _request(reddit_session, page_url, params=None, url_data=None):
     request = urllib2.Request(page_url, data=encoded_params,
                               headers=reddit_session.DEFAULT_HEADERS)
     # pylint: disable-msg=W0212
-    response = reddit_session._opener.open(request)
+    response = reddit_session._opener.open(request, timeout=timeout)
     return response.read()

--- a/reddit/reddit_api.cfg
+++ b/reddit/reddit_api.cfg
@@ -5,6 +5,9 @@ api_request_delay: 2.0
 # Time, in seconds, to save the results of a get/post request.
 cache_timeout: 30
 
+# Timeout, in seconds, for requests to reddit
+timeout: 45
+
 # How many results to retrieve by default when making content calls
 default_content_limit: 25
 

--- a/reddit/reddit_test.py
+++ b/reddit/reddit_test.py
@@ -23,9 +23,9 @@ import unittest
 import uuid
 import warnings
 from urlparse import urljoin
-from urllib2 import HTTPError
+from urllib2 import HTTPError, URLError
 
-from reddit import Reddit, errors, VERSION
+from reddit import Reddit, errors, helpers, VERSION
 from reddit.objects import Comment, LoggedInRedditor, Message, MoreComments
 
 USER_AGENT = 'reddit_api test suite %s' % VERSION
@@ -127,6 +127,10 @@ class BasicTest(unittest.TestCase, BasicHelper):
 
     def test_search_reddit_names(self):
         self.assertTrue(len(self.r.search_reddit_names('reddit')) > 0)
+
+    def test_timeout(self):
+        self.assertRaises(URLError,
+                          helpers._request, self.r, self.r.config['comments'], timeout=0.001)
 
 
 class EncodingTest(unittest.TestCase, BasicHelper):


### PR DESCRIPTION
This patch adds a timeout argument to Reddit._request. It defaults to 30, in reddit_api.cfg. This prevents client application lockups due to waiting indefinitely on an API call to finish.
