### PR TITLE
Updating the send message line

### DIFF
--- a/docs/pages/writing_a_bot.rst
+++ b/docs/pages/writing_a_bot.rst
@@ -342,7 +342,7 @@ The full Question-Discover program
             # Test if it contains a PRAW-related question
             if submission.id not in already_done and has_praw:
                 msg = '[PRAW related thread](%s)' % submission.short_link
-                r.user.send_message('_Daimon_', msg)
+                r.send_message('_Daimon_', 'Praw Thread', msg)
                 already_done.append(submission.id)
         time.sleep(1800)
 


### PR DESCRIPTION
Changing r.user.send_message to r.send_message. r.user.send_message doesn't give an error, but it doesn't actually send a message.
Adding a title to the message in the send_message parameters to fix: TypeError: send_message() takes at least 4 arguments (3 given)
