### PR TITLE
Support `*` OAuth scope (#471)

### DIFF
--- a/praw/__init__.py
+++ b/praw/__init__.py
@@ -1353,10 +1353,13 @@ class AuthenticatedReddit(OAuth2Reddit, UnauthenticatedReddit):
 
     def has_scope(self, scope):
         """Return True if OAuth2 authorized for the passed in scope(s)."""
+        if not self.is_oauth_session():
+            return False
+        if '*' in self._authentication:
+            return True
         if isinstance(scope, six.string_types):
             scope = [scope]
-        return self.is_oauth_session() and all(s in self._authentication
-                                               for s in scope)
+        return all(s in self._authentication for s in scope)
 
     def is_logged_in(self):
         """Return True when the session is authenticated via username/password.


### PR DESCRIPTION
I am unfamiliar with PRAWs testsuite, so apologies for not providing a testcase.
If anyone else could do that, that'd be welcome.

Here's a script to help with that and get a `"scope": "*"` response, according to the [reddit Quick Start example](https://github.com/reddit/reddit/wiki/OAuth2-Quick-Start-Example):

```py
from __future__ import unicode_literals, print_function
import praw
import six 

@praw.decorators.require_oauth
def get_bearer_access(self, username, password):
    data = {'grant_type': 'password',
            'username': username,
            'password': password}
    retval = self._handle_oauth_request(data)
    # scope is '*' here
    #print(retval)
    return {'access_token': retval['access_token'],
            'scope': set(retval['scope'].split(' '))}

@property
def has_oauth_app_info(self):
    return all((self.client_id is not None,
                self.client_secret is not None))

def set_oauth_app_info(self, client_id, client_secret):
    self.client_id = client_id
    self.client_secret = client_secret

praw.OAuth2Reddit.get_bearer_access = get_bearer_access
praw.OAuth2Reddit.has_oauth_app_info = has_oauth_app_info
praw.OAuth2Reddit.set_oauth_app_info = set_oauth_app_info


def has_scope(self, scope):
    """Return True if OAuth2 authorized for the passed in scope(s)."""
    if '*' in self._authentication:
        return True
    if isinstance(scope, six.string_types):
        scope = [scope]
    return self.is_oauth_session() and all(s in self._authentication
                                            for s in scope)

praw.AuthenticatedReddit.has_scope = has_scope

#
# test
#

client_id = ''
client_secret = ''
username = ''
password = ''
user_agent = 'praw testing'

session = praw.Reddit(user_agent)
session.set_oauth_app_info(client_id, client_secret)
if session.has_oauth_app_info:
    access = session.get_bearer_access(username, password)
    session.set_access_credentials(**access)


print('oauthed:', session.is_oauth_session())
print('scope check identity:', session.has_scope('identity'))
print('oauth user:', session.get_me())
```