### PR TITLE
Update PRAW documentation links to praw.readthedocs.io from .org.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -307,7 +307,7 @@ PRAW 2.1.12
  * **[FEATURE]** Add :attr:`.json_dict` to :class:`.RedditContentObject`.
  * **[FEATURE]** You can now give configuration settings directly when
    instantiating a :class:`.BaseReddit` object. See `the configuration files
-   <https://praw.readthedocs.org/en/latest/pages/configuration_files.html>`_
+   <https://praw.readthedocs.io/en/latest/pages/configuration_files.html>`_
  * **[BUGFIX]** Fixed a bug that caused an ``AttributeError`` to be raised when
    using a deprecated method.
 
@@ -375,7 +375,7 @@ PRAW 2.1.7
    on :class:`.Redditor` allows PRAW to access this info.
  * **[FEATURE]** The ``has_fetched`` attribute has been added to all objects
    save :class:`.Reddit`, see the `lazy loading
-   <http://praw.readthedocs.org/en/latest/pages/lazy-loading.html>`_ page in
+   <http://praw.readthedocs.io/en/latest/pages/lazy-loading.html>`_ page in
    PRAW's documentation for more details.
  * **[BUGFIX]** Fixed a bug that caused the ``timeout`` configuration setting
    to always be the default 45 irrespective of what it was set to in
@@ -701,7 +701,7 @@ PRAW 2.0.0
    instead.
  * **[CHANGE]** Remove depreciated method ``compose_message``.
  * **[CHANGE]** Refactored and add a number of exception classes (`docs
-   <https://praw.readthedocs.org/en/latest/pages/code_overview.html#module-praw.errors>`_,
+   <https://praw.readthedocs.io/en/latest/pages/code_overview.html#module-praw.errors>`_,
    `source <https://github.com/praw-dev/praw/blob/master/praw/errors.py>`_)
    This includes the renaming of:
 

--- a/README.rst
+++ b/README.rst
@@ -104,7 +104,7 @@ Documentation
 
 PRAW's documentation, which includes tutorials, information on configuring PRAW
 and other good stuff can be found at `readthedocs
-<https://praw.readthedocs.org>`_.
+<https://praw.readthedocs.io>`_.
 
 .. begin_license
 

--- a/docs/pages/call_and_response_bot.rst
+++ b/docs/pages/call_and_response_bot.rst
@@ -187,7 +187,7 @@ Here's our completed bot!
 
         # If you want the bot to be able to respond to people, you will need to login.
         # It is strongly recommended you login with oAuth
-        # http://praw.readthedocs.org/en/stable/pages/oauth.html
+        # http://praw.readthedocs.io/en/stable/pages/oauth.html
 
         # NB: This login method is being deprecated soon
         r.login()
@@ -195,7 +195,7 @@ Here's our completed bot!
         for c in praw.helpers.comment_stream(r, 'all'):
             if check_condition(c):
                 # set 'respond=True' to activate bot responses. Must be logged in.
-                bot_action(c, respond=False) 
+                bot_action(c, respond=False)
 
 Keep in mind: bots of this kind are often perceived as annoying and quickly get
 banned from many subreddits. If/when your bot gets banned, don't take it

--- a/docs/pages/comment_parsing.rst
+++ b/docs/pages/comment_parsing.rst
@@ -18,7 +18,7 @@ do its work.
 
 >>> import praw
 >>> r = praw.Reddit('Comment Scraper 1.0 by u/_Daimon_ see '
-...                 'https://praw.readthedocs.org/en/latest/'
+...                 'https://praw.readthedocs.io/en/latest/'
 ...                 'pages/comment_parsing.html')
 >>> submission = r.get_submission(submission_id='11v36o')
 
@@ -116,7 +116,7 @@ The full program
     import praw
 
     r = praw.Reddit('Comment Scraper 1.0 by u/_Daimon_ see '
-                    'https://praw.readthedocs.org/en/latest/'
+                    'https://praw.readthedocs.io/en/latest/'
                     'pages/comment_parsing.html')
     r.login('bot_username', 'bot_password')
     submission = r.get_submission(submission_id='11v36o')

--- a/docs/pages/configuration_files.rst
+++ b/docs/pages/configuration_files.rst
@@ -21,7 +21,7 @@ this way will take precedence over those previously defined.
     import praw
 
     user_agent = ("Configuration setting example by /u/_Daimon_. See "
-                  "https://praw.readthedocs.org/en/latest/pages/configuration_files.html")
+                  "https://praw.readthedocs.io/en/latest/pages/configuration_files.html")
     r = praw.Reddit(user_agent=user_agent, log_requests=1)
 
 Config File Locations

--- a/docs/pages/exceptions.rst
+++ b/docs/pages/exceptions.rst
@@ -7,7 +7,7 @@ This page documents the exceptions that can occur while running PRAW and what
 they mean. The exceptions can be divided into three rough categories and a full
 list of the ``ClientException`` s and ``APIException`` s that can occur can be
 found in the `errors module
-<https://praw.readthedocs.org/en/latest/pages/code_overview.html
+<https://praw.readthedocs.io/en/latest/pages/code_overview.html
 #module-praw.errors>`_.
 
 ClientException

--- a/docs/pages/oauth.rst
+++ b/docs/pages/oauth.rst
@@ -62,7 +62,7 @@ object with a clear and descriptive useragent that follows the `api rules
 
     >>> import praw
     >>> r = praw.Reddit('OAuth testing example by u/_Daimon_ ver 0.1 see '
-    ...                 'https://praw.readthedocs.org/en/latest/'
+    ...                 'https://praw.readthedocs.io/en/latest/'
     ...                 'pages/oauth.html for source')
 
 Next we set the app info to match what we got in step 1.
@@ -222,7 +222,7 @@ written to the screen.
 
     if __name__ == '__main__':
         r = praw.Reddit('OAuth Webserver example by u/_Daimon_ ver 0.1. See '
-                        'https://praw.readthedocs.org/en/latest/'
+                        'https://praw.readthedocs.io/en/latest/'
                         'pages/oauth.html for more info.')
         r.set_oauth_app_info(CLIENT_ID, CLIENT_SECRET, REDIRECT_URI)
         app.run(debug=True, port=65010)

--- a/docs/pages/writing_a_bot.rst
+++ b/docs/pages/writing_a_bot.rst
@@ -32,7 +32,7 @@ We start by importing PRAW and logging in.
 >>> import time
 >>> import praw
 >>> r = praw.Reddit('PRAW related-question monitor by /u/_Daimon_ v 1.0. '
-...                 'Url: https://praw.readthedocs.org/en/latest/'
+...                 'Url: https://praw.readthedocs.io/en/latest/'
 ...                 'pages/writing_a_bot.html')
 >>> r.login()
 >>> already_done = [] # Ignore this for now
@@ -328,7 +328,7 @@ The full Question-Discover program
     import praw
 
     r = praw.Reddit('PRAW related-question monitor by u/_Daimon_ v 1.0.'
-                    'Url: https://praw.readthedocs.org/en/latest/'
+                    'Url: https://praw.readthedocs.io/en/latest/'
                     'pages/writing_a_bot.html')
     r.login()
     already_done = []

--- a/praw/__init__.py
+++ b/praw/__init__.py
@@ -335,7 +335,7 @@ class BaseReddit(object):
         All additional parameters specified via kwargs will be used to
         initialize the Config object. This can be used to specify configuration
         settings during instantiation of the Reddit instance. See
-        https://praw.readthedocs.org/en/latest/pages/configuration_files.html
+        https://praw.readthedocs.io/en/latest/pages/configuration_files.html
         for more details.
 
         """

--- a/setup.py
+++ b/setup.py
@@ -54,5 +54,5 @@ setup(name=PACKAGE_NAME,
                      'betamax-serializers >=0.1.1, <0.2',
                      'mock ==1.0.1'],
       test_suite='tests',
-      url='https://praw.readthedocs.org/',
+      url='https://praw.readthedocs.io/',
       version=VERSION)

--- a/tests/cassettes/test_submit__duplicate_url.json
+++ b/tests/cassettes/test_submit__duplicate_url.json
@@ -1,11 +1,11 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2015-04-16T03:57:50",
+      "recorded_at": "2016-06-04T16:02:47",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "passwd=1111&user=PyAPITestUser2&api_type=json"
+          "string": "user=PyAPITestUser2&passwd=1111&api_type=json"
         },
         "headers": {
           "Accept": [
@@ -24,7 +24,7 @@
             "application/x-www-form-urlencoded"
           ],
           "User-Agent": [
-            "PRAW_test_suite PRAW/3.0a1 Python/2.7.5 Darwin-13.4.0-x86_64-i386-64bit"
+            "PRAW_test_suite PRAW/3.5.0 Python/3.5.1 b'Darwin-14.5.0-x86_64-i386-64bit'"
           ]
         },
         "method": "POST",
@@ -32,84 +32,56 @@
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAAxzLSYrDMBBA0auIWitQmmWdI7umCaVSCXcGK7G9C757SG//47/huo0FinqDrOtYNyjq51craLTTf15E2mXe9+eXOt030Qoeo820zVAUPGi9v9L0kqVTTozSgm/OO3aecJqkVtMDcm2O2RrpzKAV8Bi3P/n+yaHNMWmLJpzQn0w4WywhlYA6WM9IMVdpyFyzt41TlDx1iibF2JhsDSxwHMcHAAD//wMAfJMkd8oAAAA=",
+          "base64_string": "H4sIAAAAAAAAAx3L22oDIRCA4VeRuTYwzqqjPkfvSigeRjY9xLBrSiHsu5fk9v/4H/C5jysk9QDZtrHtkNT7WStoeeZXvoq0j3XO25Pmdhet4Ge0Ne8rJAXT/Fn53m+/hYKpoVOPrTvGzD2gCVEK2YxkXS/Ufa1LA62gjvF1kefPC1LwrAmNP6E/oX3DmJCSZe2osHNIzD0Hn2Nkia4EFJsXWwpydN1UcXAcxz97YNr5yQAAAA==",
           "encoding": "UTF-8"
         },
-        "cookies": [
-          {
-            "comment": null,
-            "comment_url": null,
-            "discard": false,
-            "domain": ".reddit.com",
-            "expires": 1460692669,
-            "name": "__cfduid",
-            "path": "/",
-            "port": null,
-            "rest": {
-              "HttpOnly": null
-            },
-            "rfc2109": false,
-            "secure": false,
-            "value": "dc3f16032da43a3c79650e6179fbc52051429156669",
-            "version": 0
-          },
-          {
-            "comment": null,
-            "comment_url": null,
-            "discard": true,
-            "domain": ".reddit.com",
-            "expires": null,
-            "name": "reddit_session",
-            "path": "/",
-            "port": null,
-            "rest": {
-              "HttpOnly": null
-            },
-            "rfc2109": false,
-            "secure": false,
-            "value": "7302867%2C2015-04-15T20%3A57%3A50%2C524c0a68bed0ccb842dc76e89fa61766dca2b5ce",
-            "version": 0
-          }
-        ],
         "headers": {
-          "cache-control": [
-            "no-cache, no-cache"
+          "CF-RAY": [
+            "2adc9c71c9422858-SJC"
           ],
-          "cf-ray": [
-            "1d7cf7e2ae840293-SJC"
-          ],
-          "connection": [
+          "Connection": [
             "keep-alive"
           ],
-          "content-encoding": [
+          "Content-Encoding": [
             "gzip"
           ],
-          "content-type": [
+          "Content-Type": [
             "application/json; charset=UTF-8"
           ],
-          "date": [
-            "Thu, 16 Apr 2015 03:57:50 GMT"
+          "Date": [
+            "Sat, 04 Jun 2016 16:02:47 GMT"
           ],
-          "pragma": [
-            "no-cache"
-          ],
-          "server": [
+          "Server": [
             "cloudflare-nginx"
           ],
-          "set-cookie": [
-            "__cfduid=dc3f16032da43a3c79650e6179fbc52051429156669; expires=Fri, 15-Apr-16 03:57:49 GMT; path=/; domain=.reddit.com; HttpOnly, secure_session=; Domain=reddit.com; Max-Age=-1429156670; Path=/; expires=Thu, 01-Jan-1970 00:00:01 GMT; HttpOnly, reddit_session=7302867%2C2015-04-15T20%3A57%3A50%2C524c0a68bed0ccb842dc76e89fa61766dca2b5ce; Domain=reddit.com; Path=/; HttpOnly"
+          "Set-Cookie": [
+            "__cfduid=d0517e31f808a362cb2be46c53ea2b7021465056166; expires=Sun, 04-Jun-17 16:02:46 GMT; path=/; domain=.reddit.com; HttpOnly",
+            "loid=3TZ4XxVD05lP0Gw125; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Mon, 04-Jun-2018 16:02:47 GMT; secure",
+            "loidcreated=2016-06-04T16%3A02%3A46.951Z; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Mon, 04-Jun-2018 16:02:47 GMT; secure",
+            "secure_session=1; Domain=reddit.com; Path=/; HttpOnly",
+            "reddit_session=7302867%2C2016-06-04T09%3A02%3A47%2C52b7550277fa86a997e95b80e4a34bb0795f1ce5; Domain=reddit.com; Path=/; secure; HttpOnly"
           ],
-          "transfer-encoding": [
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Transfer-Encoding": [
             "chunked"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate",
+            "max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
           ],
           "x-content-type-options": [
             "nosniff"
           ],
           "x-frame-options": [
             "SAMEORIGIN"
-          ],
-          "x-moose": [
-            "majestic"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -126,11 +98,11 @@
       }
     },
     {
-      "recorded_at": "2015-04-16T03:57:50",
+      "recorded_at": "2016-06-04T16:02:47",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "kind=link&title=PRAW+Documentation&url=https%3A%2F%2Fpraw.readthedocs.org%2F&sr=reddit_api_test&uh=marlq79qenfa87c0ed54d343c34a099ebb1f50cbd3cc21efcc&api_type=json"
+          "string": "title=PRAW+Documentation&kind=link&url=https%3A%2F%2Fpraw.readthedocs.io%2F&uh=t1x4elspvb281c8f2f9df570a7f80189eb24a0245fb2f6cc3d&sr=reddit_api_test&api_type=json"
         },
         "headers": {
           "Accept": [
@@ -143,16 +115,16 @@
             "keep-alive"
           ],
           "Content-Length": [
-            "163"
+            "162"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "reddit_session=7302867%2C2015-04-15T20%3A57%3A50%2C524c0a68bed0ccb842dc76e89fa61766dca2b5ce; __cfduid=dc3f16032da43a3c79650e6179fbc52051429156669"
+            "loid=3TZ4XxVD05lP0Gw125; reddit_session=7302867%2C2016-06-04T09%3A02%3A47%2C52b7550277fa86a997e95b80e4a34bb0795f1ce5; __cfduid=d0517e31f808a362cb2be46c53ea2b7021465056166; secure_session=1; loidcreated=2016-06-04T16%3A02%3A46.951Z"
           ],
           "User-Agent": [
-            "PRAW_test_suite PRAW/3.0a1 Python/2.7.5 Darwin-13.4.0-x86_64-i386-64bit"
+            "PRAW_test_suite PRAW/3.5.0 Python/3.5.1 b'Darwin-14.5.0-x86_64-i386-64bit'"
           ]
         },
         "method": "POST",
@@ -160,36 +132,43 @@
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAA6pWyirOz1OyUqhWSi0qyi8qVrJSiI5WcvQJcnV0iYwPDnVS0lFQKslILFHIyczLVshILFZIzClKTUypVEhKTc1TKC5Nys0sKUlNAakrLcpRio2trQUAAAD//wMAf0/wHVYAAAA=",
+          "base64_string": "H4sIAAAAAAAAA6tWyirOz1OyUqhWSi0qyi8qVrJSiI5WcvQJcnV0iYwPDnVS0lFQKslILFHIyczLVshILFZIzClKTUypVEhKTc1TKC5Nys0sKUlNAakrLcpRio2trQUAf0/wHVYAAAA=",
           "encoding": "UTF-8"
         },
         "headers": {
-          "cache-control": [
-            "no-cache, no-cache"
+          "CF-RAY": [
+            "2adc9c77199a2858-SJC"
           ],
-          "cf-ray": [
-            "1d7cf7e7aebb0293-SJC"
-          ],
-          "connection": [
+          "Connection": [
             "keep-alive"
           ],
-          "content-encoding": [
+          "Content-Encoding": [
             "gzip"
           ],
-          "content-type": [
+          "Content-Type": [
             "application/json; charset=UTF-8"
           ],
-          "date": [
-            "Thu, 16 Apr 2015 03:57:51 GMT"
+          "Date": [
+            "Sat, 04 Jun 2016 16:02:47 GMT"
           ],
-          "pragma": [
-            "no-cache"
-          ],
-          "server": [
+          "Server": [
             "cloudflare-nginx"
           ],
-          "transfer-encoding": [
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Transfer-Encoding": [
             "chunked"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate",
+            "max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
           ],
           "x-content-type-options": [
             "nosniff"
@@ -197,17 +176,14 @@
           "x-frame-options": [
             "SAMEORIGIN"
           ],
-          "x-moose": [
-            "majestic"
-          ],
           "x-ratelimit-remaining": [
-            "294"
+            "297"
           ],
           "x-ratelimit-reset": [
-            "130"
+            "433"
           ],
           "x-ratelimit-used": [
-            "6"
+            "3"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -224,11 +200,11 @@
       }
     },
     {
-      "recorded_at": "2015-04-16T03:57:51",
+      "recorded_at": "2016-06-04T16:02:48",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "kind=link&title=PRAW+Documentation+try+2&url=https%3A%2F%2Fpraw.readthedocs.org%2F&sr=reddit_api_test&resubmit=True&uh=marlq79qenfa87c0ed54d343c34a099ebb1f50cbd3cc21efcc&api_type=json"
+          "string": "api_type=json&resubmit=True&kind=link&url=https%3A%2F%2Fpraw.readthedocs.io%2F&uh=t1x4elspvb281c8f2f9df570a7f80189eb24a0245fb2f6cc3d&sr=reddit_api_test&title=PRAW+Documentation+try+2"
         },
         "headers": {
           "Accept": [
@@ -241,16 +217,16 @@
             "keep-alive"
           ],
           "Content-Length": [
-            "183"
+            "182"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "Cookie": [
-            "reddit_session=7302867%2C2015-04-15T20%3A57%3A50%2C524c0a68bed0ccb842dc76e89fa61766dca2b5ce; __cfduid=dc3f16032da43a3c79650e6179fbc52051429156669"
+            "loid=3TZ4XxVD05lP0Gw125; reddit_session=7302867%2C2016-06-04T09%3A02%3A47%2C52b7550277fa86a997e95b80e4a34bb0795f1ce5; __cfduid=d0517e31f808a362cb2be46c53ea2b7021465056166; secure_session=1; loidcreated=2016-06-04T16%3A02%3A46.951Z"
           ],
           "User-Agent": [
-            "PRAW_test_suite PRAW/3.0a1 Python/2.7.5 Darwin-13.4.0-x86_64-i386-64bit"
+            "PRAW_test_suite PRAW/3.5.0 Python/3.5.1 b'Darwin-14.5.0-x86_64-i386-64bit'"
           ]
         },
         "method": "POST",
@@ -258,36 +234,43 @@
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAAAAAAAAAyzMQQrDIBCF4avIrEMGkp1XKWWwUaihOjJOkBK8e7Dp8v94vBP2yhmsOSGIsFSw5vGcDHin7seHfMAaeKuWahFba7ME76POGycUvINciaShKm6cUshacV0k7y8s4hp53o6hTiNnUvnSgjAZiH5838vR2aUwRFf6Y+/9AgAA//8DAKVNl0OkAAAA",
+          "base64_string": "H4sIAAAAAAAAAy3MQQoCMQyF4auUrIcJqKteRSSEacGKbUqaocjQu0sdl//H4x3walLAuwOiqmgD7+6PxUFg4x/v+gbv4GlWm0fsva8aQ0i2bpJR8QzimshiM9wk51is4S2nroZVuVOQbZ/KlqSQ6YcuCIuDFOb3uZxdOMcpdqU/jjG+EAw3R6QAAAA=",
           "encoding": "UTF-8"
         },
         "headers": {
-          "cache-control": [
-            "no-cache, no-cache"
+          "CF-RAY": [
+            "2adc9c7959b92858-SJC"
           ],
-          "cf-ray": [
-            "1d7cf7eb7edb0293-SJC"
-          ],
-          "connection": [
+          "Connection": [
             "keep-alive"
           ],
-          "content-encoding": [
+          "Content-Encoding": [
             "gzip"
           ],
-          "content-type": [
+          "Content-Type": [
             "application/json; charset=UTF-8"
           ],
-          "date": [
-            "Thu, 16 Apr 2015 03:57:51 GMT"
+          "Date": [
+            "Sat, 04 Jun 2016 16:02:48 GMT"
           ],
-          "pragma": [
-            "no-cache"
-          ],
-          "server": [
+          "Server": [
             "cloudflare-nginx"
           ],
-          "transfer-encoding": [
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Transfer-Encoding": [
             "chunked"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate",
+            "max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
           ],
           "x-content-type-options": [
             "nosniff"
@@ -295,17 +278,14 @@
           "x-frame-options": [
             "SAMEORIGIN"
           ],
-          "x-moose": [
-            "majestic"
-          ],
           "x-ratelimit-remaining": [
-            "293"
+            "296"
           ],
           "x-ratelimit-reset": [
-            "129"
+            "433"
           ],
           "x-ratelimit-used": [
-            "7"
+            "4"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -322,7 +302,7 @@
       }
     },
     {
-      "recorded_at": "2015-04-16T03:57:52",
+      "recorded_at": "2016-06-04T16:02:48",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -339,50 +319,57 @@
             "keep-alive"
           ],
           "Cookie": [
-            "reddit_session=7302867%2C2015-04-15T20%3A57%3A50%2C524c0a68bed0ccb842dc76e89fa61766dca2b5ce; __cfduid=dc3f16032da43a3c79650e6179fbc52051429156669"
+            "loid=3TZ4XxVD05lP0Gw125; reddit_session=7302867%2C2016-06-04T09%3A02%3A47%2C52b7550277fa86a997e95b80e4a34bb0795f1ce5; __cfduid=d0517e31f808a362cb2be46c53ea2b7021465056166; secure_session=1; loidcreated=2016-06-04T16%3A02%3A46.951Z"
           ],
           "User-Agent": [
-            "PRAW_test_suite PRAW/3.0a1 Python/2.7.5 Darwin-13.4.0-x86_64-i386-64bit"
+            "PRAW_test_suite PRAW/3.5.0 Python/3.5.1 b'Darwin-14.5.0-x86_64-i386-64bit'"
           ]
         },
         "method": "GET",
-        "uri": "https://www.reddit.com/r/reddit_api_test/comments/32rnjb/praw_documentation_try_2/.json"
+        "uri": "https://www.reddit.com/r/reddit_api_test/comments/4miwrt/praw_documentation_try_2/.json"
       },
       "response": {
         "body": {
-          "base64_string": "H4sIAEAzL1UC/71UTW/bMAz9K4HPRRw7n+2twC4DdgiGDTsEhSBLcq1FljyJShcE+e8j5aSJDay77WaR4uPj45N3p2yvrcyeJtkXHUDb1+xhkkkOHEOnrHWy4aGhdNEaK6P5ZZUsNzWvxKMsCjnj5XxRlpvVejZbFKrYLNR6JcpKSjEjJNFoI72yiLC7tYL5oIt0Ldd0Jes8f5t6xSU0SjoRps4nQhW32JdVR7xkozEYapXUnKm2UgR5OmMoxMorKTUQVP/FeKcZqACEEpSpQf0G1kBrbkjXMFXRNaP3KuABfFR4jEF55lXnPFB095JKRPSKJQ43IKPtntWGa88ueJeETlPPS29/VtThFUVJtGd44B5FOqRjzU2glsJosR9E+v5Igwdn32nwCI3zhL09Pm8/f8M5vyPbknrY2DLh2lbZRJs6BeG8wu+CSrvOu8NIUwx4Vmzu+jZayrS9awCa2FaWa9IvqfUuOuunhCUrYelWlEN5YDDGnUIiBCYMD0Tu0r4f5+956d7S7DQLOvOjpYyMwYf66sBo6XcRy1tSBp3JbmvqlG85UaZM7vORpfKrvHlfkpN7Gdo2UpSDdpaBP7IyTzoB7lQP14zr7PUpFuVjsVku1sWUhos+ydsAdOEpT7jjV5EwB4JdLVw7V3FPadBg0lTbr88/Jp/uiaG5j5PkkwsJFkFciSxXqyuRjtQlv8Tu4EAxT9UUSumR/w86jPZNJrxtiUpk/5eJOjTpJpWez8nM+AjJyxewStW9W/sbD5P/+Kf6N52XP1nR3j05BQAA",
+          "base64_string": "H4sIAKj7UlcC/71Uy27bMBD8FUPnwLIVS7ZzC9BLgR6MokUPQUCsSNoixIfKh10jyL+XS8mRJaDtrTdxOdqdnZ3ly1vWCs2yp0X2RTgv9Cl7WGQMPMTQW6YMa8A1eC1VtWXt+UI3rKI7VhVbuip367Jm1fZY7GlR8tUa6B72UMAKSl5hJtoIySzXMcPLWMo/Tqowo0AgJOssXJaWA/MNZ4a6pTCIrEFrzkh9jRgdpIwhxZkAwlXNMePbewy5UFvOmPCYqf8i0AniufOYxXF59PyXJ41Xcsx0C+NfCJOi5S4evA08ZT2dYoJY3hmLoOG34LgllncxiOiX15SKBstJ4jYipdAtOUoQlgx1hguRxNgocbGJ4NEaRQaNBsgpypc6XMUD2CjnOR2PIB2yo1LQdhLpKUVm4Iz+YAbBN8ZiucP1+fD5W+zoe2ygwLIzuhoUR6B/JCM1R43F6BpzdZ0159k8YsCS9e6OSCMYS4O/BXwTVK1BoPZJ6Y+BkV4JX5LClyYZJ3Lyk77uVKTOESrBYXdD+b6/P98zc0lioIzR1H8b3MxUMBXccmXOIAd9xwJxd2grJlAc5wgQjqDTZvd95wOk41YB9oli5DafeTinRimuvcv7ueS4LSSuScAoeGE08fZKijzZ2MyMEefByW2OH/6JffQ6rzdVudpt9tV2iSIFm8bUeN+5pzyVmi1mqjLRferunwEs6Pik3NfzwsvkrsPX5x+LT/fc48JdF8mQAykSPL0RK6v1jViHU0Mfhu5sPCcW/8ZQutZBkZtOWT/vs3AzLyFodABiWP/4BeGahMQe3t/T5sTHARdn6Krmx17BHvGw+I8P6L/pvP4G3ZnFHNAFAAA=",
           "encoding": "UTF-8"
         },
         "headers": {
-          "cache-control": [
-            "no-cache, no-cache"
+          "CF-RAY": [
+            "2adc9c7de66e1e8f-SJC"
           ],
-          "cf-ray": [
-            "1d7cf7f004fb11e9-SJC"
-          ],
-          "connection": [
+          "Connection": [
             "keep-alive"
           ],
-          "content-encoding": [
+          "Content-Encoding": [
             "gzip"
           ],
-          "content-length": [
-            "594"
+          "Content-Length": [
+            "644"
           ],
-          "content-type": [
+          "Content-Type": [
             "application/json; charset=UTF-8"
           ],
-          "date": [
-            "Thu, 16 Apr 2015 03:57:52 GMT"
+          "Date": [
+            "Sat, 04 Jun 2016 16:02:48 GMT"
           ],
-          "pragma": [
-            "no-cache"
-          ],
-          "server": [
+          "Server": [
             "cloudflare-nginx"
           ],
-          "vary": [
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Vary": [
             "accept-encoding"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate",
+            "max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
           ],
           "x-content-type-options": [
             "nosniff"
@@ -390,20 +377,17 @@
           "x-frame-options": [
             "SAMEORIGIN"
           ],
-          "x-moose": [
-            "majestic"
-          ],
           "x-ratelimit-remaining": [
-            "292"
+            "295"
           ],
           "x-ratelimit-reset": [
-            "128"
+            "432"
           ],
           "x-ratelimit-used": [
-            "8"
+            "5"
           ],
           "x-reddit-tracking": [
-            "https://pixel.redditmedia.com/pixel/of_destiny.png?v=QQ%2BViPYeFlr0upcH%2F8CbmITmZj9XJ8PKGrdku9%2BNVE1ArO4P3lYqZJ%2FaOLKomXJGEfixI2AdYCrnVoCtuKtB%2FyqjA1hCiBm2"
+            "https://pixel.redditmedia.com/pixel/of_destiny.png?v=JQuVkEhX39bzAXX96dORogeJRjvS%2FP0NU%2FkKjDonLymUFpaSIT2wSoBniOW%2Bn94GJqHjS2IfVkITiO%2BGuP8W3EG2zP2S439T"
           ],
           "x-ua-compatible": [
             "IE=edge"
@@ -416,9 +400,9 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://www.reddit.com/r/reddit_api_test/comments/32rnjb/praw_documentation_try_2/.json"
+        "url": "https://www.reddit.com/r/reddit_api_test/comments/4miwrt/praw_documentation_try_2/.json"
       }
     }
   ],
-  "recorded_with": "betamax/0.4.1"
+  "recorded_with": "betamax/0.5.1"
 }

--- a/tests/test_submission.py
+++ b/tests/test_submission.py
@@ -119,7 +119,7 @@ class SubmissionTest(PRAWTest):
 
     @betamax()
     def test_submit__duplicate_url(self):
-        url = 'https://praw.readthedocs.org/'
+        url = 'https://praw.readthedocs.io/'
         self.assertRaises(errors.AlreadySubmitted, self.subreddit.submit,
                           'PRAW Documentation', url=url)
         submission = self.subreddit.submit(


### PR DESCRIPTION
Email from readthedocs:

> Hello!

> Starting today, Read the Docs will start hosting projects from subdomains on
  the domain readthedocs.io, instead of on readthedocs.org. This change
  addresses some security concerns around site cookies while hosting user
  generated data on the same domain as our dashboard.

> Changes to provide security against broader threats have been in place for a
  while, however there are still a few scenarios that can only be addressed by
  migrating to a separate domain.

> We implemented session hijacking detection and took precautions to limit
  cookie usage, but there are still a number of scenarios utilizing XSS and
  CSRF attacks that we aren't able to protect against while hosting
  documentation from subdomains on the readthedocs.org domain. Moving
  documentation hosting to a separate domain will provide more complete
  isolation between the two user interfaces.

> Projects will automatically be redirected, and this redirect will remain in
  place for the foreseeable future. Still, you should plan on updating links to
  your documentation after the new domain goes live.

> If you notice any problems with the changes, feel free to open an issue on
  our issue tracker: http://github.com/rtfd/readthedocs.org/issues. If you do
  notice any security issues, contact us at security@readthedocs.org with more
  information.

> Keep documenting,
> Read the Docs