### PR TITLE
Remove --use-mirrors flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
   - 3.3
   - 3.4
 install:
-  - pip install flake8 pep257 --use-mirrors
+  - pip install flake8 pep257
   - python setup.py install
 before_script:
   - flake8 praw


### PR DESCRIPTION
This flag has been deprecated in pip for a long time now
https://github.com/pypa/pip/pull/1098