### PR TITLE
Fix for Python 3.x in replace_more_comments()

### DIFF
--- a/praw/objects.py
+++ b/praw/objects.py
@@ -543,14 +543,12 @@ class MoreComments(RedditContentObject):
         super(MoreComments, self).__init__(reddit_session, json_dict)
         self.submission = None
         self._comments = None
-
-    def __cmp__(self, other):
-        # To work with heapq a "smaller" item is the one with the most comments
-        return -1 * cmp(self.count, other.count)
         
     def __lt__(self, other):
         # To work with heapq a "smaller" item is the one with the most comments
-        # For Python3 as overriding the __cmp__ and cmp function are gone in Python 3
+        # We are intentionally making the biggest element the smallest element to turn
+        # the min-heap implementation in heapq into a max-heap implementation for
+        # Submission.replace_more_comments()
         return self.count > other.count
 
     def __unicode__(self):


### PR DESCRIPTION
There was a bug that made replace_more_comments() unusable for Python 3.x. In the`_extract_more_comments()` function a heap requires the ability to make a comparison. You did add the `__cmp__` function to the `MoreComments` class, but unfortunately `cmp()` has been gotten rid of in Python 3 and been replaced by `__lt__`. Anyway, there it is. You will probably understand it more if you just look at the code, I'm bad at explaining stuff. Anyway, enjoy!
