### PR TITLE
Use a monotonic timer for rate limiting

### DIFF
--- a/praw/handlers.py
+++ b/praw/handlers.py
@@ -9,6 +9,7 @@ from praw.helpers import normalize_url
 from requests import Session
 from six.moves import cPickle
 from threading import Lock
+from timeit import default_timer as timer
 
 
 class RateLimitHandler(object):
@@ -45,7 +46,7 @@ class RateLimitHandler(object):
             with lock_last[0]:  # Obtain the domain specific lock
                 cls.rl_lock.release()
                 # Sleep if necessary, then perform the request
-                now = time.time()
+                now = timer()
                 delay = lock_last[1] + _rate_delay - now
                 if delay > 0:
                     now += delay
@@ -115,7 +116,7 @@ class DefaultHandler(RateLimitHandler):
             def clear_timeouts():
                 """Clear the cache of timed out results."""
                 for key in list(cls.timeouts):
-                    if time.time() - cls.timeouts[key] > _cache_timeout:
+                    if timer() - cls.timeouts[key] > _cache_timeout:
                         del cls.timeouts[key]
                         del cls.cache[key]
 
@@ -139,7 +140,7 @@ class DefaultHandler(RateLimitHandler):
             if result.status_code not in (200, 302):
                 return result
             with cls.ca_lock:
-                cls.timeouts[_cache_key] = time.time()
+                cls.timeouts[_cache_key] = timer()
                 cls.cache[_cache_key] = result
                 return result
         return wrapped

--- a/praw/helpers.py
+++ b/praw/helpers.py
@@ -26,6 +26,7 @@ import sys
 import time
 from functools import partial
 from requests.exceptions import HTTPError
+from timeit import default_timer as timer
 
 BACKOFF_START = 4  # Minimum number of seconds to sleep during errors
 KEEP_ITEMS = 128  # On each iteration only remember the first # items
@@ -107,7 +108,7 @@ def _stream_generator(get_function, reddit_session, limit=None, verbosity=1):
     while True:
         items = []
         sleep = None
-        start = time.time()
+        start = timer()
         try:
             i = None
             params = {'count': count}
@@ -148,7 +149,7 @@ def _stream_generator(get_function, reddit_session, limit=None, verbosity=1):
             backoff *= 2
         # Provide rate limit
         if verbosity >= 1:
-            rate = len(items) / (time.time() - start)
+            rate = len(items) / (timer() - start)
             sys.stderr.write(' Items: {0} ({1:.2f} ips)    \r'
                              .format(processed, rate))
             sys.stderr.flush()


### PR DESCRIPTION
This patch changes every occurrence of `time.time()` to `timeit.default_timer()`.

Currently, the rate limiter uses `time.time()` for getting the current time. Unfortunately, [`time.time()` is not monotonic](https://docs.python.org/3/library/time.html#time.time). If the system clock is adjusted while `praw` is running, it can lead to the rate limiter waiting too long or not at all.

A better alternative is [`timeit.default_timer()`](https://docs.python.org/3/library/timeit.html#timeit.default_timer), which is monotonic since Python 3.3. Older versions alias to `time.time()`, which is no different to what we have now. It's been in the standard library since Python 2.3 (albeit not documented) so there should be no issues with compatibility.
