### PR TITLE
Rename limit to content_limit. Add limit.

### DIFF
--- a/praw/decorators.py
+++ b/praw/decorators.py
@@ -226,7 +226,7 @@ def restrict_access(scope, mod=False, login=False, oauth_only=False):
 
     :param scope: Indicate the scope that is required for the API call. None or
         False must be passed to indicate that no scope handles the API call.
-        All scopes eimply login=True. Scopes with 'mod' in their name imply
+        All scopes imply login=True. Scopes with 'mod' in their name imply
         mod=True.
     :param mod: Indicate that a moderator is required. Implies login=True.
     :param login: Indicate that a login is required.

--- a/praw/objects.py
+++ b/praw/objects.py
@@ -236,7 +236,7 @@ class Editable(RedditContentObject):
     def edit(self, text):
         """Replace the body of the object with `text`.
 
-        :returns: The update object.
+        :returns: The updated object.
 
         """
         url = self.reddit_session.config['edit']

--- a/praw/praw.ini
+++ b/praw/praw.ini
@@ -28,8 +28,11 @@ comment_limit: 0
 # value means use the reddit default.
 comment_sort:
 
-# How many results to retrieve by default when making content calls
+# Total number of content to retrieve by default when making content calls
 default_content_limit: 25
+
+# The maximum number of results that can be retrieved with a content call.
+max_limit: 100
 
 # The maximum number (integer) of MoreComment objects to convert in any one
 # call to fetch_morecomments. Calls with more MoreComment objects will result

--- a/praw/tests/__init__.py
+++ b/praw/tests/__init__.py
@@ -257,8 +257,8 @@ class BasicTest(unittest.TestCase, BasicHelper):
 
     @reddit_only
     def test_info_by_url_maximum_listing(self):
-        self.assertEqual(100, len(self.r.get_info('http://reddit.com',
-                                                  limit=101)))
+        maximum = self.r.config.max_limit
+        self.assertEqual(maximum, len(self.r.get_info('http://reddit.com')))
 
     def test_is_username_available(self):
         self.assertFalse(self.r.is_username_available(self.un))


### PR DESCRIPTION
`limit` is a reddit parameter of how many results are returned with every requests. PRAW also uses `limit` as a parameter for a lot of methods. So it gives confusing function calls like ´subreddit.get_hot(limit=None, params={'limit': 100})`and for people familiar with the reddit api. So I renamed`limit`to`content_limit`and added a limit parameter that works like the upstream`limit` parameter. 
