### PR TITLE
14 April 2015 - Added method for getting a Message object by its ID or fullname

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -30,6 +30,8 @@ Unreleased
    site, not the casing used to construct the Subreddit instance. To quickly
    fetch the name of an unloaded Subreddit, use ``str(sub_instance)``, or
    ``unicode(sub_instance)``.
+ * **[FEATURE]** Added :meth:`get_message` to fetch a single Message object
+   by its ID.
 
 PRAW 2.1.21
 -----------

--- a/praw/__init__.py
+++ b/praw/__init__.py
@@ -122,6 +122,7 @@ class Config(object):  # pylint: disable=R0903
                  'login':               'api/login/',
                  'me':                  'api/v1/me',
                  'mentions':            'message/mentions',
+                 'message':             'message/messages/%s/',
                  'messages':            'message/messages/',
                  'moderators':          'r/%s/about/moderators/',
                  'modlog':              'r/%s/about/log/',
@@ -2047,6 +2048,19 @@ class PrivateMessagesMixin(AuthenticatedReddit):
 
         """
         return self.get_content(self.config['inbox'], *args, **kwargs)
+
+    @decorators.restrict_access(scope='privatemessages')
+    def get_message(self, message_id, *args, **kwargs):
+        """Return a Message object corresponding to the given ID.
+
+        :param message_id: The ID or Fullname for a Message
+
+        The additional parameters are passed into
+        :meth:`.from_id` of Message, and subsequently into
+        :meth:`.request_json`.
+
+        """
+        return objects.Message.from_id(self, message_id, *args, **kwargs)
 
     @decorators.restrict_access(scope='privatemessages')
     def get_messages(self, *args, **kwargs):

--- a/praw/objects.py
+++ b/praw/objects.py
@@ -649,7 +649,7 @@ class Message(Inboxable):
 
         """
         # Reduce fullname to ID if necessary
-        message_id = message_id.replace('t4_', '')
+        message_id = message_id.split('_', 1)[-1]
         url = reddit_session.config['message'] % message_id
         message_info = reddit_session.request_json(url, *args, **kwargs)
         message = message_info['data']['children'][0]

--- a/tests/old.py
+++ b/tests/old.py
@@ -827,7 +827,7 @@ class MessageTest(unittest.TestCase, AuthenticatedHelper):
         self.assertTrue(isinstance(message2, Message))
         self.assertTrue(message1 == message2)
         self.assertTrue(isinstance(message2.replies), list)
-        self.assertTrue(message2.dest.lower() == self.user.name.lower())
+        self.assertTrue(message2.dest.lower() == self.r.user.name.lower())
 
     def test_mark_as_read(self):
         self.r.login(self.other_user_name, self.other_user_pswd)

--- a/tests/old.py
+++ b/tests/old.py
@@ -820,6 +820,15 @@ class MessageTest(unittest.TestCase, AuthenticatedHelper):
         self.r.get_unread(limit=1, unset_has_mail=True, update_user=True)
         self.assertFalse(self.r.user.has_mail)
 
+    def test_get_single_message(self):
+        message1 = self.r.get_inbox(limit=1)
+        message1 = list(message1)[0]
+        message2 = self.r.get_message(message1.id)
+        self.assertTrue(isinstance(message2, Message))
+        self.assertTrue(message1 == message2)
+        self.assertTrue(isinstance(message2.replies), list)
+        self.assertTrue(message2.dest.lower() == self.user.name.lower())
+
     def test_mark_as_read(self):
         self.r.login(self.other_user_name, self.other_user_pswd)
         # pylint: disable-msg=E1101

--- a/tests/old.py
+++ b/tests/old.py
@@ -821,13 +821,11 @@ class MessageTest(unittest.TestCase, AuthenticatedHelper):
         self.assertFalse(self.r.user.has_mail)
 
     def test_get_single_message(self):
-        message1 = self.r.get_inbox(limit=1)
-        message1 = list(message1)[0]
+        message1 = next(self.r.get_inbox(limit=1))
         message2 = self.r.get_message(message1.id)
-        self.assertTrue(isinstance(message2, Message))
-        self.assertTrue(message1 == message2)
+        self.assertEqual(message1, message2)
+        self.assertEqual(self.r.user.name.lower(), message2.dest.lower())
         self.assertTrue(isinstance(message2.replies), list)
-        self.assertTrue(message2.dest.lower() == self.r.user.name.lower())
 
     def test_mark_as_read(self):
         self.r.login(self.other_user_name, self.other_user_pswd)


### PR DESCRIPTION
I don't quite understand the new format for the Test files, but judging by your recent commits I assume they're a work in progress. I added a test for this method in olds.py, I hope this isn't a problem.

Please critique!

edit: Did coverage go down because I did not directly test Message.from_id? I can add that in if you like.