### PR TITLE
Allow the user to override img_type in upload_image

### DIFF
--- a/praw/__init__.py
+++ b/praw/__init__.py
@@ -1749,10 +1749,8 @@ class ModConfigMixin(AuthenticatedReddit):
         """
         if name and header:
             raise TypeError('Both name and header cannot be set.')
-        if upload_as not in (None, 'png', 'jpg', 'jpeg'):
+        if upload_as not in (None, 'png', 'jpg'):
             raise TypeError("upload_as must be 'jpg', 'png', or None.")
-        elif upload_as == "jpeg":
-            upload_as = "jpg"
         image_type = None
         # Verify image is a jpeg or png and meets size requirements
         with open(image_path, 'rb') as image:


### PR DESCRIPTION
Whenever the image format and the img_type are both not set to png, reddit converts the image to RGBA mode, which may be useful if the user wishes to have a png automatically converted from any given color mode to RGBA. This is also useful in the case that the optimization that matches the format causes the image to lose quality / data, which in my experience has happened to some jpegs in the past.

If a value of "jpeg" is given it is gracefully accepted and converted to "jpg", because strangely, if "jpeg" is sent to the server, given how the validator checks the value, it will default to "png".

Implemented with the "upload_as" kwarg, because this also dictates the end file type on reddit's cdn.