### PR TITLE
Remove easy_install from README.rst.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -70,13 +70,6 @@ There is also a `Stack overflow question on installing pip on Windows
 <http://stackoverflow.com/questions/4750806/how-to-install-pip-on-windows>`_
 that might prove helpful.
 
-Alternatively you can do it via
-`easy_install <https://pypi.python.org/pypi/setuptools>`_
-
-.. code-block:: bash
-
-    $ easy_install praw
-
 .. end_installation
 
 .. begin_support


### PR DESCRIPTION
`easy_install` will install the latest version regardless if it is pre-release
or not. With PRAW4 in pre-release status, it is not desirable that people
attempting to install the latest stable PRAW receive that version.