### PR TITLE
Create link from Redditor PrivateMessageMixin

### DIFF
--- a/praw/objects.py
+++ b/praw/objects.py
@@ -658,6 +658,11 @@ class LoggedInRedditor(Redditor):
     get_liked = _get_section('liked')
     get_saved = _get_section('saved')
 
+    _methods = (('get_inbox', PMMix.get_inbox),
+                ('get_mod_mail', PMMix.get_mod_mail),
+                ('get_sent', PMMix.get_sent),
+                ('get_unread', PMMix.get_unread))
+
     def get_cached_moderated_reddits(self):
         """Return a cached dictionary of the user's moderated reddits.
 


### PR DESCRIPTION
Add _methods to `LoggedInRedditor` so `get_unread`, `get_inbox`, `get_mod_mail` and `get_sent` can be can be used from the `LoggedInredditor` object as well as from Base Reddit. Just like in version 1.0.16 and earlier. 
