### PR TITLE
Remove unneded auth code.

### DIFF
--- a/praw/__init__.py
+++ b/praw/__init__.py
@@ -832,8 +832,6 @@ class AuthenticatedReddit(OAuth2Reddit, UnauthenticatedReddit):
         self.request_json(self.config['login'], data=data)
         # Update authentication settings
         self._authentication = True
-        self.access_token = None
-        self.refresh_token = None
         self.user = self.get_redditor(user)
         self.user.__class__ = objects.LoggedInRedditor
 
@@ -880,12 +878,8 @@ class AuthenticatedReddit(OAuth2Reddit, UnauthenticatedReddit):
         self.access_token = access_token
         self.refresh_token = refresh_token
         # Update the user object
-        if not update_user:
-            pass
-        elif 'identity' in scope:
+        if update_user and 'identity' in scope:
             self.user = self.get_me()
-        else:
-            self.user = None
 
 
 class ModConfigMixin(AuthenticatedReddit):


### PR DESCRIPTION
With 71c678cd1eee0a76a both login and set_access_credentials
run clear_authentication. This means some of the code lines
in those two methods are now unneded. 

I removed `update_user`. I don't think there is a need for it anymore since `clear_authentication` is run before it sets `r.user = None`.
