### PR TITLE
Evict OAuth me when setting credentials.

### DIFF
--- a/praw/__init__.py
+++ b/praw/__init__.py
@@ -883,6 +883,7 @@ class AuthenticatedReddit(OAuth2Reddit, UnauthenticatedReddit):
         self._authentication = scope
         self.access_token = access_token
         self.refresh_token = refresh_token
+        helpers._request.evict([self.config['me']])
         # Update the user object
         if update_user and 'identity' in scope:
             self.user = self.get_me()


### PR DESCRIPTION
This fixes a bug with multiple `set_access_credentials` calls
within `cache_timeout` with the 'identity' scope and
`update_user` not set to `False`. Because config['me'] is
cached, the subsequent calls will return the cached and
inaccurate result.

Bug found because of [this r/redditdev thread](http://www.reddit.com/r/redditdev/comments/1905ed/how_to_reuse_oauth_tokens_with_praw/)
