### PR TITLE
Fix #249 Don't destroy method signatures with decorators

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -14,9 +14,6 @@
 import sys
 sys.path.insert(0, "..")
 
-import os
-os.environ['SPHINX_BUILD'] = '1'
-
 from praw import __version__
 
 # If extensions (or modules to document with autodoc) are in another directory,
@@ -98,7 +95,7 @@ pygments_style = 'sphinx'
 # -- Options for HTML output ---------------------------------------------------
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
-# a list of builtin themes. Currently Setting it to default to allow RTD 
+# a list of builtin themes. Currently Setting it to default to allow RTD
 # builds to pickup the new default theme.
 html_theme = 'default'
 

--- a/docs/pages/exceptions.rst
+++ b/docs/pages/exceptions.rst
@@ -46,7 +46,7 @@ Redirects. Are automatically handled in PRAW, but may result in a
 ``RedirectException`` if an unexpected redirect is encountered.
 
 403 (:class:`.Forbidden`)
-^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 This will occur if you try to access a restricted resource. For instance a
 private subreddit that the currently logged-in user doesn't have access to.

--- a/praw/__init__.py
+++ b/praw/__init__.py
@@ -464,8 +464,7 @@ class BaseReddit(object):
     @decorators.oauth_generator
     def get_content(self, url, params=None, limit=0, place_holder=None,
                     root_field='data', thing_field='children',
-                    after_field='after', _use_oauth=False,
-                    object_filter=None):
+                    after_field='after', object_filter=None, **kwargs):
         """A generator method to return reddit content from a URL.
 
         Starts at the initial url, and fetches content using the `after`
@@ -503,6 +502,8 @@ class BaseReddit(object):
             Submission or user flair.
 
         """
+        _use_oauth = kwargs.get('_use_oauth', False)
+
         objects_found = 0
         params = params or {}
         fetch_all = fetch_once = False
@@ -1309,8 +1310,13 @@ class AuthenticatedReddit(OAuth2Reddit, UnauthenticatedReddit):
                            'https://www.reddit.com/comments/37e2mv/\n\n'
                            'Pass ``disable_warning=True`` to ``login`` to '
                            'disable this warning.')
-    def login(self, username=None, password=None):
+    def login(self, username=None, password=None, **kwargs):
         """Login to a reddit site.
+
+        **DEPRECATED**. Will be removed in a future version of PRAW.
+
+        https://www.reddit.com/comments/2ujhkr/
+        https://www.reddit.com/comments/37e2mv/
 
         Look for username first in parameter, then praw.ini and finally if both
         were empty get it from stdin. Look for password in parameter, then
@@ -1442,10 +1448,15 @@ class ModConfigMixin(AuthenticatedReddit):
     def create_subreddit(self, name, title, description='', language='en',
                          subreddit_type='public', content_options='any',
                          over_18=False, default_set=True, show_media=False,
-                         domain='', wikimode='disabled', captcha=None):
+                         domain='', wikimode='disabled', captcha=None,
+                         **kwargs):
         """Create a new subreddit.
 
         :returns: The json response from the server.
+
+        This function may result in a captcha challenge. PRAW will
+        automatically prompt you for a response. See :ref:`handling-captchas`
+        if you want to manually handle captchas.
 
         """
         data = {'name': name,
@@ -2357,7 +2368,7 @@ class PrivateMessagesMixin(AuthenticatedReddit):
     @decorators.restrict_access(scope='privatemessages')
     @decorators.require_captcha
     def send_message(self, recipient, subject, message, from_sr=None,
-                     captcha=None):
+                     captcha=None, **kwargs):
         """Send a message to a redditor or a subreddit's moderators (mod mail).
 
         :param recipient: A Redditor or Subreddit instance to send a message
@@ -2372,6 +2383,10 @@ class PrivateMessagesMixin(AuthenticatedReddit):
             must be a moderator of the subreddit.
 
         :returns: The json response from the server.
+
+        This function may result in a captcha challenge. PRAW will
+        automatically prompt you for a response. See :ref:`handling-captchas`
+        if you want to manually handle captchas.
 
         """
         if isinstance(recipient, objects.Subreddit):
@@ -2461,7 +2476,7 @@ class SubmitMixin(AuthenticatedReddit):
     @decorators.restrict_access(scope='submit')
     @decorators.require_captcha
     def submit(self, subreddit, title, text=None, url=None, captcha=None,
-               save=None, send_replies=None, resubmit=None):
+               save=None, send_replies=None, resubmit=None, **kwargs):
         """Submit a new link to the given subreddit.
 
         Accepts either a Subreddit object or a str containing the subreddit's
@@ -2478,6 +2493,10 @@ class SubmitMixin(AuthenticatedReddit):
 
         :returns: The newly created Submission object if the reddit instance
             can access it. Otherwise, return the url to the submission.
+
+        This function may result in a captcha challenge. PRAW will
+        automatically prompt you for a response. See :ref:`handling-captchas`
+        if you want to manually handle captchas.
 
         """
         if isinstance(text, six.string_types) == bool(url):

--- a/praw/decorator_helpers.py
+++ b/praw/decorator_helpers.py
@@ -1,0 +1,25 @@
+"""Internal helper functions used by praw.decorators."""
+from requests.compat import urljoin
+import six
+import sys
+
+
+def _get_captcha(reddit_session, captcha_id):
+    """Prompt user for captcha solution and return a prepared result."""
+    url = urljoin(reddit_session.config['captcha'],
+                  captcha_id + '.png')
+    sys.stdout.write('Captcha URL: %s\nCaptcha: ' % url)
+    sys.stdout.flush()
+    raw = sys.stdin.readline()
+    if not raw:  # stdin has reached the end of file
+        # Trigger exception raising next time through. The request is
+        # cached so this will not require and extra request and delay.
+        sys.stdin.close()
+        return None
+    return {'iden': captcha_id, 'captcha': raw.strip()}
+
+
+def _is_mod_of_all(user, subreddit):
+    mod_subs = user.get_cached_moderated_reddits()
+    subs = six.text_type(subreddit).lower().split('+')
+    return all(sub in mod_subs for sub in subs)

--- a/praw/decorators.py
+++ b/praw/decorators.py
@@ -22,23 +22,18 @@ length of output strings and parse json response for certain errors.
 
 from __future__ import print_function, unicode_literals
 
+import decorator
 import inspect
-import os
 import six
 import sys
 from functools import wraps
-from requests.compat import urljoin
+from praw.decorator_helpers import _get_captcha, _is_mod_of_all
 from praw import errors
 from warnings import simplefilter, warn
 
 
-# Don't decorate functions when building the documentation
-IS_SPHINX_BUILD = bool(os.getenv('SPHINX_BUILD'))
-
 # Enable deprecation warnings
 simplefilter('default')
-
-DOC_SEPARATOR = '\n\n'
 
 
 def alias_function(function, class_name):
@@ -72,78 +67,26 @@ def alias_function(function, class_name):
 
 def deprecated(msg=''):
     """Deprecate decorated method."""
-    docstring_text = ('**DEPRECATED**. Will be removed in a future version '
-                      'of PRAW. {0}'.format(msg))
-
-    def wrap(function):
-        function.__doc__ = _embed_text(function.__doc__, docstring_text)
-
-        @wraps(function)
-        def wrapped(self, *args, **kwargs):
-            disable_warning = False
-            if 'disable_warning' in kwargs:
-                disable_warning = kwargs['disable_warning']
-                del kwargs['disable_warning']
-            if not disable_warning:
-                warn(msg, DeprecationWarning)
-            return function(self, *args, **kwargs)
-        return function if IS_SPHINX_BUILD else wrapped
+    @decorator.decorator
+    def wrap(function, *args, **kwargs):
+        if not kwargs.pop('disable_warning', False):
+            warn(msg, DeprecationWarning)
+        return function(*args, **kwargs)
     return wrap
 
 
-def limit_chars(function):
+@decorator.decorator
+def limit_chars(function, *args, **kwargs):
     """Truncate the string returned from a function and return the result."""
-    @wraps(function)
-    def wrapped(self, *args, **kwargs):
-        output_chars_limit = self.reddit_session.config.output_chars_limit
-        output_string = function(self, *args, **kwargs)
-        if -1 < output_chars_limit < len(output_string):
-            output_string = output_string[:output_chars_limit - 3] + '...'
-        return output_string
-    return function if IS_SPHINX_BUILD else wrapped
+    output_chars_limit = args[0].reddit_session.config.output_chars_limit
+    output_string = function(*args, **kwargs)
+    if -1 < output_chars_limit < len(output_string):
+        output_string = output_string[:output_chars_limit - 3] + '...'
+    return output_string
 
 
-def _embed_text(docstring, text):
-    """Return the docstring with the text embedded."""
-    if docstring is None:
-        return text + DOC_SEPARATOR
-
-    split = docstring.rsplit('\n', 1)
-    if len(split) == 1:  # Single line
-        return docstring + DOC_SEPARATOR + text + DOC_SEPARATOR
-
-    indent = split[1]
-    lines = text.split('\n')
-    text = lines[0] + '\n' + '\n'.join(indent + x for x in lines[1:])
-
-    # We readd the indent at the end of the docstring so that `_embed_text
-    # can functions can be applied multiple times.
-    return docstring + text + DOC_SEPARATOR + indent
-
-
-def _build_access_text(scope, mod, login):
-    """Return access text based on required authentication."""
-    if scope == 'read':
-        text = ('May use the read oauth scope to see content only visible to '
-                'the authenticated user')
-    elif scope:
-        text = 'Requires the {0} oauth scope'.format(scope)
-    else:
-        text = 'Requires'
-
-    if scope and (mod or login):
-        text += ' or'
-
-    if mod:
-        text += 'user/password authentication as a mod of the subreddit.'
-    elif login:
-        text += ' user/password authentication.'
-    else:
-        text += '.'
-    return text
-
-
-def oauth_generator(function):
+@decorator.decorator
+def oauth_generator(function, *args, **kwargs):
     """Set the _use_oauth keyword argument to True when appropriate.
 
     This is needed because generator functions may be called at anytime, and
@@ -153,104 +96,73 @@ def oauth_generator(function):
     Returned data is not modified.
 
     """
-    @wraps(function)
-    def wrapped(reddit_session, *args, **kwargs):
-        if getattr(reddit_session, '_use_oauth', False):
-            kwargs['_use_oauth'] = True
-        return function(reddit_session, *args, **kwargs)
-    return function if IS_SPHINX_BUILD else wrapped
+    if getattr(args[0], '_use_oauth', False):
+        kwargs['_use_oauth'] = True
+    return function(*args, **kwargs)
 
 
-def raise_api_exceptions(function):
+@decorator.decorator
+def raise_api_exceptions(function, *args, **kwargs):
     """Raise client side exception(s) when present in the API response.
 
     Returned data is not modified.
 
     """
-    @wraps(function)
-    def wrapped(reddit_session, *args, **kwargs):
-        try:
-            return_value = function(reddit_session, *args, **kwargs)
-        except errors.HTTPException as exc:
-            if exc._raw.status_code != 400:  # pylint: disable=W0212
-                raise  # Unhandled HTTPErrors
-            try:  # Attempt to convert v1 errors into older format (for now)
-                data = exc._raw.json()  # pylint: disable=W0212
-                assert len(data) == 2
-                return_value = {'errors': [(data['reason'],
-                                            data['explanation'], '')]}
-            except Exception:
-                raise exc
-        if isinstance(return_value, dict):
-            if return_value.get('error') == 304:  # Not modified exception
-                raise errors.NotModified(return_value)
-            elif return_value.get('errors'):
-                error_list = []
-                for error_type, msg, value in return_value['errors']:
-                    if error_type in errors.ERROR_MAPPING:
-                        if error_type == 'RATELIMIT':
-                            reddit_session.evict(args[0])
-                        error_class = errors.ERROR_MAPPING[error_type]
-                    else:
-                        error_class = errors.APIException
-                    error_list.append(error_class(error_type, msg, value,
-                                                  return_value))
-                if len(error_list) == 1:
-                    raise error_list[0]
+    try:
+        return_value = function(*args, **kwargs)
+    except errors.HTTPException as exc:
+        if exc._raw.status_code != 400:  # pylint: disable=W0212
+            raise  # Unhandled HTTPErrors
+        try:  # Attempt to convert v1 errors into older format (for now)
+            data = exc._raw.json()  # pylint: disable=W0212
+            assert len(data) == 2
+            return_value = {'errors': [(data['reason'],
+                                        data['explanation'], '')]}
+        except Exception:
+            raise exc
+    if isinstance(return_value, dict):
+        if return_value.get('error') == 304:  # Not modified exception
+            raise errors.NotModified(return_value)
+        elif return_value.get('errors'):
+            error_list = []
+            for error_type, msg, value in return_value['errors']:
+                if error_type in errors.ERROR_MAPPING:
+                    if error_type == 'RATELIMIT':
+                        args[0].evict(args[1])
+                    error_class = errors.ERROR_MAPPING[error_type]
                 else:
-                    raise errors.ExceptionList(error_list)
-        return return_value
-    return function if IS_SPHINX_BUILD else wrapped
+                    error_class = errors.APIException
+                error_list.append(error_class(error_type, msg, value,
+                                              return_value))
+            if len(error_list) == 1:
+                raise error_list[0]
+            else:
+                raise errors.ExceptionList(error_list)
+    return return_value
 
 
-def require_captcha(function):
+@decorator.decorator
+def require_captcha(function, *args, **kwargs):
     """Return a decorator for methods that require captchas."""
-    def get_captcha(reddit_session, captcha_id):
-        """Prompt user for captcha solution and return a prepared result."""
-        url = urljoin(reddit_session.config['captcha'],
-                      captcha_id + '.png')
-        sys.stdout.write('Captcha URL: %s\nCaptcha: ' % url)
-        sys.stdout.flush()
-        raw = sys.stdin.readline()
-        if not raw:  # stdin has reached the end of file
-            # Trigger exception raising next time through. The request is
-            # cached so this will not require and extra request and delay.
-            sys.stdin.close()
-            return None
-        return {'iden': captcha_id, 'captcha': raw.strip()}
+    raise_captcha_exception = kwargs.pop('raise_captcha_exception', False)
+    captcha_id = None
 
-    captcha_text = ('This function may result in a captcha challenge. PRAW '
-                    'will automatically prompt you for a response. See '
-                    ':ref:`handling-captchas` if you want to manually handle '
-                    'captchas.')
-    function.__doc__ = _embed_text(function.__doc__, captcha_text)
+    # Get a handle to the reddit session
+    if hasattr(args[0], 'reddit_session'):
+        reddit_session = args[0].reddit_session
+    else:
+        reddit_session = args[0]
 
-    @wraps(function)
-    def wrapped(obj, *args, **kwargs):
-        if 'raise_captcha_exception' in kwargs:
-            raise_captcha_exception = kwargs['raise_captcha_exception']
-            del kwargs['raise_captcha_exception']
-        else:
-            raise_captcha_exception = False
-        captcha_id = None
-
-        # Get a handle to the reddit session
-        if hasattr(obj, 'reddit_session'):
-            reddit_session = obj.reddit_session
-        else:
-            reddit_session = obj
-
-        while True:
-            try:
-                if captcha_id:
-                    kwargs['captcha'] = get_captcha(reddit_session, captcha_id)
-                return function(obj, *args, **kwargs)
-            except errors.InvalidCaptcha as exception:
-                if raise_captcha_exception or \
-                        not hasattr(sys.stdin, 'closed') or sys.stdin.closed:
-                    raise
-                captcha_id = exception.response['captcha']
-    return function if IS_SPHINX_BUILD else wrapped
+    while True:
+        try:
+            if captcha_id:
+                kwargs['captcha'] = _get_captcha(reddit_session, captcha_id)
+            return function(*args, **kwargs)
+        except errors.InvalidCaptcha as exception:
+            if raise_captcha_exception or \
+                    not hasattr(sys.stdin, 'closed') or sys.stdin.closed:
+                raise
+            captcha_id = exception.response['captcha']
 
 
 def restrict_access(scope, mod=None, login=None, oauth_only=False):
@@ -288,83 +200,71 @@ def restrict_access(scope, mod=None, login=None, oauth_only=False):
     mod = mod is not False and (mod or scope and 'mod' in scope)
     login = login is not False and (login or mod or scope and scope != 'read')
 
-    def wrap(function):
-        access_info = _build_access_text(scope, mod, login)
-        function.__doc__ = _embed_text(function.__doc__, access_info)
-
-        @wraps(function)
-        def wrapped(cls, *args, **kwargs):
-            def is_mod_of_all(user, subreddit):
-                mod_subs = user.get_cached_moderated_reddits()
-                subs = six.text_type(subreddit).lower().split('+')
-                return all(sub in mod_subs for sub in subs)
-
-            if cls is None:  # Occurs with (un)friend
-                assert login
-                raise errors.LoginRequired(function.__name__)
-            # This segment of code uses hasattr to determine what instance type
-            # the function was called on. We could use isinstance if we wanted
-            # to import the types at runtime (decorators is used by all the
-            # types).
-            if mod:
-                if hasattr(cls, 'reddit_session'):
-                    # Defer access until necessary for RedditContentObject.
-                    # This is because scoped sessions may not require this
-                    # attribute to exist, thus it might not be set.
-                    from praw.objects import Subreddit
-                    subreddit = cls if isinstance(cls, Subreddit) else False
-                else:
-                    subreddit = kwargs.get(
-                        'subreddit', args[0] if args else None)
-                    if subreddit is None:  # Try the default value
-                        defaults = six.get_function_defaults(function)
-                        subreddit = defaults[0] if defaults else None
+    @decorator.decorator
+    def wrap(function, *args, **kwargs):
+        if args[0] is None:  # Occurs with (un)friend
+            assert login
+            raise errors.LoginRequired(function.__name__)
+        # This segment of code uses hasattr to determine what instance type
+        # the function was called on. We could use isinstance if we wanted
+        # to import the types at runtime (decorators is used by all the
+        # types).
+        if mod:
+            if hasattr(args[0], 'reddit_session'):
+                # Defer access until necessary for RedditContentObject.
+                # This is because scoped sessions may not require this
+                # attribute to exist, thus it might not be set.
+                from praw.objects import Subreddit
+                subreddit = args[0] if isinstance(args[0], Subreddit) \
+                    else False
             else:
-                subreddit = None
+                subreddit = kwargs.get(
+                    'subreddit', args[1] if len(args) > 1 else None)
+                if subreddit is None:  # Try the default value
+                    defaults = six.get_function_defaults(function)
+                    subreddit = defaults[0] if defaults else None
+        else:
+            subreddit = None
 
-            obj = getattr(cls, 'reddit_session', cls)
-            # This function sets _use_oauth for one time use only.
-            # Verify that statement is actually true.
-            assert not obj._use_oauth  # pylint: disable=W0212
+        obj = getattr(args[0], 'reddit_session', args[0])
+        # This function sets _use_oauth for one time use only.
+        # Verify that statement is actually true.
+        assert not obj._use_oauth  # pylint: disable=W0212
 
-            if scope and obj.has_scope(scope):
-                obj._use_oauth = True  # pylint: disable=W0212
-            elif oauth_only:
-                raise errors.OAuthScopeRequired(function.__name__, scope)
-            elif login and obj.is_logged_in():
-                if subreddit is False:
-                    # Now fetch the subreddit attribute. There is no good
-                    # reason for it to not be set during a logged in session.
-                    subreddit = cls.subreddit
-                if mod and not is_mod_of_all(obj.user, subreddit):
-                    if scope:
-                        raise errors.ModeratorOrScopeRequired(
-                            function.__name__, scope)
-                    raise errors.ModeratorRequired(function.__name__)
-            elif login:
+        if scope and obj.has_scope(scope):
+            obj._use_oauth = True  # pylint: disable=W0212
+        elif oauth_only:
+            raise errors.OAuthScopeRequired(function.__name__, scope)
+        elif login and obj.is_logged_in():
+            if subreddit is False:
+                # Now fetch the subreddit attribute. There is no good
+                # reason for it to not be set during a logged in session.
+                subreddit = args[0].subreddit
+            if mod and not _is_mod_of_all(obj.user, subreddit):
                 if scope:
-                    raise errors.LoginOrScopeRequired(function.__name__, scope)
-                raise errors.LoginRequired(function.__name__)
-            try:
-                return function(cls, *args, **kwargs)
-            finally:
-                obj._use_oauth = False  # pylint: disable=W0212
-        return function if IS_SPHINX_BUILD else wrapped
+                    raise errors.ModeratorOrScopeRequired(
+                        function.__name__, scope)
+                raise errors.ModeratorRequired(function.__name__)
+        elif login:
+            if scope:
+                raise errors.LoginOrScopeRequired(function.__name__, scope)
+            raise errors.LoginRequired(function.__name__)
+        try:
+            return function(*args, **kwargs)
+        finally:
+            obj._use_oauth = False  # pylint: disable=W0212
     return wrap
 
 
-def require_oauth(function):
+@decorator.decorator
+def require_oauth(function, *args, **kwargs):
     """Verify that the OAuth functions can be used prior to use.
 
     Returned data is not modified.
 
     """
-    @wraps(function)
-    def wrapped(self, *args, **kwargs):
-        if not self.has_oauth_app_info:
-            err_msg = ("The OAuth app config parameters client_id, "
-                       "client_secret and redirect_url must be specified to "
-                       "use this function.")
-            raise errors.OAuthAppRequired(err_msg)
-        return function(self, *args, **kwargs)
-    return function if IS_SPHINX_BUILD else wrapped
+    if not args[0].has_oauth_app_info:
+        err_msg = ("The OAuth app config parameters client_id, client_secret "
+                   "and redirect_url must be specified to use this function.")
+        raise errors.OAuthAppRequired(err_msg)
+    return function(*args, **kwargs)

--- a/praw/objects.py
+++ b/praw/objects.py
@@ -856,9 +856,8 @@ class Redditor(Gildable, Messageable, Refreshable):
         # Sending an OAuth authenticated request for a redditor, who isn't the
         # authenticated user. But who has a public voting record will be
         # successful.
-        use_oauth = self.reddit_session.is_oauth_session()
-        return _get_redditor_listing('downvoted')(
-            self, *args, _use_oauth=use_oauth, **kwargs)
+        kwargs['_use_oauth'] = self.reddit_session.is_oauth_session()
+        return _get_redditor_listing('downvoted')(self, *args, **kwargs)
 
     def get_liked(self, *args, **kwargs):
         """Return a listing of the Submissions the user has upvoted.
@@ -883,9 +882,8 @@ class Redditor(Gildable, Messageable, Refreshable):
         will be needed to access this listing.
 
         """
-        use_oauth = self.reddit_session.is_oauth_session()
-        return _get_redditor_listing('upvoted')(self, *args,
-                                                _use_oauth=use_oauth, **kwargs)
+        kwargs['_use_oauth'] = self.reddit_session.is_oauth_session()
+        return _get_redditor_listing('upvoted')(self, *args, **kwargs)
 
     def mark_as_read(self, messages, unread=False):
         """Mark message(s) as read or unread.

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,8 @@ setup(
     keywords='reddit api wrapper',
     packages=[PACKAGE_NAME],
     package_data={'': ['COPYING'], PACKAGE_NAME: ['*.ini']},
-    install_requires=['requests>=2.3.0', 'six>=1.4', 'update_checker>=0.11'],
+    install_requires=['decorator>=3.4.2', 'requests>=2.3.0', 'six>=1.4',
+                      'update_checker>=0.11'],
     tests_require=['betamax>=0.4.2', 'betamax-matchers>=0.2.0', 'mock>=1.0.0'],
     entry_points={'console_scripts': [
             'praw-multiprocess = praw.multiprocess:run']},

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,104 +1,10 @@
 from __future__ import print_function, unicode_literals
 
 import unittest
-from praw.decorators import _embed_text, restrict_access
+from praw.decorators import restrict_access
 
 
 class DecoratorTest(unittest.TestCase):
     def test_require_access_failure(self):
         self.assertRaises(TypeError, restrict_access, scope=None,
                           oauth_only=True)
-
-
-class EmbedTextTest(unittest.TestCase):
-    EMBED_TEXT = "HELLO"
-
-    def test_no_docstring(self):
-        new_doc = _embed_text(None, self.EMBED_TEXT)
-        self.assertEqual(self.EMBED_TEXT + '\n\n', new_doc)
-
-    def test_one_liner(self):
-        new_doc = _embed_text("Returns something cool", self.EMBED_TEXT)
-        self.assertEqual("Returns something cool\n\n{0}\n\n"
-                         .format(self.EMBED_TEXT), new_doc)
-
-    def test_multi_liner(self):
-        doc = """Jiggers the bar
-
-              Only run if foo is instantiated.
-
-              """
-        new_doc = _embed_text(doc, self.EMBED_TEXT)
-        self.assertEqual(doc + self.EMBED_TEXT + '\n\n\n              ',
-                         new_doc)
-
-    def test_single_plus_params(self):
-        doc = """Jiggers the bar
-
-              :params foo: Self explanatory.
-
-              """
-        expected_doc = """Jiggers the bar
-
-              :params foo: Self explanatory.
-
-              {0}
-
-
-              """.format(self.EMBED_TEXT)
-        new_doc = _embed_text(doc, self.EMBED_TEXT)
-        self.assertEqual(expected_doc, new_doc)
-
-    def test_multi_plus_params(self):
-        doc = """Jiggers the bar
-
-              Jolly importment.
-
-              :params foo: Self explanatory.
-              :returns: The jiggered bar.
-
-              """
-        expected_doc = """Jiggers the bar
-
-              Jolly importment.
-
-              :params foo: Self explanatory.
-              :returns: The jiggered bar.
-
-              {0}
-
-
-              """.format(self.EMBED_TEXT)
-        new_doc = _embed_text(doc, self.EMBED_TEXT)
-        self.assertEqual(expected_doc, new_doc)
-
-    def test_additional_params(self):
-        doc = """Jiggers the bar
-
-              Jolly important.
-
-              :params foo: Self explanatory.
-              :returns: The jiggered bar.
-
-              The additional parameters are passed directly into
-              :meth:`.get_content`. Note: the `url` parameter cannot be
-              altered.
-
-              """
-        expected_doc = """Jiggers the bar
-
-              Jolly important.
-
-              :params foo: Self explanatory.
-              :returns: The jiggered bar.
-
-              The additional parameters are passed directly into
-              :meth:`.get_content`. Note: the `url` parameter cannot be
-              altered.
-
-              {0}
-
-
-              """.format(self.EMBED_TEXT)
-        new_doc = _embed_text(doc, self.EMBED_TEXT)
-        self.assertEqual(expected_doc, new_doc)


### PR DESCRIPTION
Utilize decorator.decorator in order to prevent method signature destruction. Using this library required flattening the existing decorator methods. It also made it such that the decorators themselves couldn't (easily) modify the docstring so we're not super DRY for that but that's okay.

Finally resolves #249.