### PR TITLE
Saveable.save() requires the 'save' scope

### DIFF
--- a/praw/objects.py
+++ b/praw/objects.py
@@ -402,7 +402,7 @@ class Saveable(RedditContentObject):
 
     """Interface for RedditContentObjects that can be saved."""
 
-    @restrict_access(scope=None, login=True)
+    @restrict_access(scope='save')
     def save(self, unsave=False):
         """Save the object.
 


### PR DESCRIPTION
The `save()` and `unsave()` calls require that the `save` scope be enabled for an access token.
