### PR TITLE
Fixed typo "Creddit"

### DIFF
--- a/praw/errors.py
+++ b/praw/errors.py
@@ -438,11 +438,11 @@ class InvalidUserPass(APIException):
     ERROR_TYPE = 'WRONG_PASSWORD'
 
 
-class InsufficientCreddits(APIException):
+class InsufficientCredits(APIException):
 
-    """Raised when there are not enough creddits to complete the action."""
+    """Raised when there are not enough credits to complete the action."""
 
-    ERROR_TYPE = 'INSUFFICIENT_CREDDITS'
+    ERROR_TYPE = 'INSUFFICIENT_CREDITS'
 
 
 class NotLoggedIn(APIException):

--- a/praw/objects.py
+++ b/praw/objects.py
@@ -324,7 +324,7 @@ class Gildable(RedditContentObject):
 
     """Interface for RedditContentObjects that can be gilded."""
 
-    @restrict_access(scope='creddits', oauth_only=True)
+    @restrict_access(scope='credits', oauth_only=True)
     def gild(self, months=None):
         """Gild the Redditor or author of the content.
 

--- a/tests/test_oauth2_reddit.py
+++ b/tests/test_oauth2_reddit.py
@@ -161,10 +161,10 @@ class OAuth2RedditTest(PRAWTest):
         self.assertTrue(list(self.r.get_my_moderation()))
 
     @betamax()
-    def test_scope_creddits(self):
-        # Assume there are insufficient creddits.
+    def test_scope_credits(self):
+        # Assume there are insufficient credits.
         self.r.refresh_access_information(
-            self.refresh_token['creddits'])
+            self.refresh_token['credits'])
         redditor = self.r.get_redditor('bboe')
         sub = self.r.get_submission(url=self.comment_url)
 
@@ -174,9 +174,9 @@ class OAuth2RedditTest(PRAWTest):
             self.assertRaises(TypeError, redditor.gild, value)
 
         # Test object gilding
-        self.assertRaises(errors.InsufficientCreddits, redditor.gild)
-        self.assertRaises(errors.InsufficientCreddits, sub.gild)
-        self.assertRaises(errors.InsufficientCreddits, sub.comments[0].gild)
+        self.assertRaises(errors.InsufficientCredits, redditor.gild)
+        self.assertRaises(errors.InsufficientCredits, sub.gild)
+        self.assertRaises(errors.InsufficientCredits, sub.comments[0].gild)
 
     @betamax()
     def test_scope_privatemessages(self):


### PR DESCRIPTION
Typo "Creddit" used in error module and subsequent documentation seemed to need to be changed to "Credit" and all respective forms of the word.