### PR TITLE
fix get_wiki_page not sending the oauth headers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -27,6 +27,7 @@ Unreleased
  * **[BUGFIX]** Fixed methods which require more than one OAuth scope.
  * **[BUGFIX]** Fixed :meth:`praw.objects.WikiPage.remove_editor` raising
    AssertionError when used through OAuth.
+ * **[BUGFIX]** Fixed :meth:`get_wiki_page` not sending the OAuth headers.
  * **[CHANGE]** :meth:`praw.objects.Refreshable.refresh` will now always return
    a fresh object. Previously, Subreddits and Redditors would use cache content
    when available.

--- a/praw/objects.py
+++ b/praw/objects.py
@@ -130,11 +130,18 @@ class RedditContentObject(object):
 
         # OAuth handling needs to be special cased here. For instance, the user
         # might be calling a method on a Subreddit object that requires first
-        # loading the information about the subreddit. Unless the `read` scope
-        # is set, then this function should try to obtain the information in a
-        # scope-less manner.
+        # loading the information about the subreddit. This method should try
+        # to obtain the information in a scope-less manner unless either:
+        # a) The object is a WikiPage and the reddit_session has the `wikiread`
+        #    scope.
+        # b) The object is not a WikiPage and the reddit_session has the
+        #    `read` scope.
         prev_use_oauth = self.reddit_session._use_oauth
-        self.reddit_session._use_oauth = self.reddit_session.has_scope('read')
+        self.reddit_session._use_oauth = (
+            isinstance(self, WikiPage) and
+            self.reddit_session.has_scope('wikiread')) or \
+            (not isinstance(self, WikiPage) and
+                self.reddit_session.has_scope('read'))
         try:
             params = {'uniq': self._uniq} if self._uniq else {}
             response = self.reddit_session.request_json(


### PR DESCRIPTION
It turned out that the get_wiki_page method was not sending the oauth headers unless you had the `read` scope due to some logic within RedditContentObjects. Of course, they require the `wikiread` scope instead, so this PR reflects that. 

Visually I think this change ended up looking messy, but flake8 didn't like any of the alternatives. Hopefully my comment makes up for it.

Here's what was happening before I realized the issue: https://i.imgur.com/VbKqRcm.png

&nbsp;

I was planning to open a secondary PR that accompanies this one, but I think I accidentally just nuked it without a suitable backup, so I'm going to start rewriting that.