### PR TITLE
Added Python version and dependency information to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ Or via `setup.py`
     # First download or checkout the code then run
     python setup.py install
 
+PRAW works with Python 2.6 or later.
+
+Installation via `pip` or `easy_install` automatically installs PRAW's only
+dependency, the module [six](http://pypi.python.org/pypi/six/). If you install 
+via `setup.py` you'll need to install `six` manually.
 
 # Examples and Configuration
 


### PR DESCRIPTION
The authors of praw-dev/praw#111 and a recent [r/learnpython](http://www.reddit.com/r/learnpython/comments/vxa9u/trouble_trying_reddit_api/) thread both had problems installing PRAW. This was because the user tried using PRAW with python 2.5 when it requires at least 2.6. Adding this information to the README should make it easier for people with a similar problem in the future to trouble shoot. 
