### PR TITLE
Set Reddit.user on the wildcard OAuth scope

### DIFF
--- a/praw/__init__.py
+++ b/praw/__init__.py
@@ -1582,7 +1582,7 @@ class AuthenticatedReddit(OAuth2Reddit, UnauthenticatedReddit):
         self.access_token = access_token
         self.refresh_token = refresh_token
         # Update the user object
-        if update_user and 'identity' in scope:
+        if update_user and ('identity' in scope or '*' in scope):
             self.user = self.get_me()
 
 


### PR DESCRIPTION
The '*' OAuth scope provides for all possible scopes, including methods that would require 'identity'. This scope is what is used in when using the 'password' grant_type, as well as can be set manually. If using the token based flow.