### PR TITLE
Fix typo in  and clarify docs of helpers.valid_redditors

### DIFF
--- a/praw/helpers.py
+++ b/praw/helpers.py
@@ -105,7 +105,8 @@ def valid_redditors(redditors, sub):
         flair changing permission on.
 
     Note: Flair will be unset for all valid redditors in `redditors` on the
-    subreddit `mod_sub`.
+    subreddit `sub`. A valid redditor is defined as a redditor that is
+    registered on reddit.
 
     """
     simplified = list(set(six.text_type(x).lower() for x in redditors))


### PR DESCRIPTION
The parameter is "sub", not "mod_sub", and it's unclear as to what a "valid redditor" actually is.