### PR TITLE
Switch to Travis Docker build system

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - 3.2
   - 3.3
   - 3.4
+sudo: false
 install:
   - pip install flake8 pep257 --use-mirrors
   - python setup.py install


### PR DESCRIPTION
This commit switches praw to the Travis Docker build system. [This blog post](http://blog.travis-ci.com/2014-12-17-faster-builds-with-container-based-infrastructure/) highlights the benefits, but the main ones are:
* Builds start in seconds
* Faster builds
* More available resources in a build container
* Better network capacity, availability and throughput
* Caching available for open source projects
* Easier to scale