### PR TITLE
Remove depreciated method from documentation

### DIFF
--- a/docs/pages/comment_parsing.rst
+++ b/docs/pages/comment_parsing.rst
@@ -78,13 +78,15 @@ call as specified in the `api guidelines
 Getting all recent comments to a subreddit or everywhere
 --------------------------------------------------------
 
-We can get all comments made anywhere with :meth:`.get_comments('all')`.
+We can get comments made to all subreddits by using :meth:`.get_comments` and
+setting the subreddit argument to the value "all".
 
 >>> import praw
 >>> r = praw.Reddit('Comment parser example by u/_Daimon_')
 >>> all_comments = r.get_comments('all')
 
-The results are equivalent to `/comments <http://www.reddit.com/comments>`_.
+The results are equivalent to `/r/all/comments
+<http://www.reddit.com/r/all/comments>`_.
 
 We can also choose to only get the comments from a specific subreddit. This is
 much simpler than getting all comments made to a reddit and filtering them. It


### PR DESCRIPTION
I was going though the documentation for parsing comments and noticed that the example under "[Getting all recent comments to a subreddit or everywhere](https://praw.readthedocs.org/en/latest/pages/comment_parsing.html#getting-all-recent-comments-to-a-subreddit-or-everywhere)" wasn't working. I did some research and found out via issue #254 the method `get_all_comments()` has been depreciated in the latest version and that using `get_comments('all')` is preferred.

I went ahead and changed the docs in order to accurately represent this so people won't have trouble in the future.
