### PR TITLE
OAuth password for "installed app" type

### DIFF
--- a/praw/__init__.py
+++ b/praw/__init__.py
@@ -704,7 +704,9 @@ class OAuth2Reddit(BaseReddit):
         ``redirect_uri``.
 
         """
-        return all((self.client_id, self.client_secret, self.redirect_uri))
+        return all((self.client_id is not None,
+                    self.client_secret is not None,
+                    self.redirect_uri is not None))
 
     @decorators.require_oauth
     def refresh_access_information(self, refresh_token):


### PR DESCRIPTION
"installed app" type oauth applications don't have client secrets. For these applications, the Reddit docs specify that the secret should be passed though as an empty string.

> https://github.com/reddit/reddit/wiki/OAuth2
> The "user" is the client_id. The "password" for confidential clients is the client_secret. The "password" for non-confidential clients (installed apps) is an empty string. 

This pull request allows the oauth client_secret to remain empty by differentiating between an unset value (None) and a deliberate empty string. You can currently get around this limitation by setting the secret to some non-empty string like "placeholder", but I would rather follow the official documentation.