### PR TITLE
change scope of report()

### DIFF
--- a/praw/objects.py
+++ b/praw/objects.py
@@ -433,7 +433,7 @@ class Reportable(RedditContentObject):
 
     """Interface for RedditContentObjects that can be reported."""
 
-    @restrict_access(scope=None, login=True)
+    @restrict_access(scope="report")
     def report(self, reason=None):
         """Report this object to the moderators.
 


### PR DESCRIPTION
having @restrict_access(login=True), prevents using the report function in the oauth scope.

changing the scope from None to "report" and removing the login requirement will allow the report function to work properly with Oauth.


see hide() for precedence of this change and http://www.reddit.com/dev/api/oauth#scope_report