### PR TITLE
Fix limit=None bug in replace_more_comments

### DIFF
--- a/praw/objects.py
+++ b/praw/objects.py
@@ -845,7 +845,7 @@ class Submission(Editable, Hideable, Moderatable, Refreshable, Reportable,
 
             # Fetch new comments and decrease remaining if a request was made
             new_comments = item.comments(update=False)
-            if new_comments is not None:
+            if new_comments is not None and remaining is not None:
                 remaining -= 1
             elif new_comments is None:
                 continue


### PR DESCRIPTION
This fixes the following error, which came from trying to decrement `remaining` when it was `None`.

``` python
>>> import praw
>>> r = praw.Reddit('bug example for limit=None by u/_Daimon_')
>>> s = r.get_submission('http://www.reddit.com/r/AskReddit/comments/16r8tc/what_
little_tricks_do_you_play_on_your_so/')
>>> s.replace_more_comments(limit=None, threshold=20)
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "c:\Python27\lib\site-packages\praw\objects.py", line 849, in replace_more
_comments
    remaining -= 1
TypeError: unsupported operand type(s) for -=: 'NoneType' and 'int'
>>>
```
