### PR TITLE
Prevent `dir` from making web requests in Python 2

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,7 +12,8 @@ upstream changes.
 
 Unreleased
 ----------
-
+* **[BUGFIX]** Prevent built-in method `dir` from causing RedditContentObjects
+  to perform web requests in Python 2.
 * **[FEATURE]** Added support for thread locking. See
   :meth:`~praw.objects.Submission.lock` and
   :meth:`~praw.objects.Submission.unlock`.

--- a/praw/objects.py
+++ b/praw/objects.py
@@ -80,7 +80,12 @@ class RedditContentObject(object):
 
     def __getattr__(self, attr):
         """Return the value of the `attr` attribute."""
-        if attr != '__setstate__' and not self._has_fetched:
+        # Because this method may perform web requests, there are certain
+        # attributes we must blacklist to prevent accidental requests:
+        # __members__, __methods__: Caused by `dir(obj)` in Python 2.
+        # __setstate__: Caused by Pickle deserialization.
+        blacklist = ('__members__', '__methods__', '__setstate__')
+        if attr not in blacklist and not self._has_fetched:
             self._has_fetched = self._populate(None, True)
             return getattr(self, attr)
         msg = '\'{0}\' has no attribute \'{1}\''.format(type(self), attr)


### PR DESCRIPTION
Fixes #595.

Python2 goes looking for `__members__` and `__methods__` attributes when building the result for `dir(obj)`. These attributes are now blacklisted from RedditContentObject's `__getattr__` method which performs web requests.