### PR TITLE
Praw 19 November -- Early support for Multireddits

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -38,6 +38,8 @@ Unreleased
  * **[FEATURE]** Added :meth:`get_multireddit` to get a single multireddit obj
  * **[FEATURE]** Added :meth:`get_my_multis` to get all multireddits owned
    by the logged in user.
+ * **[FEATURE]** Added :meth:`get_multireddit` to :class:`Redditor` to quickly
+   get a multireddit belonging to that user.
 
 PRAW 2.1.19
 -----------

--- a/praw/objects.py
+++ b/praw/objects.py
@@ -733,6 +733,16 @@ class Redditor(Messageable, Refreshable):
         return _get_redditor_listing('liked')(self, *args,
                                               _use_oauth=use_oauth, **kwargs)
 
+    def get_multireddit(self, multi, *args, **kwargs):
+        """Return a multireddit that belongs to this user.
+
+        :param multi: The name of the multireddit
+
+        :returns: Multireddit object with author=Redditor and name=multi
+
+        """
+        return self.reddit_session.get_multireddit(self, multi)
+
     def mark_as_read(self, messages, unread=False):
         """Mark message(s) as read or unread.
 
@@ -1320,20 +1330,24 @@ class Multireddit(Refreshable):
     get_top_from_week = _get_sorter('top', t='week')
     get_top_from_year = _get_sorter('top', t='year')
 
-    def __init__(self, reddit_session, multi_author=None, multi_name=None,
+    def __init__(self, reddit_session, redditor=None, multi=None,
                  json_dict=None, fetch=False):
-        # Special case for when my_multireddits is called, no name is returned
+        # Special case for when get_my_multis is called, no name is returned
         # so we have to extract the name from the URL. The URLs are returned
-        # as: /user/author_name/m/multi_name
-        if not multi_name:
-            multi_name = json_dict['path'].split('/')[-1]
+        # as: /user/redditor/m/multi
+        if not multi:
+            multi = json_dict['path'].split('/')[-1]
+        if not redditor:
+            redditor = json_dict['path'].split('/')[-3]
+        else:
+            redditor = six.text_type(redditor)
 
-        info_url = reddit_session.config['multireddit_about'] % (multi_author,
-                                                                 multi_name)
+        info_url = reddit_session.config['multireddit_about'] % (redditor,
+                                                                 multi)
         super(Multireddit, self).__init__(reddit_session, json_dict, fetch,
                                           info_url)
-        self.display_name = multi_name
-        self.author = multi_author
+        self.display_name = multi
+        self.author = redditor
         self._url = reddit_session.config['multireddit'] % (self.author,
                                                             self.display_name)
 

--- a/praw/tests/__init__.py
+++ b/praw/tests/__init__.py
@@ -1341,7 +1341,15 @@ class MultiredditTest(unittest.TestCase, AuthenticatedHelper):
         self.assertEqual(self.multi_name.lower(),
                          multireddit.display_name.lower())
         self.assertEqual([], multireddit.subreddits)
-        self.assertEqual(1, len(mymultis))
+
+    def test_get_multireddit_from_user(self):
+        multi = self.r.user.get_multireddit(self.multi_name)
+        self.assertEqual(self.r.user.name.lower(), multi.author.name.lower())
+
+    def test_get_new(self):
+        multi = self.r.user.get_multireddit(self.multi_name)
+        new = list(multi.get_new())
+        self.assertEqual(0, len(new))
 
 
 class OAuth2Test(unittest.TestCase, BasicHelper):


### PR DESCRIPTION
New :class:`Multireddit` for multireddit objects. Proper endpoints and kind added to init config

New :meth:`get_multireddit` to get a single mr object. Standard usage: `r.get_multireddit(multi_author, multi_name)`

New :meth:`get_my_multis` which requires logged in scope. Returns a list of all multireddit objects you own.

New :class:`MultiredditTest` in tests which will test the get_my_multis function. As of writing, :class:`BasicTest` will test get_multireddit since that does not require logged in.

Added proper material to CHANGES.rst

Edit: Travis build failed but I see the error and will re-commit.

Sorry for the commit-flood :( I will learn to squash before next time.

Edit: [Build 498 failed on account of test_scope_submit timing out](https://travis-ci.org/praw-dev/praw/jobs/41518483#L415) (Line 415). Can a new build be initiated without a commit?
