### PR TITLE
Addressing issue #519

### DIFF
--- a/praw/objects.py
+++ b/praw/objects.py
@@ -445,7 +445,9 @@ class Refreshable(RedditContentObject):
         elif isinstance(self, Comment):
             sub = Submission.from_url(self.reddit_session, self.permalink,
                                       params={'uniq': unique})
-            other = sub.comments[0]
+            if len(sub.comments) > 0:
+                other = sub.comments[0]
+            
         elif isinstance(self, Multireddit):
             other = Multireddit(self.reddit_session, author=self._author,
                                 name=self.name, uniq=unique, fetch=True)


### PR DESCRIPTION
Somewhat temporary solution to only try to access index 0 if the list size is at least 1, avoiding the error in the Refreshable Object's if-block pertaining to comments.