### PR TITLE
Added an option to log the underlying http requests being made, useful for debugging/learning

### DIFF
--- a/praw/__init__.py
+++ b/praw/__init__.py
@@ -119,6 +119,8 @@ class Config(object):  # pylint: disable-msg=R0903
         self.default_content_limit = int(obj['default_content_limit'])
         self.domain = obj['domain']
         self.more_comments_max = int(obj['more_comments_max'])
+        self.log_requests = int(obj['log_requests'])
+
         if 'short_domain' in obj:
             self._short_domain = 'http://' + obj['short_domain']
         else:

--- a/praw/helpers.py
+++ b/praw/helpers.py
@@ -15,6 +15,7 @@
 from . import backport
 backport.add_moves()
 
+import sys
 import six
 from six.moves import Request, quote, urlencode, urljoin
 from .decorators import Memoize, SleepAfter, require_login
@@ -97,6 +98,13 @@ def _request(reddit_session, page_url, params=None, url_data=None, timeout=45):
         encoded_params = urlencode(params).encode('utf-8')
     request = Request(page_url, data=encoded_params,
                       headers=reddit_session.DEFAULT_HEADERS)
+
+    if reddit_session.config.log_requests >= 1:
+        sys.stderr.write('retrieving: %s\n' % page_url)
+    if reddit_session.config.log_requests >= 2:
+        sys.stderr.write('data: %s\n' % (encoded_params or 'None'))
+
+        
     # pylint: disable-msg=W0212
     response = reddit_session._opener.open(request, timeout=timeout)
     return response.read()

--- a/praw/praw.ini
+++ b/praw/praw.ini
@@ -39,6 +39,12 @@ redditor_kind:   t2
 submission_kind: t3
 subreddit_kind:  t5
 
+# log the API calls
+# 0: no logging
+# 1: log only the request URIs
+# 2: log the request URIs as well as any POST data
+log_requests: 0
+
 [reddit]
 domain: www.reddit.com
 short_domain: redd.it


### PR DESCRIPTION
While learning about the API and debugging I've found it helpful to see the underlying http requests as they're made.

I would be happy to build this out to use more legitimate logging techniques, please let me know what your thoughts are.  I did it this way because it was quick & easy and the project doesn't use python's `logging` modules anywhere else.

Here's what my IPython terminal looks like with the logging:

```
In [14]: top5 = list(r.get_subreddit('funny').get_hot(limit=5))
retrieving: http://www.reddit.com/r/funny/.json
data: None

In [15]: top5
Out[15]:
[<praw.objects.Submission at 0x310ba90>,
 <praw.objects.Submission at 0x310b810>,
 <praw.objects.Submission at 0x2d20ad0>,
 <praw.objects.Submission at 0x2d200d0>,
 <praw.objects.Submission at 0x310bb90>]

In [16]: print len(top5[0].all_comments_flat)
retrieving: http://www.reddit.com/r/funny/comments/wbbaf/well_played_simpsons_ad_well_played/.json
data: None
retrieving: http://www.reddit.com/api/morechildren/.json
data: r=funny&link_id=t3_wbbaf&uh=5dq5xo1l2t1de3251a5922b4b27b9a3a5b9ce95758fa354e29&api_type=json&children=c5bwsba%2Cc5bwlpb%2Cc5bx076%2Cc5bx4yw
retrieving: http://www.reddit.com/api/morechildren/.json
data: r=funny&link_id=t3_wbbaf&uh=5dq5xo1l2t1de3251a5922b4b27b9a3a5b9ce95758fa354e29&api_type=json&children=c5bygra
retrieving: http://www.reddit.com/api/morechildren/.json
data: r=funny&link_id=t3_wbbaf&uh=5dq5xo1l2t1de3251a5922b4b27b9a3a5b9ce95758fa354e29&api_type=json&children=c5bxzep
203

In [17]:
```
