### PR TITLE
Fix OAuth scopes in _modify_relationship in internal.py

### DIFF
--- a/praw/internal.py
+++ b/praw/internal.py
@@ -89,6 +89,8 @@ def _modify_relationship(relationship, unlink=False, is_sub=False):
         access = {'scope': None, 'login': True}
     elif relationship == 'moderator':
         access = {'scope': 'modothers'}
+    elif relationship == 'banned' or relationship == 'contributor':
+        access = {'scope': 'modcontributors'}
     else:
         access = {'scope': None, 'mod': True}
 

--- a/praw/internal.py
+++ b/praw/internal.py
@@ -89,7 +89,7 @@ def _modify_relationship(relationship, unlink=False, is_sub=False):
         access = {'scope': None, 'login': True}
     elif relationship == 'moderator':
         access = {'scope': 'modothers'}
-    elif relationship == 'banned' or relationship == 'contributor':
+    elif relationship in ['banned', 'contributor']:
         access = {'scope': 'modcontributors'}
     else:
         access = {'scope': None, 'mod': True}


### PR DESCRIPTION
I seem to have found some mistakes in the ``_modify_relationship`` function in internal.py: it doesn't pass a scope value of ``modcontributor`` to the ``@restrict_access`` decorator of the local ``do_relationship`` function when the relationship is set to ``banned`` or ``contributor``, despite [the API documentation](https://www.reddit.com/dev/api/oauth#POST_api_friend) saying that the ``modcontributor`` relationship requires that scope. The same is true for the ``wikibanned`` and ``wikicontributor`` relationships, except they also require the ``modwiki`` scope on top of the ``modcontributor`` scope.

The first commit fixes the ``banned`` and ``modcontributor`` relationships (or at least tries to do so)~~, but, to fix the other two, I need an answer to this rookie question: How can one pass two or more scopes to the ``@restrict_access`` decorator?~~ Edit: apparently, that's currently impossible


~~Of course, since I'm quite inexperienced with PRAW and the Reddit API, I might be completely wrong about all of this, in which case, sorry for wasting the time of anyone that read this.~~ Edit: After testing this a bit, it looks like not having the two lines that this PR would add causes ``remove_contributor`` and ``add_contributor`` to not work and raise the following exception if logged in via OAuth:

    Traceback (most recent call last):
      File "<pyshell#17>", line 1, in <module>
        r.get_subreddit("automodtestsub").remove_contributor(r.user.name)
      File "C:\Python27\lib\site-packages\praw\decorators.py", line 346, in wrapped
        raise errors.LoginRequired(function.__name__)
    LoginRequired: `do_relationship` requires a logged in session

...and the following exception if logged in via cookie authentication (the ``login()`` method):

    Traceback (most recent call last):
      File "<pyshell#23>", line 1, in <module>
        r.get_subreddit("automodtestsub").remove_contributor(r.user.name)
      File "C:\Python27\lib\site-packages\praw\decorators.py", line 342, in wrapped
        raise errors.ModeratorRequired(function.__name__)
    ModeratorRequired: ``do_relationship` requires a moderator of the subreddit` requires a logged in session

And this happens regardless of whether you're a moderator and have access permissions or not.