### PR TITLE
add prevstyle to set_stylesheet requests

### DIFF
--- a/praw/__init__.py
+++ b/praw/__init__.py
@@ -546,8 +546,10 @@ class SubredditExtension(BaseReddit):
     @decorators.require_moderator
     def set_stylesheet(self, subreddit, stylesheet):
         """Set stylesheet for the given subreddit."""
+		prev_stylesheet = self.get_stylesheet(subreddit)
         params = {'r': six.text_type(subreddit),
                   'stylesheet_contents': stylesheet,
+				  'prevstyle': prev_stylesheet['prevstyle'],
                   'op': 'save'}  # Options: save / preview
         return self.request_json(self.config['subreddit_css'], params)
 


### PR DESCRIPTION
Earlier in the week reddit rolled out a new wiki system which also included stylesheet versioning to prevent people from overwriting eachother's changes.

The attached code will perform a get_stylesheet request before the set_stylesheet request so it can pass along the prevstyle argument so the request goes through.

PS. sorry for the earlier pull request, it wanted to delete the whole file and create it again. oops.
