### PR TITLE
Renamed and move LoggedInExtension.get_saved_links

### DIFF
--- a/praw/__init__.py
+++ b/praw/__init__.py
@@ -691,7 +691,18 @@ class LoggedInExtension(BaseReddit):
 
     @decorators.require_login
     def get_saved_links(self, limit=0):
+        """
+        Return a listing of the logged-in user's saved links.
+
+        Moved to LoggedInRedditor and renamed to get_saved. You should now use
+        r.user.get_saved() instead of r.get_saved_links where
+        r = praw.Reddit(useragent).
+        """
+        # Remove around the end of Q1 2013
         """Return a listing of the logged-in user's saved links."""
+        warn('get_saved_links has been renamed to get_saved and moved to '
+             'LoggedInRedditor. get_saved_links will be removed in a future '
+             'version. Please update.', DeprecationWarning)
         return self.get_content(self.config['saved'], limit=limit)
 
     def login(self, username=None, password=None):

--- a/praw/objects.py
+++ b/praw/objects.py
@@ -513,6 +513,7 @@ class LoggedInRedditor(Redditor):
     get_disliked = _get_section('disliked')
     get_hidden = _get_section('hidden')
     get_liked = _get_section('liked')
+    get_saved = _get_section('saved')
 
     @require_login
     def get_inbox(self, limit=0):

--- a/praw/tests.py
+++ b/praw/tests.py
@@ -805,6 +805,14 @@ class SubmissionTest(unittest.TestCase, AuthenticatedHelper):
         submission = self.r.get_submission(submission_id=submission.id)
         self.assertEqual(None, submission.author)
 
+    def test_deprecated_saved_links(self):
+        subject = 'Deprecated Test'
+        with warnings.catch_warnings(record=True) as warning:
+            warnings.simplefilter('always')
+            self.r.get_saved_links()
+            self.assertEqual(len(warning), 1)
+            self.assertEqual(warning[0].category, DeprecationWarning)
+
     def test_downvote(self):
         submission = None
         for submission in self.r.user.get_submitted():
@@ -861,7 +869,7 @@ class SubmissionTest(unittest.TestCase, AuthenticatedHelper):
         submission = self.r.get_submission(submission_id=submission.id)
         self.assertTrue(submission.saved)
         # verify in saved_links
-        for item in self.r.get_saved_links():
+        for item in self.r.user.get_saved():
             if item == submission:
                 break
         else:


### PR DESCRIPTION
I would like to have get_saved_links renamed to get_saved and moved to LoggedInRedditor before the 1.1 update. It is the logical place for it to be now that there is get_liked, get_disliked and get_hidden there.
