### PR TITLE
Add parameter values to docs for _listing method

### DIFF
--- a/praw/internal.py
+++ b/praw/internal.py
@@ -33,9 +33,11 @@ def _get_redditor_listing(subpath=''):
     def _listing(self, sort='new', time='all', *args, **kwargs):
         """Return a get_content generator for some RedditContentObject type.
 
-        :param sort: Specify the sort order of the results if applicable.
+        :param sort: Specify the sort order of the results if applicable
+            (one of ``'hot'``, ``'new'``, ``'top'``, ``'controversial'``).
         :param time: Specify the time-period to return submissions if
-            applicable.
+            applicable (one of ``'hour'``, ``'day'``, ``'week'``, 
+            ``'month'``, ``'year'``, ``'all'``).
 
         The additional parameters are passed directly into
         :meth:`.get_content`. Note: the `url` parameter cannot be altered.

--- a/praw/internal.py
+++ b/praw/internal.py
@@ -36,7 +36,7 @@ def _get_redditor_listing(subpath=''):
         :param sort: Specify the sort order of the results if applicable
             (one of ``'hot'``, ``'new'``, ``'top'``, ``'controversial'``).
         :param time: Specify the time-period to return submissions if
-            applicable (one of ``'hour'``, ``'day'``, ``'week'``, 
+            applicable (one of ``'hour'``, ``'day'``, ``'week'``,
             ``'month'``, ``'year'``, ``'all'``).
 
         The additional parameters are passed directly into


### PR DESCRIPTION
Updated the documentation with valid values for `sort` and `time` parameters to the `_listing` method (generated by `internal._get_redditor_listing` for e.g. `Redditor.get_comment`), per [Reddit API docs](https://www.reddit.com/dev/api#GET_user_{username}_{where}), in response to [this StackOverflow question](http://stackoverflow.com/q/27768132/3001761).