### PR TITLE
Fixed a bug in RateLimitExceeded with incorrect key to response dict

### DIFF
--- a/praw/errors.py
+++ b/praw/errors.py
@@ -322,7 +322,7 @@ class RateLimitExceeded(APIException):
     def __init__(self, error_type, message, field='', response=None):
         super(RateLimitExceeded, self).__init__(error_type, message,
                                                 field, response)
-        self.sleep_time = self.response['ratelimit']
+        self.sleep_time = self.response['delay']
 
 
 class UsernameExists(APIException):


### PR DESCRIPTION
RateLimitExceeded.**init** was setting sleep_time to response['ratelimit'] which was throwing a KeyError exception every time I hit it. Swtiched to 'delay' which seemed to fix the functionality.

If this isn't correct, ignore this, but it fixed my problem and I thought I'd share it.

If this isn't the correct branch to send the pull request to but the fix should still be pulled, please let me know.
