### PR TITLE
Fix OS-dependent error in upload_image.

### DIFF
--- a/praw/tests/__init__.py
+++ b/praw/tests/__init__.py
@@ -1211,41 +1211,41 @@ class UploadImageTests(unittest.TestCase, AuthenticatedHelper):
         self.image_path = os.path.join(test_dir, 'files', '{0}')
 
     def test_invalid_image(self):
-        image = open(self.image_path.format('white-square.tiff'))
+        image = self.image_path.format('white-square.tiff')
         self.assertRaises(errors.ClientException, self.subreddit.upload_image,
                           image)
 
-    def test_invalid_image_argument(self):
-        self.assertRaises(TypeError, self.subreddit.upload_image, 'bar.png')
-
     def test_invalid_image_too_small(self):
-        image = open(self.image_path.format('invalid.jpg'))
+        image = self.image_path.format('invalid.jpg')
         self.assertRaises(errors.ClientException, self.subreddit.upload_image,
                           image)
 
     def test_invalid_image_too_large(self):
-        image = open(self.image_path.format('big'))
+        image = self.image_path.format('big')
         self.assertRaises(errors.ClientException, self.subreddit.upload_image,
                           image)
 
     def test_invalid_params(self):
-        image = open(self.image_path.format('white-square.jpg'))
+        image = self.image_path.format('white-square.jpg')
         self.assertRaises(TypeError, self.subreddit.upload_image, image,
                           name='Foo', header=True)
 
+    def test_invalid_image_path(self):
+        self.assertRaises(IOError, self.subreddit.upload_image, 'bar.png')
+
     @reddit_only
     def test_jpg_header(self):
-        image = open(self.image_path.format('white-square.jpg'))
+        image = self.image_path.format('white-square.jpg')
         self.assertTrue(self.subreddit.upload_image(image, header=True))
 
     @reddit_only
     def test_jpg_image(self):
-        image = open(self.image_path.format('white-square.jpg'))
+        image = self.image_path.format('white-square.jpg')
         self.assertTrue(self.subreddit.upload_image(image))
 
     @reddit_only
     def test_jpg_image_named(self):
-        image = open(self.image_path.format('white-square.jpg'))
+        image = self.image_path.format('white-square.jpg')
         name = text_type(uuid.uuid4())
         self.assertTrue(self.subreddit.upload_image(image, name))
         images_json = self.subreddit.get_stylesheet()['images']
@@ -1253,22 +1253,22 @@ class UploadImageTests(unittest.TestCase, AuthenticatedHelper):
 
     @reddit_only
     def test_jpg_image_no_extension(self):
-        image = open(self.image_path.format('white-square'))
+        image = self.image_path.format('white-square')
         self.assertTrue(self.subreddit.upload_image(image))
 
     @reddit_only
     def test_png_header(self):
-        image = open(self.image_path.format('white-square.png'))
+        image = self.image_path.format('white-square.png')
         self.assertTrue(self.subreddit.upload_image(image, header=True))
 
     @reddit_only
     def test_png_image(self):
-        image = open(self.image_path.format('white-square.png'))
+        image = self.image_path.format('white-square.png')
         self.assertTrue(self.subreddit.upload_image(image))
 
     @reddit_only
     def test_png_image_named(self):
-        image = open(self.image_path.format('white-square.png'))
+        image = self.image_path.format('white-square.png')
         name = text_type(uuid.uuid4())
         self.assertTrue(self.subreddit.upload_image(image, name))
         images_json = self.subreddit.get_stylesheet()['images']


### PR DESCRIPTION
Some operation systems, such as windows, treat binary and text files
differently. For them opening an image with 'r' and not 'rb' would
cause the cryptic ClientException '`image` is not a valid image'. 
The same would also be true if the mode was some varient of 'w'
irrespective of OS.

Also, the old `white-square` file was a copy of the `invalid` file not `white-square.jpg`, which caused `test_jpg_no_extension` to fail for the minimum size requirement.
