### PR TITLE
Use deque instead of list

### DIFF
--- a/praw/helpers.py
+++ b/praw/helpers.py
@@ -237,14 +237,13 @@ def flatten_tree(tree, nested_attr='replies', depth_first=False):
 
     """
     stack = deque(tree)
+    extend = stack.extend if depth_first else stack.extendleft
     retval = []
     while stack:
         item = stack.popleft()
         nested = getattr(item, nested_attr, None)
-        if nested and depth_first:
-            stack.extend(nested)
-        elif nested:
-            stack.extendleft(nested)
+        if nested:
+            extend(nested)
         retval.append(item)
     return retval
 

--- a/praw/helpers.py
+++ b/praw/helpers.py
@@ -24,6 +24,7 @@ from __future__ import unicode_literals
 import six
 import sys
 import time
+from collections import deque
 from functools import partial
 from timeit import default_timer as timer
 from praw.errors import HTTPException
@@ -235,15 +236,15 @@ def flatten_tree(tree, nested_attr='replies', depth_first=False):
         rather than the default breadth-first manner.
 
     """
-    stack = tree[:]
+    stack = deque(tree)
     retval = []
     while stack:
-        item = stack.pop(0)
+        item = stack.popleft()
         nested = getattr(item, nested_attr, None)
         if nested and depth_first:
             stack.extend(nested)
         elif nested:
-            stack[0:0] = nested
+            stack.extendleft(nested)
         retval.append(item)
     return retval
 


### PR DESCRIPTION
Reason being that [deques](https://docs.python.org/2/library/collections.html#collections.deque) offer O(1) insert on *both* ends of the stack instead of just the end. Previously, using a list and appending to the 'head' is an O(n) operation.

A simple demonstration/benchmark: https://gist.github.com/eugene-eeo/549b5b5c5b72a882bc02