### PR TITLE
Fix to _use_oauth not being reset

### DIFF
--- a/praw/__init__.py
+++ b/praw/__init__.py
@@ -458,6 +458,7 @@ class BaseReddit(object):
                     return re.sub('&([^;]+);', decode, response.text)
             except errors.OAuthInvalidToken as error:
                 if not attempt_oauth_refresh:
+                    self._use_oauth = tempauth
                     raise
                 attempt_oauth_refresh = False
                 self._use_oauth = False
@@ -471,6 +472,7 @@ class BaseReddit(object):
                 # pylint: disable=W0212
                 if error._raw.status_code not in self.RETRY_CODES or \
                         remaining_attempts == 0:
+                    self._use_oauth = tempauth
                     raise
 
     def _json_reddit_objecter(self, json_data):

--- a/praw/__init__.py
+++ b/praw/__init__.py
@@ -451,14 +451,12 @@ class BaseReddit(object):
                 response = handle_redirect()
                 _raise_response_exceptions(response)
                 self.http.cookies.update(response.cookies)
-                self._use_oauth = tempauth
                 if raw_response:
                     return response
                 else:
                     return re.sub('&([^;]+);', decode, response.text)
             except errors.OAuthInvalidToken as error:
                 if not attempt_oauth_refresh:
-                    self._use_oauth = tempauth
                     raise
                 attempt_oauth_refresh = False
                 self._use_oauth = False
@@ -472,8 +470,9 @@ class BaseReddit(object):
                 # pylint: disable=W0212
                 if error._raw.status_code not in self.RETRY_CODES or \
                         remaining_attempts == 0:
-                    self._use_oauth = tempauth
                     raise
+            finally:
+                self._use_oauth = tempauth
 
     def _json_reddit_objecter(self, json_data):
         """Return an appropriate RedditObject from json_data when possible."""


### PR DESCRIPTION
This addresses a problem when an exception is re-thrown while using oauth.

**Problem:**
If using oauth, and the number of retries is reached, it will not re-assign the value of `self._use_oauth` before rethrowing the exception.  

In the situation where the user catches this exception, it will then cause an assertion error in the `@restrict_access` decorator from then on, such as in [this issue](https://github.com/praw-dev/praw/issues/536).

**Solution:**
Have self._use_oauth re-set for every code path.