### PR TITLE
Added more spaces to praw/helpers.py#L153

### DIFF
--- a/praw/helpers.py
+++ b/praw/helpers.py
@@ -150,7 +150,7 @@ def _stream_generator(get_function, reddit_session, limit=None, verbosity=1):
                     items.append(item)
                     processed += 1
                 if verbosity >= 1 and processed % 100 == 0:
-                    sys.stderr.write(' Items: {0}          \r'
+                    sys.stderr.write(' Items: {0}            \r'
                                      .format(processed))
                     sys.stderr.flush()
                 if i < KEEP_ITEMS:


### PR DESCRIPTION
In order to completely overwrite any text from L172, I added 2 spaces. For example, `Items: 20372 (24.92 ips)` has exactly 12 characters after `Items {0}`. This character count may increase if 1 request/second is reached, so perhaps even 13 spaces is needed.
