### PR TITLE
fix spelling it's -> its

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -324,7 +324,7 @@ PRAW 2.0.9
 
  * **[FEATURE]** Add parameter ``update_user`` (default False) to
    :meth:`.get_unread` if it and ``unset_has_mail`` are both True, then the
-   ``user`` object in the :class:`.Reddit` object will have it's ``has_mail``
+   ``user`` object in the :class:`.Reddit` object will have its ``has_mail``
    attribute set to ``False``.
  * **[FEATURE]** Add :meth:`.get_friends` and :meth:`.get_blocked` to
    :class:`.LoggedInRedditor`.

--- a/docs/pages/comment_parsing.rst
+++ b/docs/pages/comment_parsing.rst
@@ -13,7 +13,7 @@ Submission Comments
 -------------------
 
 As usual, we start by importing PRAW and initializing our contact with
-reddit.com. We also get a submission object, where our script will do it's
+reddit.com. We also get a submission object, where our script will do its
 work.
 
 >>> import praw

--- a/docs/pages/contributor_guidelines.rst
+++ b/docs/pages/contributor_guidelines.rst
@@ -35,7 +35,7 @@ Documentation
   docstring.
 * Use correct terminology. A subreddits name is something like ' t3_xyfc7'.
   The correct term for a subreddits "name" like
-  `python <http://www.reddit.com/r/python>`_ is it's display name.
+  `python <http://www.reddit.com/r/python>`_ is its display name.
 * When referring to any reddit. Refer to it as 'reddit'. When you are speaking
   of the specific reddit instance with the website reddit.com, refer to it as
   'reddit.com'. This helps prevent any confusion between what is universally

--- a/docs/pages/oauth.rst
+++ b/docs/pages/oauth.rst
@@ -35,7 +35,7 @@ later. Click create app and you should something like the following.
 
  .. image:: ../_static/CreateApp.png
 
-The random string of letters under your app's name is it's ``client id``. The
+The random string of letters under your app's name is its ``client id``. The
 random string of letters next to secret are your ``client_secret`` and should
 not be shared with anybody. At the bottom is the ``redirect_uri``.
 
@@ -141,7 +141,7 @@ need to refresh the access token.
 
     >>> r.refresh_access_information(access_information['refresh_token'])
 
-This returns a dict, where the ``access_token`` key has had it's value updated.
+This returns a dict, where the ``access_token`` key has had its value updated.
 Neither ``scope`` or ``refresh_token`` will have changed.
 
 .. _oauth_webserver:


### PR DESCRIPTION
Just fixing some minor errors. "It's" means "it is" or "it has" whereas "its" is the possessive form
