### PR TITLE
Oauth login.

### DIFF
--- a/praw/tests/__init__.py
+++ b/praw/tests/__init__.py
@@ -743,10 +743,9 @@ class OAuth2Test(unittest.TestCase):
                         disable_update_check=True)
         self.invalid = Reddit(USER_AGENT, disable_update_check=True)
 
-    def test_access_token(self):
+    def test_access_token_bad_code(self):
         if not os.getenv('INTERACTIVE'):
             return
-        self.r.set_oauth_app_info()
         print('Visit this URL: {0}'.format(self.r.get_authorize_url('...')))
         code = prompt('Code from redir URL: ')
         token = self.r.get_access_token(code)
@@ -755,12 +754,10 @@ class OAuth2Test(unittest.TestCase):
         self.assertNotEqual(None, self.r.user)
 
     def test_access_token_with_invalid_code(self):
-        self.r.set_oauth_app_info()
         self.assertRaises(errors.OAuthException, self.r.get_access_token,
                           'invalid_code')
 
     def test_authorize_url(self):
-        self.r.set_oauth_app_info()
         url, params = self.r.get_authorize_url('...').split('?', 1)
         self.assertTrue('api/v1/authorize/' in url)
         params = dict(x.split('=', 1) for x in params.split('&'))
@@ -772,24 +769,20 @@ class OAuth2Test(unittest.TestCase):
         self.assertEqual(expected, params)
 
     def test_invalid_app_access_token(self):
-        self.r.set_oauth_app_info()
         self.assertRaises(errors.OAuthRequired, self.invalid.get_access_token,
                           'dummy_code')
 
     def test_invalid_app_authorize_url(self):
-        self.r.set_oauth_app_info()
         self.assertRaises(errors.OAuthRequired, self.invalid.get_authorize_url,
                           'dummy_state')
 
     def test_invalid_set_access_credentials(self):
-        self.r.set_oauth_app_info()
         self.assertRaises(HTTPError, self.r.set_access_credentials,
                           'dummy_access_token')
 
     def test_refreshable_access_token(self):
         if not os.getenv('INTERACTIVE'):
             return
-        self.r.set_oauth_app_info()
         url = self.r.get_authorize_url('dummy_state', refreshable=True)
         print('Visit this URL: {0}'.format(url))
         code = prompt('Code from redir URL: ')
@@ -814,28 +807,24 @@ class OAuth2Test(unittest.TestCase):
     def test_oauth_without_identy_doesnt_set_user(self):
         if not os.getenv('INTERACTIVE'):
             return
-        self.r.set_oauth_app_info()
         url = self.r.get_authorize_url('dummy_state', 'edit',
                                        refreshable=False)
-        import webbrowser
         print('Visit this URL: {0}'.format(url))
-        webbrowser.open(url)
         code = prompt('Code from redir URL: ')
         self.assertTrue(self.r.user is None)
         self.r.get_access_token(code)
         self.assertTrue(self.r.user is None)
 
 
-    def test_oauth_info(self):
-        self.assertTrue(self.r.client_id is None)
-        self.assertTrue(self.r.client_secret is None)
-        self.assertTrue(self.r.redirect_uri is None)
-        self.assertRaises(errors.OAuthRequired, self.r.get_authorize_url,
+    def test_set_oauth_info(self):
+        self.assertRaises(errors.OAuthRequired, self.invalid.get_authorize_url,
                           'dummy_state')
-        self.r.set_oauth_app_info()
-        self.assertFalse(self.r.client_id is None)
-        self.assertFalse(self.r.client_secret is None)
-        self.assertFalse(self.r.redirect_uri is None)
+        self.invalid.set_oauth_app_info(self.r.client_id, self.r.client_secret,
+                                        self.r.redirect_uri)
+        try:
+            self.invalid.get_authorize_url('dummy_state')
+        except errors.OAuthRequired:
+            self.fail("Still doesn't have valid oauth app info.")
 
 
 class RedditorTest(unittest.TestCase, AuthenticatedHelper):


### PR DESCRIPTION
- Add set_access_credentials to explicitly set access_token and
  refresh_token.
  - Add set_oauth_app_info to explictly set app info / retrieve
    it from the configuration file.
  - Stop retrieving the app info from the configuration file to make
    these variables changeable.

This will make oauth login similair to regular login, but mutually exclusive. It allows app info and credentials to be changed more easily and sets `r.user` when setting access credentials. But at the same time also recover gracefully if the scope of oauth doesn't include `identity`. A 403 error will only be given if we are authenticated as the user, but lack `identity` scope. For bad access token it will give a 401.
