### PR TITLE
Documentation and style fixes/improvements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@
 
 PRAW, an acronym for "Python Reddit API Wrapper", is a python package that
 allows for simple access to reddit's API. PRAW aims to be as easy to use as
-possible. PRAW is coded to follow all of [reddit's API
-rules](https://github.com/reddit/reddit/wiki/API) so that you needn't worry
+possible and is designed to follow all of [reddit's API
+rules](https://github.com/reddit/reddit/wiki/API). You have to give a useragent
+that follows the rules, everything else is handled by PRAW so you needn't worry
 about violating them.
 
 Here's a quick peek, getting the first 5 submissions from
@@ -37,7 +38,10 @@ Or via `easy_install`
 
     easy_install praw
 
-Or via `setup.py`
+You can also install via `setup.py`, this requires either a download or
+checkout of the code first. Downloading PRAW from [the cheeseshop]
+(http://pypi.python.org/pypi/praw) is recommended, as downloading from github
+or doing a checkout may give you a between releases unstable codestate.
 
     # First download or checkout the code then run
     python setup.py install

--- a/praw/__init__.py
+++ b/praw/__init__.py
@@ -12,7 +12,17 @@
 # You should have received a copy of the GNU General Public License along with
 # PRAW.  If not, see <http://www.gnu.org/licenses/>.
 
-"""Reddit object."""
+"""
+Python Reddit API Wrapper.
+
+PRAW, an acronym for "Python Reddit API Wrapper", is a python package that
+allows for simple access to reddit's API. PRAW aims to be as easy to use as
+possible and is designed to follow all of reddit's API rules. You have to give
+a useragent, everything else is handled by PRAW so you needn't worry about
+violating them.
+
+More information about PRAW can be found at https://github.com/praw-dev/praw
+"""
 
 import json
 import os
@@ -349,8 +359,7 @@ class BaseReddit(object):
         :param url: the url to grab content from.
         :param params: a dictionary containing the GET data to put in the url
         :param data: a dictionary containing the extra data to submit
-        :param as_objects: Whether to return constructed reddit objects or the
-        raw json dict.
+        :param as_objects: if true return reddit objects else raw json dict.
         :returns: JSON processed page
         """
         url += '.json'
@@ -1028,7 +1037,8 @@ class Reddit(LoggedInExtension,  # pylint: disable-msg=R0904
         """
         Send feedback to the admins.
 
-        Please don't abuse this. Read the send feedback page before use.
+        Please don't abuse this. Read the send feedback page at
+        http://www.reddit.com/feedback/ (for reddit.com) before use.
         """
         data = {'name': name,
                 'email': email,

--- a/praw/errors.py
+++ b/praw/errors.py
@@ -50,14 +50,16 @@ class ModeratorRequired(ClientException):
 
 
 class OAuthException(ClientException):
-    """Raised when an OAuth API call fails.
+    """
+    Raised when an OAuth API call fails.
 
     The message attribute indicates the specific reddit OAuth exception.
     """
 
 
 class OAuthRequired(ClientException):
-    """Raised when an OAuth client cannot be initialized.
+    """
+    Raised when an OAuth client cannot be initialized.
 
     This occurs when any one of the OAuth config values are not set.
     """

--- a/praw/objects.py
+++ b/praw/objects.py
@@ -123,7 +123,13 @@ class Approvable(RedditContentObject):
     @require_login
     @require_moderator
     def approve(self):
-        """Give approval to object."""
+        """
+        Approve object.
+
+        This reverts a removal, resets the report counter, marks it with a
+        green checkmark (only visible to other moderators) on the webend and
+        sets the approved_by attribute to the logged in user.
+        """
         url = self.reddit_session.config['approve']
         data = {'id': self.content_id}
         response = self.reddit_session.request_json(url, data=data)
@@ -136,7 +142,13 @@ class Approvable(RedditContentObject):
     @require_login
     @require_moderator
     def remove(self, spam=False):
-        """Remove approval from object."""
+        """
+        Remove object. This is the moderator version of delete.
+
+        The object is removed from the subreddit listings and placed into the
+        spam listing. If spam is set to True, then the automatic spam filter
+        will try to remove objects with similair attributes in the future.
+        """
         url = self.reddit_session.config['remove']
         data = {'id': self.content_id,
                 'spam': 'True' if spam else 'False'}
@@ -167,9 +179,8 @@ class Distinguishable(RedditContentObject):
         """
         Distinguish object as made by mod, admin or special.
 
-        Distingusihed objects have a different background author color.
-        Similar to how the comments of the original poster are distinguished
-        from other comments in submissions.
+        Distinguished objects have a different author color. With Reddit
+        enhancement suite it is the background color that changes.
         """
         url = self.reddit_session.config['distinguish']
         data = {'id': self.content_id,
@@ -709,7 +720,7 @@ class Submission(Approvable, Deletable, Distinguishable, Editable, Hideable,
     @property
     def all_comments(self):
         """
-        Return forest of all comments, with top-level comments as tree roots
+        Return forest of all comments, with top-level comments as tree roots.
 
         Use a comment's replies to walk down the tree. To get an unnested,
         flat list if comments use all_comments_flat. Multiple API


### PR DESCRIPTION
Stuff changed, from commit msg
- param as_objects in request_json has been rephrased to keep it within
  one line as the automated documentation creater has problems if the
  final param (in the generated order) streches over multiple lines.
  - Change **init** docstring to reflect that it is the docstring for the
    PRAW package, eg what people get when they help(praw).
  - Add link to Reddit.com's feedback page to 'send_feedback'.
  - Put the summary part of the docstring on it's own line for consistency.
  - Modify README so the first three sentences doesn't start wiht 'PRAW',
    use the word 'designed' instead of 'coded' to show following API rules
    is a design decision, i.e something which won't change.
  - Added that downloading from github or checking out the code may
    return unstable development code.
