### PR TITLE
Only perform the update check once per session

### DIFF
--- a/praw/__init__.py
+++ b/praw/__init__.py
@@ -369,10 +369,10 @@ class BaseReddit(object):
         self.modhash = None
 
         # Check for updates if permitted and this is the first Reddit instance
-        if not disable_update_check and not self.update_checked \
+        if not disable_update_check and not BaseReddit.update_checked \
                 and self.config.check_for_updates:
             update_check(__name__, __version__)
-            self.update_checked = True
+            BaseReddit.update_checked = True
 
         # Initial values
         self._use_oauth = False


### PR DESCRIPTION
Currently, the update checker will run each time a `Reddit` instance is created. This is because accessing `update_checked` with `self.` treats it as an instance variable rather than a static class variable. Changing the call to `[class name].update_checked` will treat it as a static class variable.

I haven't tested this change (so make sure to test it please), but a similar patch worked in my code base.