### PR TITLE
Configuration options for SSL validation

### DIFF
--- a/docs/pages/configuration_files.rst
+++ b/docs/pages/configuration_files.rst
@@ -96,6 +96,11 @@ config file. Each site can overwrite any of these variables.
   ``https_proxy: http://user:pass@addr:port``. If no proxy is specified, PRAW
   will pick up the environment variable for https_proxy, if it has been set.
 
+* *validate_certs:* A **boolean** to indicate if SSL certificates should be
+  validated or not.  If not specified, will default to ``True``.  This is
+  mainly for testing local reddit installation with self-signed
+  certificates.
+
 * *store_json_result:* A **boolean** to indicate if json_dict, which contains
   the original API response, should be stored on every object in the json_dict
   attribute. Default is ``False`` as memory usage will double if enabled. For

--- a/docs/pages/configuration_files.rst
+++ b/docs/pages/configuration_files.rst
@@ -59,6 +59,21 @@ config file. Each site can overwrite any of these variables.
   package updates.
 * *cache_timeout:* An **integer** that defines the number of seconds to
   internally cache GET/POST requests based on URL.
+* *http_proxy:* A **string** that declares a http proxy to be used. It follows
+  the `requests proxy conventions
+  <http://docs.python-requests.org/en/latest/user/advanced/#proxies>`_, e.g.,
+  ``http_proxy: http://user:pass@addr:port``. If no proxy is specified, PRAW
+  will pick up the environment variable for http_proxy, if it has been set.
+* *https_proxy:* A **string** that declares a https proxy to be used. It follows
+  the `requests proxy conventions
+  <http://docs.python-requests.org/en/latest/user/advanced/#proxies>`_, e.g.,
+  ``https_proxy: http://user:pass@addr:port``. If no proxy is specified, PRAW
+  will pick up the environment variable for https_proxy, if it has been set.
+* *log_requests:* An **integer** that determines the level of API call logging.
+
+ * **0:** no logging
+ * **1:** log only the request URIs
+ * **2:** log the request URIs as well as any POST data
 * *oauth_domain:* A **string** that defines the *domain* where OAuth
   authenticated requests are sent.
 * *oauth_https:* A **boolean** that determines whether or not to use HTTPS for
@@ -71,39 +86,22 @@ config file. Each site can overwrite any of these variables.
    the display *permalink* for Submissions and Comments.
 * *short_domain:* A **string** that defines the *domain* that is used for
    short urls.
+* *store_json_result:* A **boolean** to indicate if json_dict, which contains
+  the original API response, should be stored on every object in the json_dict
+  attribute. Default is ``False`` as memory usage will double if enabled. For
+  lazy objects, json_dict will be ``None`` until the data has been fetched.
 * *timeout:* Maximum time, a **float**, in seconds, before a single HTTP request
   times out. urllib2.URLError is raised upon timeout.
+* *validate_certs:* A **boolean** to indicate if SSL certificates should be
+  validated or not.  If not specified, will default to ``True``.  This is
+  mainly for testing local reddit installations with self-signed certificates.
 * *xxx_kind:* A **string** that maps the *type* returned by json results to a
   local object. **xxx** is one of: *comment*, *message*, *more*, *redditor*,
   *submission*, *subreddit*, *userlist*. This variable is needed as the
   object-to-kind mapping is created dynamically on site creation and thus isn't
   consistent across sites.
-* *log_requests:* An **integer** that determines the level of API call logging.
 
- * **0:** no logging
- * **1:** log only the request URIs
- * **2:** log the request URIs as well as any POST data
 
-* *http_proxy:* A **string** that declares a http proxy to be used. It follows
-  the `requests proxy conventions
-  <http://docs.python-requests.org/en/latest/user/advanced/#proxies>`_, e.g.,
-  ``http_proxy: http://user:pass@addr:port``. If no proxy is specified, PRAW
-  will pick up the environment variable for http_proxy, if it has been set.
-
-* *https_proxy:* A **string** that declares a https proxy to be used. It follows
-  the `requests proxy conventions
-  <http://docs.python-requests.org/en/latest/user/advanced/#proxies>`_, e.g.,
-  ``https_proxy: http://user:pass@addr:port``. If no proxy is specified, PRAW
-  will pick up the environment variable for https_proxy, if it has been set.
-
-* *validate_certs:* A **boolean** to indicate if SSL certificates should be
-  validated or not.  If not specified, will default to ``True``.  This is
-  mainly for testing local reddit installations with self-signed certificates.
-
-* *store_json_result:* A **boolean** to indicate if json_dict, which contains
-  the original API response, should be stored on every object in the json_dict
-  attribute. Default is ``False`` as memory usage will double if enabled. For
-  lazy objects, json_dict will be ``None`` until the data has been fetched.
 
 The are additional variables that each site can define. These additional
 variables are:

--- a/docs/pages/configuration_files.rst
+++ b/docs/pages/configuration_files.rst
@@ -98,8 +98,7 @@ config file. Each site can overwrite any of these variables.
 
 * *validate_certs:* A **boolean** to indicate if SSL certificates should be
   validated or not.  If not specified, will default to ``True``.  This is
-  mainly for testing local reddit installation with self-signed
-  certificates.
+  mainly for testing local reddit installations with self-signed certificates.
 
 * *store_json_result:* A **boolean** to indicate if json_dict, which contains
   the original API response, should be stored on every object in the json_dict

--- a/praw/__init__.py
+++ b/praw/__init__.py
@@ -239,11 +239,7 @@ class Config(object):  # pylint: disable=R0903
                             os.getenv('https_proxy') or None)
         # We use `get(...) or None` because `get` may return an empty string
 
-        if 'validate_certs' in obj:
-            self.validate_certs = \
-                config_boolean(obj.get('validate_certs'))
-        else:
-            self.validate_certs = True
+        self.validate_certs = config_boolean(obj.get('validate_certs'))
 
         self.client_id = obj.get('oauth_client_id') or None
         self.client_secret = obj.get('oauth_client_secret') or None
@@ -333,6 +329,8 @@ class BaseReddit(object):
         self.handler = handler or DefaultHandler()
         self.http = Session()
         self.http.headers['User-Agent'] = UA_STRING % user_agent
+        self.http.validate_certs = self.config.validate_certs
+
         # This `Session` object is only used to store request information that
         # is used to make prepared requests. It _should_ never be used to make
         # a direct request, thus we raise an exception when it is used.
@@ -348,8 +346,6 @@ class BaseReddit(object):
             if self.config.https_proxy:
                 self.http.proxies['https'] = self.config.https_proxy
         self.modhash = None
-
-        self.http.validate_certs = self.config.validate_certs
 
         # Check for updates if permitted and this is the first Reddit instance
         if not disable_update_check and not self.update_checked \
@@ -389,12 +385,12 @@ class BaseReddit(object):
                 request.url = url
                 kwargs['_cache_key'] = (normalize_url(request.url),
                                         tuple(key_items))
-                response = \
-                    self.handler.request(request=request.prepare(),
-                                         proxies=self.http.proxies,
-                                         timeout=timeout,
-                                         verify=self.http.validate_certs,
-                                         **kwargs)
+                response = self.handler.request(
+                    request=request.prepare(),
+                    proxies=self.http.proxies,
+                    timeout=timeout,
+                    verify=self.http.validate_certs, **kwargs)
+
                 if self.config.log_requests >= 2:
                     sys.stderr.write('status: {0}\n'
                                      .format(response.status_code))

--- a/praw/handlers.py
+++ b/praw/handlers.py
@@ -81,7 +81,7 @@ class RateLimitHandler(object):
         """Establish the HTTP session."""
         self.http = Session()  # Each instance should have its own session
 
-    def request(self, request, proxies, timeout, **_):
+    def request(self, request, proxies, timeout, verify, **_):
         """Responsible for dispatching the request and returning the result.
 
         Network level exceptions should be raised and only
@@ -99,7 +99,7 @@ class RateLimitHandler(object):
 
         """
         return self.http.send(request, proxies=proxies, timeout=timeout,
-                              allow_redirects=False)
+                              allow_redirects=False, verify=verify)
 RateLimitHandler.request = RateLimitHandler.rate_limit(
     RateLimitHandler.request)
 

--- a/praw/handlers.py
+++ b/praw/handlers.py
@@ -93,6 +93,7 @@ class RateLimitHandler(object):
             request.
         :param timeout: Specifies the maximum time that the actual HTTP request
             can take.
+        :param verify: Specifies if SSL certificates should be validated.
 
         ``**_`` should be added to the method call to ignore the extra
         arguments intended for the cache handler.

--- a/praw/praw.ini
+++ b/praw/praw.ini
@@ -69,13 +69,3 @@ permalink_domain: reddit.local
 submission_kind: t6
 subreddit_kind: t5
 
-[local]
-domain: 192.168.140.135:443
-api_domain: 192.168.140.135:443
-api_request_delay: 0
-log_requests: 0
-message_kind: t7
-permalink_domain: 192.168.140.135:443
-submission_kind: t6
-subreddit_kind: t5
-validate_certs: False

--- a/praw/praw.ini
+++ b/praw/praw.ini
@@ -12,6 +12,12 @@ check_for_updates: True
 # Time, a float, in seconds, to save the results of a get/post request.
 cache_timeout: 30
 
+# Log the API calls
+# 0: no logging
+# 1: log only the request URIs
+# 2: log the request URIs as well as any POST data
+log_requests: 0
+
 # The domain name PRAW will use for oauth-related requests.
 oauth_domain: oauth.reddit.com
 
@@ -30,9 +36,18 @@ permalink_domain: www.reddit.com
 # The domain name to use for short urls.
 short_domain: redd.it
 
+# A boolean to indicate if json_dict, which contains the original API response,
+# should be stored on every object in the json_dict attribute. Default is
+# False as memory usage will double if enabled.
+store_json_result: False
+
 # Maximum time, a float, in seconds, before a single HTTP request times
 # out. urllib2.URLError is raised upon timeout.
 timeout: 45
+
+# A boolean to indicate if SSL certificats should be validated. The
+# default is True.
+validate_certs: True
 
 # Object to kind mappings
 comment_kind:    t1
@@ -41,16 +56,6 @@ redditor_kind:   t2
 submission_kind: t3
 subreddit_kind:  t5
 
-# Log the API calls
-# 0: no logging
-# 1: log only the request URIs
-# 2: log the request URIs as well as any POST data
-log_requests: 0
-
-# A boolean to indicate if json_dict, which contains the original API response,
-# should be stored on every object in the json_dict attribute. Default is
-# False as memory usage will double if enabled.
-store_json_result: False
 
 [reddit]
 # Uses the default settings
@@ -68,4 +73,3 @@ message_kind: t7
 permalink_domain: reddit.local
 submission_kind: t6
 subreddit_kind: t5
-

--- a/praw/praw.ini
+++ b/praw/praw.ini
@@ -68,3 +68,14 @@ message_kind: t7
 permalink_domain: reddit.local
 submission_kind: t6
 subreddit_kind: t5
+
+[local]
+domain: 192.168.140.135:443
+api_domain: 192.168.140.135:443
+api_request_delay: 0
+log_requests: 0
+message_kind: t7
+permalink_domain: 192.168.140.135:443
+submission_kind: t6
+subreddit_kind: t5
+validate_certs: False

--- a/scripts/init_test_environment.py
+++ b/scripts/init_test_environment.py
@@ -3,7 +3,7 @@ import praw
 import sys
 
 
-PASSWORD = '1111'
+PASSWORD = '111111'
 SUBMISSIONS = ({'subreddit': 'reddit_api_test', 'text': 'blah blah blah',
                 'title': 'Init Submission', 'username': 'pyapitestuser3'},
                {'subreddit': 'python', 'title': 'Python Website',
@@ -56,8 +56,8 @@ def adjust_subscriptions(r):
 
     for username in USER_TO_SUBS:
         r.login(username, PASSWORD)
-        subscribed = set(x.display_name.lower()
-                         for x in r.user.my_reddits(limit=None))
+        subscribed = set(x['data']['display_name'].lower()
+                         for x in r.get_my_subreddits(limit=None))
         for subreddit_name in subscribed - subreddits:
             r.unsubscribe(subreddit_name)
             print('{0} unsubscribed from {1}'.format(username, subreddit_name))


### PR DESCRIPTION
This request stems from #318.  

I think the "target" moved slightly since this was opened.  It doesn't restore the ability to use HTTP instead of HTTPS, but a default reddit install using the install script is now HTTPS enabled using a self-signed certificate.  This allows you to ignore the certificate validation errors and successfully interact with an out of the box installation of reddit.

I did what testing I could, I wasn't familiar enough to generate new test cases for with and without valid certificates.