### PR TITLE
Add python nightly testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ python:
   - 3.2
   - 3.3
   - 3.4
+  - nightly
+matrix:
+  allow_failures:
+    - python: nightly
 install:
   - pip install flake8 pep257 --use-mirrors
   - python setup.py install


### PR DESCRIPTION
[PEP478](http://legacy.python.org/dev/peps/pep-0478/) shows Python 3.5 is scheduled for beta release  on May 24, 2015 and final release on September 13, 2015. I think it's worth starting testing on Python 3.5, but allowing failures until it is at least in beta.