### PR TITLE
WikiPage.revision_by now grabs proper username (issue #258)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,6 +29,8 @@ Unreleased
  * **[FEATURE]** Enable gathering of duplicate submissions for a Submission
    object (issue 290).
  * **[FEATURE]** Add :meth:`~praw.__init__.LoggedInReddior.delete`.
+ * **[BUGFIX]** Fix user_name=None when building Redditor objects from wikipage
+   submissions. Now grabs proper name.
 
 
 PRAW 2.1.15

--- a/praw/objects.py
+++ b/praw/objects.py
@@ -54,6 +54,11 @@ class RedditContentObject(object):
             subreddit = parts[4]
             page = parts[6].split('.', 1)[0]
             return cls(reddit_session, subreddit, page, json_dict=json_dict)
+        # Following hack required to initialize Redditor objects with username
+        # explicitly, fixes bug where WikiPage authors weren't being recognized
+        if cls == Redditor:
+            return cls(reddit_session, user_name=json_dict['name'], 
+                       json_dict=json_dict)
         return cls(reddit_session, json_dict=json_dict)
 
     def __init__(self, reddit_session, json_dict=None, fetch=True,


### PR DESCRIPTION
This hack seems to resolve the issue, and as far as I can tell doesn't break anything. You guys know the codebase better than I do at this point, so let me know if you think this is a good solution. Some manual tests:

```
>>> r = praw.Reddit('sdf', site_name='local')
>>> w = r.get_wiki_page('reddit_test0', 'wiki1')
>>> w.revision_by
Redditor(user_name='reddit')
```

...

And on the /r/webdev wiki index, where we'd expect the latest revision to have been made by user 'jaredcheeda':

```
>>> import praw
>>> r = praw.Reddit('PRAW-dev testing wiki revision grab')
>>> w = r.get_wiki_page('webdev', 'index')
>>> w.revision_by
Redditor(user_name='jaredcheeda')
```

For unit testing there'd have to be a static wiki page for which we always know which user we expect to have revised. Or we could run it against a private reddit.com sub where no changes are planned (I think I remember seeing @bboe using this method in the code already). 
