### PR TITLE
07 July 2015 - Remove reference to user in mark_as_read

### DIFF
--- a/praw/objects.py
+++ b/praw/objects.py
@@ -379,7 +379,7 @@ class Inboxable(RedditContentObject):
         :returns: The json response from the server.
 
         """
-        return self.reddit_session.user.mark_as_read(self)
+        return self.reddit_session._mark_as_read([self.fullname])
 
     def mark_as_unread(self):
         """Mark object as unread.
@@ -387,7 +387,7 @@ class Inboxable(RedditContentObject):
         :returns: The json response from the server.
 
         """
-        return self.reddit_session.user.mark_as_read(self, unread=True)
+        return self.reddit_session._mark_as_read([self.fullname], unread=True)
 
     def reply(self, text):
         """Reply to object with the specified text.


### PR DESCRIPTION
Because `reddit_session.user` is None when the app does not have the Identity scope, messages could not be marked as read (NoneType has no attribute mark_as_read). This method needs to work even if privatemessages is the only scope provided.

`user.mark_as_read` doesn't provide any extra functionality when you're only using a single item anyway.

&nbsp;

This is a simple PR, so I'd like this to be the last one and then I'll release 3.1.0. The to-do list is ever increasing but I've put it off long enough.