### PR TITLE
Add configure_flair

### DIFF
--- a/praw/__init__.py
+++ b/praw/__init__.py
@@ -49,6 +49,7 @@ class Config(object):  # pylint: disable-msg=R0903
                  'edit':                'api/editusertext/',
                  'feedback':            'api/feedback/',
                  'flair':               'api/flair/',
+                 'flairconfig':         'api/flairconfig/',
                  'flaircsv':            'api/flaircsv/',
                  'flairlist':           'r/%s/api/flairlist/',
                  'flairtemplate':       'api/flairtemplate/',
@@ -392,6 +393,28 @@ class SubredditExtension(BaseReddit):
         params = {'r': six.text_type(subreddit),
                   'flair_type': 'LINK_FLAIR' if is_link else 'USER_FLAIR'}
         return self.request_json(self.config['clearflairtemplates'], params)
+
+    @decorators.require_login
+    @decorators.require_moderator
+    def configure_flair(self, subreddit, flair_enabled=False,
+                        flair_position='right',
+                        flair_self_assign=False,
+                        link_flair_enabled=False,
+                        link_flair_position='left',
+                        link_flair_self_assign=False):
+        """Configure the flair setting for the given subreddit."""
+        flair_enabled = 'on' if flair_enabled else 'off'
+        flair_self_assign = 'on' if flair_self_assign else 'off'
+        if not link_flair_enabled:
+            link_flair_position = ''
+        link_flair_self_assign = 'on' if link_flair_self_assign else 'off'
+        params = {'r': six.text_type(subreddit),
+                  'flair_enabled': flair_enabled,
+                  'flair_position': flair_position,
+                  'flair_self_assign_enabled': flair_self_assign,
+                  'link_flair_position': link_flair_position,
+                  'link_flair_self_assign_enabled': link_flair_self_assign}
+        return self.request_json(self.config['flairconfig'], params)
 
     def flair_list(self, subreddit, limit=None):
         """

--- a/praw/objects.py
+++ b/praw/objects.py
@@ -844,6 +844,10 @@ class Subreddit(Messageable, NSFWable, Refreshable):
         """Clear flair templates for this subreddit."""
         return self.reddit_session.clear_flair_templates(self, *args, **kwargs)
 
+    def configure_flair(self, *args, **kwargs):
+        """Set overall flair settings for this subreddit."""
+        return self.reddit_session.configure_flair(self, *args, **kwargs)
+
     def flair_list(self, *args, **kwargs):
         """Return a list of flair for this subreddit."""
         return self.reddit_session.flair_list(self, *args, **kwargs)


### PR DESCRIPTION
The big change.

c/p'ing some arguments from last time

> configure_flair currently doesn't come with any tests, because there doesn't seem to be any way of testing it via the api. I've tested it manually and everything seems to work as intended. Potentially we could test it by scraping Reddit, but I would prefer to keep all testing within the API.
> 
> I added the variable link_flair_enabled to configure_flair to make it identical to change link_flair and user_flair. I also stripped the trailing '_enabled', from the self_assign variables because they were a bit lengthy and link_flair_self_assign = True is perfectly readable.
