### PR TITLE
Gives the class Comment the attribute score through a property decorated function.

### DIFF
--- a/praw/objects.py
+++ b/praw/objects.py
@@ -277,6 +277,10 @@ class Comment(Approvable, Deletable, Distinguishable, Editable, Inboxable,
             reply._update_submission(submission)
 
     @property
+    def score(self):
+        return self.ups - self.downs
+
+    @property
     def is_root(self):
         return self.parent_id is None
 


### PR DESCRIPTION
Functions doing karma calculations can now use `score` for both submissions and comments.

I closed the previous pull request as I had accidentally pulled from mellorts now depreciated fork.
