### PR TITLE
Remove obsolete test case of users sharing cache.

### DIFF
--- a/praw/tests/__init__.py
+++ b/praw/tests/__init__.py
@@ -365,16 +365,6 @@ class CacheTest(unittest.TestCase, AuthenticatedHelper):
         submission.refresh()
         self.assertNotEqual(submission.likes, same_submission.likes)
 
-    def test_users_share_cache(self):
-        subreddit = self.r.get_subreddit(self.sr)
-        title = 'Test User Sharing Of Cache: %s' % uuid.uuid4()
-        body = "BODY"
-        original_listing = list(subreddit.get_new(limit=5))
-        subreddit.submit(title, body)
-        self.r.login('PyAPITestUser2', '1111')
-        new_user_listing = list(subreddit.get_new(limit=5))
-        self.assertEqual(original_listing, new_user_listing)
-
 
 class EncodingTest(unittest.TestCase, AuthenticatedHelper):
     def setUp(self):


### PR DESCRIPTION
With 1252908, the cache is now cleared upon logging in, which
means the test case tests for something which is no longer true.
