### PR TITLE
Run tests locally using tox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@ _build/
 build/
 dist/
 .DS_Store
-
+.tox/

--- a/README.rst
+++ b/README.rst
@@ -44,7 +44,7 @@ This will display something similar to the following:
 Installation
 ------------
 
-PRAW works with python 2.6, 2.7, 3.1, 3.2, and 3.3. The recommended way to
+PRAW works with python 2.6, 2.7, 3.1, 3.2, 3.3, and 3.4. The recommended way to
 install is via `pip <http://pypi.python.org/pypi/pip>`_
 
 .. code-block:: bash

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -637,7 +637,7 @@ class MoreCommentsTest(unittest.TestCase, AuthenticatedHelper):
         c_len = len(self.submission.comments)
         flat = helpers.flatten_tree(self.submission.comments)
         continue_items = [x for x in flat if isinstance(x, MoreComments) and
-                         x.count == 0]
+                          x.count == 0]
         self.assertTrue(continue_items)
         cf_len = len(flat)
         saved = self.submission.replace_more_comments(threshold=2)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,6 @@
 [tox]
-envlist = py27
+envlist = py26,py27,py31,py32,py33
+skip_missing_interpreters = true
 
 [testenv]
 deps = mock

--- a/tox.ini
+++ b/tox.ini
@@ -3,10 +3,13 @@ envlist = py26,py27,py31,py32,py33
 skip_missing_interpreters = true
 
 [testenv]
-deps = mock
+deps =
+    flake8
+    mock
 setenv =
     REDDIT_SITE=reddit_bypass_cdn
 commands =
     python setup.py test -s tests.BasicTest
     python setup.py test -s tests.OAuth2Test
     python setup.py test -s tests.ModeratorSubredditTest.test_mod_mail_send
+    flake8 praw

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,6 @@
+[tox]
+envlist = py27
+
+[testenv]
+deps = mock
+commands = python setup.py test

--- a/tox.ini
+++ b/tox.ini
@@ -6,4 +6,7 @@ skip_missing_interpreters = true
 deps = mock
 setenv =
     REDDIT_SITE=reddit_bypass_cdn
-commands = python setup.py test
+commands =
+    python setup.py test -s tests.BasicTest
+    python setup.py test -s tests.OAuth2Test
+    python setup.py test -s tests.ModeratorSubredditTest.test_mod_mail_send

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py31,py32,py33
+envlist = py26,py27,py31,py32,py33,py34
 skip_missing_interpreters = true
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -4,4 +4,6 @@ skip_missing_interpreters = true
 
 [testenv]
 deps = mock
+setenv =
+    REDDIT_SITE=reddit_bypass_cdn
 commands = python setup.py test


### PR DESCRIPTION
Provides a `tox.ini` file that will allow tests to be run using tox. This should make it easier for developers to run tests against a spectrum of Python interpreters when developing locally.

The tox config is set up to run tests in a manner similar to how Travis runs tests. In particular, it only runs tests against a subset of test suites. (It seems that several test cases don't pass, but perhaps eventually they can be fixed up and tox can run the full suite of tests.)