### PR TITLE
Resolve issue #485.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -26,6 +26,8 @@ UNRELEASED
 ----------
  * **[BUGFIX]** Fixed login password prompt issue on windows (#485).
  * **[BUGFIX]** Fixed unicode user-agent issue (#483).
+ * **[BUGFIX]** Fix duplicate request issue with comment and submission streams
+   (#501).
  * **[CHANGE]** Added messages to all PRAW exceptions (#491).
 
 PRAW 3.2.1

--- a/praw/helpers.py
+++ b/praw/helpers.py
@@ -129,7 +129,7 @@ def _stream_generator(get_function, limit=None, verbosity=1):
         start = timer()
         try:
             i = None
-            params = {'count': count}
+            params = {'uniq': count}
             count = (count + 1) % 100
             if before:
                 params['before'] = before


### PR DESCRIPTION
When passing a `count` parameter, it appears reddit now always returns an
`after` parameter in the data set making for duplicate requests. The `count`
parameter has now been renamed to `uniq` for streams.