### PR TITLE
Useful_scripts.rst formatting fix

### DIFF
--- a/docs/pages/useful_scripts.rst
+++ b/docs/pages/useful_scripts.rst
@@ -80,7 +80,8 @@ this page to add in more.
     list of words that should be considered common.
 
 **\<Your Script Here\>**
-    Edit this page to add it yourself.
+    Edit `this page on github <https://github.com/praw-dev/praw/blob/master/
+    docs/pages/useful_scripts.rst>`_ to add your script to this list.
 
 **Note:** The following use very outdated versions of the API. Don't expect
 them to work with the latest version.


### PR DESCRIPTION
Fixes syntax and formatting in useful_scripts.rst
- Remove whitespace at the end of lines
- Remove 2 accidentally added _
- Add `` around Submission.all_comments
- Reformat to keep within 80 chars pr line

Also added another small commit that adds a direct link to the github page, so it becomes that much easier for people to add their own scripts to the list.
