### PR TITLE
Add tests 1

### DIFF
--- a/praw/__init__.py
+++ b/praw/__init__.py
@@ -54,12 +54,6 @@ from warnings import warn_explicit
 
 __version__ = '3.5.0'
 
-# Compatibility
-if six.PY3:
-    CHR = chr
-else:
-    CHR = unichr  # NOQA
-
 
 class Config(object):  # pylint: disable=R0903
     """A class containing the configuration for a reddit site."""
@@ -422,7 +416,7 @@ class BaseReddit(object):
             return (request, key_items, kwargs)
 
         def decode(match):
-            return CHR(html_entities.name2codepoint[match.group(1)])
+            return six.unichr(html_entities.name2codepoint[match.group(1)])
 
         def handle_redirect():
             response = None

--- a/tests/cassettes/test_cache_hit_callback.json
+++ b/tests/cassettes/test_cache_hit_callback.json
@@ -1,0 +1,204 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2016-07-17T18:43:14",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "passwd=1111&api_type=json&user=PyAPITestUser2"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "45"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "PRAW_test_suite PRAW/3.5.0 Python/3.4.3 b'Linux-3.13.0-91-generic-x86_64-with-Ubuntu-14.04-trusty'"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://api.reddit.com/api/login/.json"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAAx3LTWoDMQxA4asYrR2wbMt/5+iulKKJZKYtiRvPZJMwdy/p9n28J3xv4wrNPEHnHHODZt4/rAHhnf/zVVU+133/fdE+72oNXIasvK3QDNyWGPERbvMiC51z75VCzehCJY+uKgek2MnnXAtTqhzBGjiP8fOlrz8H50vK1jtMJ5dPmN8QWwwNoy2VRRdliiUUTFEkdQ1VyXdZckkkThyzwHEcfxqnD0nJAAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "CF-RAY": [
+            "2c3fd69ea9ea2162-EWR"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 17 Jul 2016 18:43:14 GMT"
+          ],
+          "Server": [
+            "cloudflare-nginx"
+          ],
+          "Set-Cookie": [
+            "__cfduid=d842cbdef2c108afbef534b8790f097581468780994; expires=Mon, 17-Jul-17 18:43:14 GMT; path=/; domain=.reddit.com; HttpOnly",
+            "loid=YTE3qTMU3KrozV1SR8; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Tue, 17-Jul-2018 18:43:14 GMT; secure",
+            "loidcreated=2016-07-17T18%3A43%3A14.471Z; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Tue, 17-Jul-2018 18:43:14 GMT; secure",
+            "secure_session=1; Domain=reddit.com; Path=/; HttpOnly",
+            "reddit_session=7302867%2C2016-07-17T11%3A43%3A14%2C89adebea54838164dd6fe39e52fdb7865d0d0aad; Domain=reddit.com; Path=/; secure; HttpOnly"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate",
+            "max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.reddit.com/api/login/.json"
+      }
+    },
+    {
+      "recorded_at": "2016-07-17T18:43:15",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "secure_session=1; reddit_session=7302867%2C2016-07-17T11%3A43%3A14%2C89adebea54838164dd6fe39e52fdb7865d0d0aad; loid=YTE3qTMU3KrozV1SR8; __cfduid=d842cbdef2c108afbef534b8790f097581468780994; loidcreated=2016-07-17T18%3A43%3A14.471Z"
+          ],
+          "User-Agent": [
+            "PRAW_test_suite PRAW/3.5.0 Python/3.4.3 b'Linux-3.13.0-91-generic-x86_64-with-Ubuntu-14.04-trusty'"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://api.reddit.com/new/.json?limit=5"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAMPRi1cC/+2YXW/bNhSG/wrni14tkWRL/mixi6xA2gJDGywtdtEMBCVSEhOJVEnKjhfkv++QkmJZddY0aVwM8EUA6/Do8Hy8fCDmZnTFBR29RKM/uDZcZKNf0YgSQ8B0MyolzYnO7XLBrjOZX8frL2y8CBfpYjqZxdQPSRqT+difxdMgSBM/XszmKQnmYRLbSEnOC6qYgAifb+62MpOtXagsCbcuI82K9FgxSrnBpOLYMG2sa0yEYBTHa3ASdVGAqWSUE8zKmNmQN7dg0nXcvGtD7Yhioxt2bXBuysL6vCjMq1+OjtD5a/zh9BQdHb3IzCtrpHyJkoJo/dvFqKQXo85e2R+xpGv74LmnC+F+wxudUxfxfRuwv7Xd1b5vbQW/YnpTkK6zDBKFMrVU1rG115oprFgFRuv9+W8XLqkVw64HG8+CiyucFoQr3O7VLnDX9VCv9DK0O6dKlrgdRuuSwZxcJ314IArmtnSPKSk0s4MseHK1ZWlSgsyIluIuM1KbXCq7namVKVhMuBnbPQe56kQqBo+BfaeqlFwO5gsGhYN5b8OcU+qU1BlEXeJEliUTrjM2c5PXZSwId+N1je80gZsmmAiPTSSndg0CMtwl0gWFNM1Wnb2uJlpjJ4tNmk29969TuXLNscn1pzZQLtnutmKlXJKibW6vawamwLdc7Sw3DlxjKzUwGFV3y03prUfFVElsTbYbnvIG58TrGuo1cvHKdcqVNm7NqVYOdCBIafsHhxpvFJZA5k0bg3A6j2bReLI4tj2olRtNbkylX3rearVqz/sxbPyIdLb6v636LzVRRADT+uM1HERpM+gF6iWMa5N0SYfTsE2aNmisuc5dTR2CJB0ezCXXA/lYkW6cXAsq+yu4hcE/AImGCUiN6mMun4+Enbx6lPo5hCova39vhEprkRguBSmIaJB8gNR+IdVffyylrGS8NOY4A0HgusJSgD6LJRxYHCxmvsYVzJfhnF8SyEtkD8BYJ8NtjIWTaDGNhhhrKdY7p542Uq29YOoH0SR6EqVOf3+H3kBd6FOFPgh03tSFXF3ozNaF3nZ1oSP0sU1iN9FCfxa0+R+ItjeipfPrA9EORPseooFkvEzKrABqEZHJ2micQrkwVCU5xRkDwxLaKKEqrUn2QKq1UhxSbRKFX32c/RfVxpO5+6R/NNXeuNrQ27Y2BLWhk6Y2ZGtDrjZ0VxvSdWWFfx/WwllbwM/E2v/i7vqeraCZccm1BkwcP+UaOwjVp2t799gDXcec/rM3up6tT87efYSKPkEBh0vtM9C1d2ndrP/QO60VjFcpssIb7WJtIKey8f02RjvNbWM0mPjR+KuPw++94z4ovUdz9+zPk7/Q+V1gdO4CIyvp3WgN/GDWFnVA6zfQegoHlFH0mlQmyYlr6lPwuiNcH7Hd2Xl+xAaL9eXeEAt5a/t3gOuPh2vn+ox0tVrxrLGHrwcQtZPYgKhB6M/nTyXqvSk9mqL2KPYoupuc/jwat8k/EzndwQFcNP9s77cxZmmjULvT7e2/f2xJZOMZAAA=",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "CF-RAY": [
+            "2c3fd6a21a552162-EWR"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "1154"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 17 Jul 2016 18:43:15 GMT"
+          ],
+          "Server": [
+            "cloudflare-nginx"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Vary": [
+            "accept-encoding"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate",
+            "max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299"
+          ],
+          "x-ratelimit-reset": [
+            "406"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-reddit-tracking": [
+            "https://pixel.redditmedia.com/pixel/of_destiny.png?v=APKdTlYN6uTwNdddnIaYofGGpNYpIvlWTjYZOs54UiaPc2t9cUCa7be3I2Z3dwIOhE96vzF5CXv4zKDwYqeHfz%2Ffw3CmOZkV"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.reddit.com/new/.json?limit=5"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/test_authenticated_reddit.py
+++ b/tests/test_authenticated_reddit.py
@@ -1,7 +1,6 @@
 """Tests for AuthenticatedReddit class and its mixins."""
 
 from __future__ import print_function, unicode_literals
-import warnings
 from praw import errors
 from .helper import PRAWTest, betamax
 
@@ -56,11 +55,8 @@ class AuthenticatedRedditTest(PRAWTest):
 
     @betamax()
     def test_login__deprecation_warning(self):
-        with warnings.catch_warnings(record=True) as warning_list:
-            self.r.login(self.un, self.un_pswd)
-            self.assertEqual(1, len(warning_list))
-            self.assertTrue(isinstance(warning_list[0].message,
-                                       DeprecationWarning))
+        self.assertWarnings(DeprecationWarning, self.r.login,
+                            self.un, self.un_pswd)
 
     @betamax()
     def test_moderator_or_oauth_required__logged_in_from_reddit_obj(self):

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -1,0 +1,54 @@
+"""Tests for UnauthenticatedReddit class."""
+
+from __future__ import print_function, unicode_literals
+
+from functools import wraps
+from mock import patch
+from praw import handlers
+from random import choice
+from six.moves import cStringIO
+from .helper import PRAWTest, betamax
+
+
+def replace_handler(new_handler):
+    def factory(func):
+        @wraps(func)
+        def wrapped(obj):
+            old_handler = obj.r.handler
+            obj.r.handler = new_handler
+            try:
+                retval = func(obj)
+            finally:
+                obj.r.handler = old_handler
+            return retval
+        return wrapped
+    return factory
+
+
+class HandlerTest(PRAWTest):
+    def setUp(self):
+        super(HandlerTest, self).setUp()
+        self.cache_store = cStringIO()
+
+    def _cache_hit_callback(self, key):
+        pass
+
+    @replace_handler(handlers.RateLimitHandler())
+    def test_ratelimit_handlers(self):
+        to_evict = self.r.config[choice(list(self.r.config.API_PATHS.keys()))]
+        self.assertIs(0, self.r.handler.evict(to_evict))
+
+    @betamax()
+    def test_cache_hit_callback(self):
+        with patch.object(HandlerTest, '_cache_hit_callback') as mock:
+            self.r.handler.cache_hit_callback = self._cache_hit_callback
+
+            # ensure there won't be a difference in the cache key
+            self.r.login(self.un, self.un_pswd, disable_warning=True)
+
+            before_cache = list(self.r.get_new(limit=5))
+            after_cache = list(self.r.get_new(limit=5))
+
+            self.assertTrue(mock.called)
+            self.assertEqual(before_cache, after_cache)
+        self.r.handler.cache_hit_callback = None

--- a/tests/test_oauth2_reddit.py
+++ b/tests/test_oauth2_reddit.py
@@ -49,7 +49,13 @@ class OAuth2RedditTest(PRAWTest):
     # @betamax() is currently broken for this test because the cassettes
     # are caching too aggressively and not performing a token refresh.
     def test_auto_refresh_token(self):
-        self.r.refresh_access_information(self.refresh_token['identity'])
+        self.r.set_oauth_app_info(
+            'IlQgN8A5fPCbpA',
+            '7iYM6T1rh8REihHQEVNgQsE16OE',
+            'http://localhost:8080'
+        )
+        self.r.refresh_access_information(
+            '7302867-l3Gl-kyNxcLJxbr2xn8Q3Ao42UA')
         old_token = self.r.access_token
 
         self.r.access_token += 'x'  # break the token

--- a/tests/test_subreddit.py
+++ b/tests/test_subreddit.py
@@ -1,7 +1,6 @@
-﻿"""Tests for Subreddit class."""
+"""Tests for Subreddit class."""
 
 from __future__ import print_function, unicode_literals
-import warnings
 from praw import errors
 from praw.objects import Subreddit
 from six import text_type
@@ -82,10 +81,8 @@ class SubredditTest(PRAWTest):
 
     @betamax()
     def test_multiple_subreddit__fetch(self):
-        with warnings.catch_warnings(record=True) as w:
-            self.r.get_subreddit('python+redditdev', fetch=True)
-            assert len(w) == 1
-            assert isinstance(w[0].message, UserWarning)
+        self.assertWarnings(UserWarning, self.r.get_subreddit,
+                            'python+redditdev', fetch=True)
 
     @betamax()
     def test_subreddit_refresh(self):

--- a/tests/test_unauthenticated_reddit.py
+++ b/tests/test_unauthenticated_reddit.py
@@ -3,7 +3,6 @@
 from __future__ import print_function, unicode_literals
 
 import mock
-import warnings
 from six import text_type
 from praw import Reddit, errors, helpers
 from praw.objects import Comment, MoreComments, Submission
@@ -332,7 +331,4 @@ class UnauthenticatedRedditTest(PRAWTest):
         self.assertTrue(subreddit.json_dict)
 
     def test_user_agent(self):
-        with warnings.catch_warnings(record=True) as w:
-            Reddit('robot agent')
-            assert len(w) == 1
-            assert isinstance(w[0].message, UserWarning)
+        self.assertWarnings(UserWarning, Reddit, 'robot agent')

--- a/tests/test_unauthenticated_reddit.py
+++ b/tests/test_unauthenticated_reddit.py
@@ -3,6 +3,7 @@
 from __future__ import print_function, unicode_literals
 
 import mock
+import os
 from six import text_type
 from praw import Reddit, errors, helpers
 from praw.objects import Comment, MoreComments, Submission
@@ -269,6 +270,9 @@ class UnauthenticatedRedditTest(PRAWTest):
     def test_not_logged_in_when_initialized(self):
         self.assertEqual(self.r.user, None)
 
+    def test_raise_on_direct_request(self):
+        self.assertRaises(errors.ClientException, self.r.http.request)
+
     def test_require_user_agent(self):
         self.assertRaises(TypeError, Reddit, user_agent=None)
         self.assertRaises(TypeError, Reddit, user_agent='')
@@ -332,3 +336,13 @@ class UnauthenticatedRedditTest(PRAWTest):
 
     def test_user_agent(self):
         self.assertWarnings(UserWarning, Reddit, 'robot agent')
+        google_app_engine = "Google App Engine v2.6"
+        old_server_software, os.environ['SERVER_SOFTWARE'] = \
+            os.environ.get('SERVER_SOFTWARE'), google_app_engine
+        try:
+            self.assertIn(google_app_engine,
+                          Reddit('robot engine').http.headers['User-Agent'])
+        finally:
+            del os.environ['SERVER_SOFTWARE']
+            if old_server_software is not None:
+                os.environ['SERVER_SOFTWARE'] = old_server_software


### PR DESCRIPTION
## Feature Summary and Justification

This feature provides tests / updates tests as mentioned in the commit summaries, and also simplifies one import in `praw.__init__` (six provides a unichar method so a if/else block is not needed for [equivalent function](https://pythonhosted.org/six/#six.unichr))


Unfortunately, one of the tests won't pass because it isn't cached and the tokens were regenerated. I've fixed this, (and found a way for it to be cached so it won't happen again) in a later commit on my /add_tests branch; however the commit history is a bit convoluted until that point and fixing conflicts is giving me a headache, so I hope that can wait until I make a PR with those commits in sequence or I can just add those commits in sequence to this PR.