### PR TITLE
Resolve errors with inadequate pyOpenSSL versions

### DIFF
--- a/praw/__init__.py
+++ b/praw/__init__.py
@@ -37,7 +37,8 @@ from praw.handlers import DefaultHandler
 from praw.helpers import chunk_sequence, normalize_url
 from praw.internal import (_image_type, _prepare_request,
                            _raise_redirect_exceptions,
-                           _raise_response_exceptions, _to_reddit_list)
+                           _raise_response_exceptions,
+                           _to_reddit_list, _warn_pyopenssl)
 from praw.settings import CONFIG
 from requests import Session
 from requests.compat import urljoin
@@ -306,6 +307,7 @@ class BaseReddit(object):
 
     RETRY_CODES = [502, 503, 504]
     update_checked = False
+    openssl_warned = False
 
     def __init__(self, user_agent, site_name=None, handler=None,
                  disable_update_check=False, **kwargs):
@@ -370,6 +372,11 @@ class BaseReddit(object):
                 and self.config.check_for_updates:
             update_check(__name__, __version__)
             BaseReddit.update_checked = True
+
+        # Warn against a potentially incompatible version of pyOpenSSL
+        if not BaseReddit.openssl_warned and self.config.validate_certs:
+            _warn_pyopenssl()
+            BaseReddit.openssl_warned = True
 
         # Initial values
         self._use_oauth = False

--- a/praw/internal.py
+++ b/praw/internal.py
@@ -30,6 +30,13 @@ from praw.errors import (ClientException, HTTPException, Forbidden, NotFound,
                          InvalidSubreddit, OAuthException,
                          OAuthInsufficientScope, OAuthInvalidToken,
                          RedirectException)
+from warnings import warn
+try:
+    from OpenSSL import __version__ as _opensslversion
+    _opensslversionlist = [int(minor) if minor.isdigit() else minor
+                           for minor in _opensslversion.split('.')]
+except ImportError:
+    _opensslversionlist = [0, 15]
 
 MIN_PNG_SIZE = 67
 MIN_JPEG_SIZE = 128
@@ -251,3 +258,14 @@ def _to_reddit_list(arg):
         return six.text_type(arg)
     else:
         return ','.join(six.text_type(a) for a in arg)
+
+
+def _warn_pyopenssl():
+    """Warn the user against faulty versions of pyOpenSSL."""
+    if _opensslversionlist < [0, 15]:  # versions >= 0.15 are fine
+        warn(RuntimeWarning(
+            "pyOpenSSL {0} may be incompatible with praw if validating"
+            "ssl certificates, which is on by default.\nSee https://"
+            "github.com/praw/pull/625 for more information".format(
+                _opensslversion)
+        ))

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,19 @@ with open(path.join(HERE, PACKAGE_NAME, '__init__.py'),
           encoding='utf-8') as fp:
     VERSION = re.search("__version__ = '([^']+)'", fp.read()).group(1)
 
+dependencies = ['decorator >=4.0.9, <4.1',
+                'requests >=2.3.0',
+                'six ==1.10',
+                'update_checker >=0.12, <1.0']
+
+try:
+    from OpenSSL import __version__ as opensslversion
+    opensslversion = [int(minor) if minor.isdigit() else minor
+                      for minor in opensslversion.split('.')]
+    if opensslversion < [0, 15]:  # versions less than 0.15 have a regression
+        dependencies.append('pyopenssl >=0.15')
+except ImportError:
+    pass  # open ssl not installed
 
 setup(name=PACKAGE_NAME,
       author='Timothy Mellor',
@@ -38,10 +51,7 @@ setup(name=PACKAGE_NAME,
                    'reddit\'s API.'),
       entry_points={'console_scripts': [
           'praw-multiprocess = praw.multiprocess:run']},
-      install_requires=['decorator >=4.0.9, <4.1',
-                        'requests >=2.3.0',
-                        'six ==1.10',
-                        'update_checker >=0.12, <1.0'],
+      install_requires=dependencies,
       keywords='reddit api wrapper',
       license='GPLv3',
       long_description=README,

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -211,6 +211,31 @@ class PRAWTest(unittest.TestCase):
                 raise AssertionError('Pattern "{0}" not found in'
                                      'any caught warnings'.format(regexp))
 
+    def assertNoWarnings(self, callable, *args, **kwds):
+        """Fail unless no warnings are triggered by callable with
+           arguments args and keyword arguments kwds.
+        """
+        with warnings.catch_warnings(record=True) as warning_list:
+            warnings.simplefilter('always')
+
+            callable(*args, **kwds)
+            if len(warning_list) == 1:
+                wname, warningmsg = (warning_list[0].category.__name__,
+                                     warning_list[0].message.args[0])
+                raise AssertionError("A warning with a category of {0} "
+                                     "and a message of {1} were triggered "
+                                     "by {2}".format(wname, repr(warningmsg),
+                                                     callable.__name__))
+            elif warning_list:
+                wnames = [(w.category.__name__, w.message.args[0])
+                          if w.message.args else (w.category.__name__, "")
+                          for w in warning_list]
+                wnames = ["{}: {}".format(k, repr(v)) for k, v in warnings]
+                raise AssertionError("The following warnings were triggered "
+                                     "by {0}:\n{1}".format(
+                                         callable.__name__,
+                                         "    \n".join(wnames)))
+
 
 class OAuthPRAWTest(PRAWTest):
     def betamax_init(self):

--- a/tests/test_internal.py
+++ b/tests/test_internal.py
@@ -1,6 +1,39 @@
 from __future__ import print_function, unicode_literals
+from six.moves import reload_module
+import sys
+from types import ModuleType
 from praw.internal import _to_reddit_list
 from .helper import PRAWTest, betamax
+
+
+def patch_openpyssl(version):
+    """Wrapper to patch a pyOpenSSL version.
+
+       - Calls the function with praw's internal module as the second argument.
+       - version defines the version string to patch in
+       - Reverts OpenSSL back to it's normal state after the function call if
+         it exists on the system, otherwise, deletes the patched module from
+         sys.modules
+    """
+    def factory(func):
+        def wrapped(obj):
+            try:
+                import OpenSSL as RealOpenSSL
+            except ImportError:
+                RealOpenSSL = None
+            FakeOpenSSL = ModuleType(str('openssl'))
+            FakeOpenSSL.__version__ = version
+            sys.modules['OpenSSL'] = FakeOpenSSL
+            from praw import internal
+            reload_module(internal)
+
+            retval = func(obj, internal)
+            del sys.modules['OpenSSL']
+            if RealOpenSSL is not None:
+                sys.modules['OpenSSL'] = RealOpenSSL
+            return retval
+        return wrapped
+    return factory
 
 
 class InternalTest(PRAWTest):
@@ -34,3 +67,16 @@ class InternalTest(PRAWTest):
         obj = self.r.get_subreddit(self.sr)
         output = _to_reddit_list([obj, 'hello'])
         self.assertEqual("{0},{1}".format(self.sr, 'hello'), output)
+
+    @patch_openpyssl('0.14')
+    def test__warn_pyopenssl_invalid_version(self, internal):
+        self.assertWarningsRegexp("0\.14", RuntimeWarning,
+                                  internal._warn_pyopenssl)
+
+    @patch_openpyssl('0.15')
+    def test__warn_pyopenssl_valid_version(self, internal):
+        self.assertNoWarnings(internal._warn_pyopenssl)
+
+    @patch_openpyssl('16.0.1.dev001')
+    def test__warn_pyopenssl_valid_version_dev(self, internal):
+        self.assertNoWarnings(internal._warn_pyopenssl)


### PR DESCRIPTION
I finally looked into this after kline on the reddit-dev irc brought it up the other day.

This closes #548 and @bboe/reddit_irc#3.

The issue lies in the fact that requests does not *require* pyOpenSSL. However, if it's on the system, it injects it into urllib3 [upon loading](https://github.com/kennethreitz/requests/blob/master/requests/__init__.py#L54). This allows for certificates to be validated with SNI support.

However,  some systems, such as debian from what I recall, and others, come with pyOpenSSL 0.14 or lower. Somewhere before 0.15, a regression caused data to not be accepted as strings, albeit previously allowed. This was fixed in version 0.15 and higher.

Personally, I didn't feel that praw should outright *require* pyOpenSSL, since requests didn't. So instead, this patch requires a version >= 0.15 *only* if a version less than that is found. In addition, upon first instantiation of the Reddit class a warning is given if applicable (some packages install versions of pyOpenSSL < 0.15).

If this method is accepted, I'll port the changes to prawcore for PRAW4 support.