### PR TITLE
fixed store_json_result config bug

### DIFF
--- a/praw/__init__.py
+++ b/praw/__init__.py
@@ -211,7 +211,7 @@ class Config(object):  # pylint: disable-msg=R0903, R0924
         self.client_id = obj.get('oauth_client_id') or None
         self.client_secret = obj.get('oauth_client_secret') or None
         self.redirect_uri = obj.get('oauth_redirect_uri') or None
-        self.store_json_result = obj.get('store_json_result') or None
+        self.store_json_result = config_boolean(obj.get('store_json_result')) or None
 
         if 'short_domain' in obj:
             self._short_domain = 'http://' + obj['short_domain']


### PR DESCRIPTION
The config setting `store_json_result` does not work correctly when specified in `praw.ini` due to it not being parsed by `config_boolean`. This was not caught by the unit tests as they manually cast `True` onto the config object.
