### PR TITLE
Add duplicate submissions functionality (issue #290)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,8 +24,7 @@ formatted links that link to the relevant place in the code overview.
 
 Unreleased
 ----------
- * **[CHANGE]** Increase the dependency of ``update_checker`` to 0.10 or 
-   later
+ * **[CHANGE]** Increase the dependency of ``update_checker`` to 0.10 or later 
    to prevent ImportWarnings (issue 291).
  * **[FEATURE]** Enable gathering of duplicate submissions for a 
    Submission object (issue 290).

--- a/praw/__init__.py
+++ b/praw/__init__.py
@@ -95,7 +95,7 @@ class Config(object):  # pylint: disable-msg=R0903, R0924
                  'delete_sr_image':     'r/%s/api/delete_sr_img',
                  'distinguish':         'api/distinguish/',
                  'domain':              'domain/%s/',
-                 'duplicates':          'r/%s/duplicates/%s/',
+                 'duplicates':          'duplicates/%s/',
                  'edit':                'api/editusertext/',
                  'feedback':            'api/feedback/',
                  'flair':               'api/flair/',
@@ -411,7 +411,8 @@ class BaseReddit(object):
     @decorators.oauth_generator
     def get_content(self, url, params=None, limit=0, place_holder=None,
                     root_field='data', thing_field='children',
-                    after_field='after', _use_oauth=False):
+                    after_field='after', _use_oauth=False,
+                    object_filter=None):
         """A generator method to return reddit content from a URL.
 
         Starts at the initial url, and fetches content using the `after`
@@ -438,6 +439,11 @@ class BaseReddit(object):
             contains the list of things. Most objects use 'children'.
         :param after_field: indicates the field which holds the after item
             element
+        :param object_filter: if set to an integer value, fetch content from
+            the corresponding list index in the JSON response. For example
+            the JSON response for submission duplicates is a list of objects,
+            and the object we want to fetch from is at index 1. So we set
+            object_filter=1 to filter out the other useless list elements.
         :type place_holder: a string corresponding to a reddit base36 id
             without prefix, e.g. 'asdfasdf'
         :returns: a list of reddit content, of type Subreddit, Comment,
@@ -462,6 +468,8 @@ class BaseReddit(object):
                 self._use_oauth = _use_oauth  # pylint: disable-msg=W0201
             try:
                 page_data = self.request_json(url, params=params)
+                if object_filter:
+                    page_data = page_data[object_filter]
             finally:  # Restore _use_oauth value
                 if _use_oauth:
                     self._use_oauth = False  # pylint: disable-msg=W0201

--- a/praw/objects.py
+++ b/praw/objects.py
@@ -927,19 +927,15 @@ class Submission(Editable, Hideable, Moderatable, Refreshable, Reportable,
         self._update_comments(new_comments)
         self._orphaned = {}
 
-    @property
-    def duplicates(self):
-        """Get duplicate submissions for this submission.
+    def get_duplicates(self):
+        """Return a get_content generator for the submission's duplicates.
 
-        :returns: List of duplicate submissions as Submission objects,
-        empty list if no duplicates.
+        :returns: get_content generator iterating over Submission objects.
 
         """
-        url = (self.reddit_session.config['duplicates'] %
-               (self.subreddit.display_name, self.id))
-        new_json = self.reddit_session.request_json(url)
-        duplicate_list = new_json[1]['data']['children']
-        return duplicate_list
+        url = self.reddit_session.config['duplicates'] % self.id
+        return self.reddit_session.get_content(url, object_filter=1,
+                                               limit=None)
 
     def mark_as_nsfw(self, unmark_nsfw=False):
         """Mark as Not Safe For Work.


### PR DESCRIPTION
Submissions objects now have an attribute .duplicates which returns either a list of Submission objects (the duplicate submissions) or an empty list (if no duplicates). Address issue #290.

Would need to write tests against static (thus private) Submission objects as far as I can tell. 

Super hacky and also my first ever contribution to a project, so forgive any messiness.
