### PR TITLE
Add ability to load refresh_token from praw.ini

### DIFF
--- a/docs/pages/configuration_files.rst
+++ b/docs/pages/configuration_files.rst
@@ -39,7 +39,7 @@ path for specific operating systems should be:
 * **WINDOWS XP:** C:\\Documents and Settings\\foobar\\Application
   Data\\praw.ini
 * **WINDOWS Vista/7:** C:\\Users\\foobar\\AppData\\Roaming\\praw.ini
-* **OS with XDG_CONFIG_HOME defined**: $XDG_CONFIG_HOME/praw.ini
+* **OS with XDG_CONFIG_HOME defined:** $XDG_CONFIG_HOME/praw.ini
 * **OS X** / **Linux:** /home/foobar/.config/praw.ini
 
 The *local* configuration file is located in the current working directory.

--- a/docs/pages/configuration_files.rst
+++ b/docs/pages/configuration_files.rst
@@ -36,11 +36,11 @@ The *user* configuration file location depends on your operating system.
 Assuming typical operating system installations and the username *foobar* the
 path for specific operating systems should be:
 
-* **WINDOWS XP**: C:\\Documents and Settings\\foobar\\Application
+* **WINDOWS XP:** C:\\Documents and Settings\\foobar\\Application
   Data\\praw.ini
-* **WINDOWS Vista/7**: C:\\Users\\foobar\\AppData\\Roaming\\praw.ini
+* **WINDOWS Vista/7:** C:\\Users\\foobar\\AppData\\Roaming\\praw.ini
 * **OS with XDG_CONFIG_HOME defined**: $XDG_CONFIG_HOME/praw.ini
-* **OS X** / **Linux**: /home/foobar/.config/praw.ini
+* **OS X** / **Linux:** /home/foobar/.config/praw.ini
 
 The *local* configuration file is located in the current working directory.
 This location works best if you want script-specific configuration files.
@@ -51,52 +51,52 @@ Configuration Variables
 The following variables are provided in the [DEFAULT] section of the *global*
 config file. Each site can overwrite any of these variables.
 
-* *api_request_delay*: A **float** that defines the number of seconds required
+* *api_request_delay:* A **float** that defines the number of seconds required
   between calls to the same domain.
-* *api_domain*: A **string** that defines the *domain* to use for all
+* *api_domain:* A **string** that defines the *domain* to use for all
   standard API requests.
-* *check_for_updates* A **boolean** to indicate whether or not to check for
+* *check_for_updates:* A **boolean** to indicate whether or not to check for
   package updates.
-* *cache_timeout*: An **integer** that defines the number of seconds to
+* *cache_timeout:* An **integer** that defines the number of seconds to
   internally cache GET/POST requests based on URL.
-* *oauth_domain*: A **string** that defines the *domain* where OAuth
+* *oauth_domain:* A **string** that defines the *domain* where OAuth
   authenticated requests are sent.
-* *oauth_https*: A **boolean** that determines whether or not to use HTTPS for
+* *oauth_https:* A **boolean** that determines whether or not to use HTTPS for
   oauth connections. This should only be changed for development environments.
-* *output_chars_limit*: A **integer** that defines the maximum length of
+* *output_chars_limit:* An **integer** that defines the maximum length of
   unicode representations of :class:`.Comment`, :class:`.Message` and
   :class:`.Submission` objects. This is mainly used to fit them within a
   terminal window line. A negative value means no limit.
-* *permalink_domain*: A **string** that defines the *domain* that is used for
+* *permalink_domain:* A **string** that defines the *domain* that is used for
    the display *permalink* for Submissions and Comments.
-* *short_domain*: A **string** that defines the *domain* that is used for
+* *short_domain:* A **string** that defines the *domain* that is used for
    short urls.
-* *timeout* Maximum time, a **float**, in seconds, before a single HTTP request
+* *timeout:* Maximum time, a **float**, in seconds, before a single HTTP request
   times out. urllib2.URLError is raised upon timeout.
-* *xxx_kind*: A **string** that maps the *type* returned by json results to a
+* *xxx_kind:* A **string** that maps the *type* returned by json results to a
   local object. **xxx** is one of: *comment*, *message*, *more*, *redditor*,
   *submission*, *subreddit*, *userlist*. This variable is needed as the
   object-to-kind mapping is created dynamically on site creation and thus isn't
   consistent across sites.
-* *log_requests* A **integer** that determines the level of API call logging.
+* *log_requests:* An **integer** that determines the level of API call logging.
 
- * **0**: no logging
- * **1**: log only the request URIs
- * **2**: log the request URIs as well as any POST data
+ * **0:** no logging
+ * **1:** log only the request URIs
+ * **2:** log the request URIs as well as any POST data
 
-* *http_proxy* A **string** that declares a http proxy to be used. It follows
+* *http_proxy:* A **string** that declares a http proxy to be used. It follows
   the `requests proxy conventions
   <http://docs.python-requests.org/en/latest/user/advanced/#proxies>`_, e.g.,
   ``http_proxy: http://user:pass@addr:port``. If no proxy is specified, PRAW
   will pick up the environment variable for http_proxy, if it has been set.
 
-* *https_proxy* A **string** that declares a https proxy to be used. It follows
+* *https_proxy:* A **string** that declares a https proxy to be used. It follows
   the `requests proxy conventions
   <http://docs.python-requests.org/en/latest/user/advanced/#proxies>`_, e.g.,
   ``https_proxy: http://user:pass@addr:port``. If no proxy is specified, PRAW
   will pick up the environment variable for https_proxy, if it has been set.
 
-* *store_json_result* A **boolean** to indicate if json_dict, which contains
+* *store_json_result:* A **boolean** to indicate if json_dict, which contains
   the original API response, should be stored on every object in the json_dict
   attribute. Default is ``False`` as memory usage will double if enabled. For
   lazy objects, json_dict will be ``None`` until the data has been fetched.
@@ -104,28 +104,28 @@ config file. Each site can overwrite any of these variables.
 The are additional variables that each site can define. These additional
 variables are:
 
-* *domain*: (**REQUIRED**) A **string** that provides the domain name, and
+* *domain:* (**REQUIRED**) A **string** that provides the domain name, and
   optionally port, used to connect to the desired reddit site. For reddit
   proper, this is: `www.reddit.com`. Note that if you are running a custom
   reddit install, this name needs to match the domain name listed in the
   reddit configuration ini.
-* *user*: A **string** that defines the default username to use when *login*
+* *user:* A **string** that defines the default username to use when *login*
   is called without a *user* parameter.
-* *pswd*: A **string** that defines the password to use in conjunction with
+* *pswd:*A **string** that defines the password to use in conjunction with
   the provided *user*.
-* *ssl_domain*: A **string** that defines the *domain*  where encrypted
+* *ssl_domain:* A **string** that defines the *domain*  where encrypted
   requests are sent. This is used for logging in, both OAuth and user/password.
   When not provided, these requests are sent in plaintext (unencrypted).
 * *oauth_client_id:* A **string** that, if given, defines the ``client_id`` a
   reddit object is initialized with.
 * *oauth_client_secret:* A **string** that, if given, defines the
   ``client_secret`` a reddit object is initialized with.
-* *oauth_redirect_uri* A **string** that, if given, defines the
+* *oauth_redirect_uri:* A **string** that, if given, defines the
   ``redirect_uri`` a reddit object is initialized with. If *oauth_client_id*
   and *oauth_client_secret* is also given, then :meth:`.get_authorize_url` can
   be run without first setting the oauth settings with running
   :meth:`.set_oauth_app_info`.
-* *oauth_refresh_token* A **string** that, if given, defines the
+* *oauth_refresh_token:* A **string** that, if given, defines the
   ``refresh_token`` a reddit object is initialized with. If *oauth_client_id*,
   *oauth_client_secret*, and *oauth_redirect_uri* are also given, then
   :meth:`.refresh_access_information` can be run with no arugments to acquire
@@ -143,10 +143,10 @@ The Sites
 
 The default provided sites are:
 
-* *reddit*: This site defines the settings for reddit proper. It is used by
+* *reddit:* This site defines the settings for reddit proper. It is used by
   default if the *site* parameter is not defined when creating the *Reddit*
   object.
-* *local*: This site defines settings for a locally running instance of reddit.
+* *local:* This site defines settings for a locally running instance of reddit.
   The *xxx_kind* mappings may differ so you may need to shadow (overwrite) the
   'local' site in your *user*-level or *local*-level ``praw.ini`` file.
 

--- a/docs/pages/configuration_files.rst
+++ b/docs/pages/configuration_files.rst
@@ -128,7 +128,7 @@ variables are:
 * *oauth_refresh_token:* A **string** that, if given, defines the
   ``refresh_token`` a reddit object is initialized with. If *oauth_client_id*,
   *oauth_client_secret*, and *oauth_redirect_uri* are also given, then
-  :meth:`.refresh_access_information` can be run with no arugments to acquire
+  :meth:`.refresh_access_information` can be run with no arguments to acquire
   new access information without first running :meth:`.get_authorize_url` and
   :meth:`.get_access_information`.
 

--- a/docs/pages/configuration_files.rst
+++ b/docs/pages/configuration_files.rst
@@ -125,6 +125,14 @@ variables are:
   and *oauth_client_secret* is also given, then :meth:`.get_authorize_url` can
   be run without first setting the oauth settings with running
   :meth:`.set_oauth_app_info`.
+* *oauth_refresh_token* A **string** that, if given, defines the
+  ``refresh_token`` a reddit object is initialized with. If *oauth_client_id*,
+  *oauth_client_secret*, and *oauth_redirect_uri* are also given, then
+  :meth:`.refresh_access_information` can be run without first setting the
+  oauth settings by running :meth:`.set_oauth_app_info`.  Also allows 
+  :meth:`.refresh_access_information` to be run without arguments to acquire
+  a new access token without first running :meth:`.get_authorize_url` and
+  :meth:`.get_access_information`.
 
 Note: The tracking for *api_request_delay* and *cache_timeout* is on a
 per-domain, not per-site, basis. Essentially, this means that the time since

--- a/docs/pages/configuration_files.rst
+++ b/docs/pages/configuration_files.rst
@@ -125,14 +125,6 @@ variables are:
   and *oauth_client_secret* is also given, then :meth:`.get_authorize_url` can
   be run without first setting the oauth settings with running
   :meth:`.set_oauth_app_info`.
-* *oauth_refresh_token* A **string** that, if given, defines the
-  ``refresh_token`` a reddit object is initialized with. If *oauth_client_id*,
-  *oauth_client_secret*, and *oauth_redirect_uri* are also given, then
-  :meth:`.refresh_access_information` can be run without first setting the
-  oauth settings by running :meth:`.set_oauth_app_info`.  Also allows 
-  :meth:`.refresh_access_information` to be run with no arguments to acquire
-  a new access token without first running :meth:`.get_authorize_url` and
-  :meth:`.get_access_information`.
 
 Note: The tracking for *api_request_delay* and *cache_timeout* is on a
 per-domain, not per-site, basis. Essentially, this means that the time since

--- a/docs/pages/configuration_files.rst
+++ b/docs/pages/configuration_files.rst
@@ -125,14 +125,6 @@ variables are:
   and *oauth_client_secret* is also given, then :meth:`.get_authorize_url` can
   be run without first setting the oauth settings with running
   :meth:`.set_oauth_app_info`.
-* *oauth_refresh_token* A **string** that, if given, defines the
-  ``refresh_token`` a reddit object is initialized with. If *oauth_client_id*,
-  *oauth_client_secret*, and *oauth_redirect_uri* are also given, then
-  :meth:`.refresh_access_information` can be run without first setting the
-  oauth settings by running :meth:`.set_oauth_app_info`.  Also allows 
-  :meth:`.refresh_access_information` to be run without arguments to acquire
-  a new access token without first running :meth:`.get_authorize_url` and
-  :meth:`.get_access_information`.
 
 Note: The tracking for *api_request_delay* and *cache_timeout* is on a
 per-domain, not per-site, basis. Essentially, this means that the time since

--- a/docs/pages/configuration_files.rst
+++ b/docs/pages/configuration_files.rst
@@ -125,6 +125,12 @@ variables are:
   and *oauth_client_secret* is also given, then :meth:`.get_authorize_url` can
   be run without first setting the oauth settings with running
   :meth:`.set_oauth_app_info`.
+* *oauth_refresh_token* A **string** that, if given, defines the
+  ``refresh_token`` a reddit object is initialized with. If *oauth_client_id*,
+  *oauth_client_secret*, and *oauth_redirect_uri* are also given, then
+  :meth:`.refresh_access_information` can be run with no arugments to acquire
+  new access information without first running :meth:`.get_authorize_url` and
+  :meth:`.get_access_information`.
 
 Note: The tracking for *api_request_delay* and *cache_timeout* is on a
 per-domain, not per-site, basis. Essentially, this means that the time since

--- a/docs/pages/configuration_files.rst
+++ b/docs/pages/configuration_files.rst
@@ -125,6 +125,14 @@ variables are:
   and *oauth_client_secret* is also given, then :meth:`.get_authorize_url` can
   be run without first setting the oauth settings with running
   :meth:`.set_oauth_app_info`.
+* *oauth_refresh_token* A **string** that, if given, defines the
+  ``refresh_token`` a reddit object is initialized with. If *oauth_client_id*,
+  *oauth_client_secret*, and *oauth_redirect_uri* are also given, then
+  :meth:`.refresh_access_information` can be run without first setting the
+  oauth settings by running :meth:`.set_oauth_app_info`.  Also allows 
+  :meth:`.refresh_access_information` to be run with no arguments to acquire
+  a new access token without first running :meth:`.get_authorize_url` and
+  :meth:`.get_access_information`.
 
 Note: The tracking for *api_request_delay* and *cache_timeout* is on a
 per-domain, not per-site, basis. Essentially, this means that the time since

--- a/praw/__init__.py
+++ b/praw/__init__.py
@@ -582,6 +582,7 @@ class OAuth2Reddit(BaseReddit):
         self.client_id = self.config.client_id
         self.client_secret = self.config.client_secret
         self.redirect_uri = self.config.redirect_uri
+        self.refresh_token = self.config.refresh_token
 
     def _handle_oauth_request(self, data):
         auth = (self.client_id, self.client_secret)

--- a/praw/__init__.py
+++ b/praw/__init__.py
@@ -231,6 +231,7 @@ class Config(object):  # pylint: disable=R0903
         self.client_id = obj.get('oauth_client_id') or None
         self.client_secret = obj.get('oauth_client_secret') or None
         self.redirect_uri = obj.get('oauth_redirect_uri') or None
+        self.refresh_token = obj.get('oauth_refresh_token') or None
         self.store_json_result = config_boolean(obj.get('store_json_result'))
 
         if 'short_domain' in obj:
@@ -1141,7 +1142,7 @@ class AuthenticatedReddit(OAuth2Reddit, UnauthenticatedReddit):
         #  * set(...) means OAuth authenticated with the scopes in the set
         self._authentication = None
         self.access_token = None
-        self.refresh_token = None
+        self.refresh_token = self.config.refresh_token or None
         self.user = None
 
     def __str__(self):

--- a/praw/__init__.py
+++ b/praw/__init__.py
@@ -582,7 +582,6 @@ class OAuth2Reddit(BaseReddit):
         self.client_id = self.config.client_id
         self.client_secret = self.config.client_secret
         self.redirect_uri = self.config.redirect_uri
-        self.refresh_token = self.config.refresh_token
 
     def _handle_oauth_request(self, data):
         auth = (self.client_id, self.client_secret)


### PR DESCRIPTION
I have a bot that does not run 24/7, only uses 1 reddit account, and has no additional configuration.  With this change, I can store refresh_token along with client_id and client_secret in praw.ini and simply refresh_access_information() on bot startup to retrieve a new access_key.