### PR TITLE
adding get_liked and get_disliked to Redditor. Redditor's have the optio...

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,13 @@ The changes listed below are divided into four categories.
 Read `r/changelog <http://www.reddit.com/r/changelog>`_ to be notified of
 upstream changes.
 
+Unreleased
+----------
+ * **[FEATURE]** Move methods :meth:`get_liked` and :meth:`get_disliked` to
+   class :class:`Redditor` from :class:`LoggedInRedditor`. Redditors can
+   make their likes and dislikes public. Having :meth:`get_liked` and
+   :meth:`get_disliked` on :class:`Redditor` allows praw to access this info
+
 PRAW 2.1.6
 ----------
  * **[BUGFIX]** PRAW automatically retries failed requests to reddit if the

--- a/praw/objects.py
+++ b/praw/objects.py
@@ -608,6 +608,8 @@ class Redditor(Messageable, Refreshable):
 
     get_overview = _get_section('')
     get_comments = _get_section('comments')
+    get_disliked = _get_section('disliked')
+    get_liked = _get_section('liked')
     get_submitted = _get_section('submitted')
 
     def __init__(self, reddit_session, user_name=None, json_dict=None,
@@ -679,9 +681,7 @@ class LoggedInRedditor(Redditor):
 
     """A class representing a currently logged in Redditor."""
 
-    get_disliked = _get_section('disliked')
     get_hidden = _get_section('hidden')
-    get_liked = _get_section('liked')
     get_saved = _get_section('saved')
 
     def get_blocked(self):


### PR DESCRIPTION
redditors have the option to make their likes and dislikes public. I feel the praw should have the ability to access this public information.

If you attempt to access a redditor's likes, and they are not public, an exception is raised (requests.exceptions.HTTPError).
