### PR TITLE
Allow search() function to use params parameter

### DIFF
--- a/praw/__init__.py
+++ b/praw/__init__.py
@@ -1122,14 +1122,16 @@ class UnauthenticatedReddit(BaseReddit):
         :param period: The time period of the results.
 
         The additional parameters are passed directly into
-        :meth:`.get_content`. Note: the `url` and `param` parameters cannot be
-        altered.
+        :meth:`.get_content`. Note: the `url` parameter cannot be altered.
 
         See https://www.reddit.com/wiki/search for more information on how to
         build a search query.
 
         """
         params = {'q': query}
+        if 'params' in kwargs:
+            params.update(kwargs['params'])
+            kwargs.pop('params')
         if sort:
             params['sort'] = sort
         if syntax:


### PR DESCRIPTION
As shown in [this comment](https://www.reddit.com/r/NoStupidQuestions/comments/3dtjbs/how_do_you_stick_photos_together/) by [/u/GoldenSights](http://www.reddit.com/u/GoldenSights), this allows the params parameter within the search() function to be altered. This allows for greater use of the function, from defining pages via `params={'after' : 't3_code'}` to the option of specifically defining to use the "new" legacy search e.g. `params={'feature' : 'legacy_search'}`