### PR TITLE
Add tests 3

### DIFF
--- a/tests/cassettes/test_auto_refresh_token.json
+++ b/tests/cassettes/test_auto_refresh_token.json
@@ -1,0 +1,503 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2016-07-29T01:44:36",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=refresh_token&refresh_token=7302867-fd_RVSYjT644cKl4J2oRWeRV_mo&redirect_uri=http%3A%2F%2Flocalhost%3A8080"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic SWxRZ044QTVmUENicEE6N2lZTTZUMXJoOFJFaWhIUUVWTmdRc0UxNk9F"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "117"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "PRAW_test_suite PRAW/3.5.0 Python/3.4.3 b'Linux-3.13.0-92-generic-x86_64-with-Ubuntu-14.04-trusty'"
+          ],
+          "custom_header": [
+            "test_auto_refresh_token__initial__0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://api.reddit.com/api/v1/access_token/"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUCouzCytygxKLzaPzLBMCTQvCjfJMPcoNvcKyFbSUVACq4svqSxIBSlOSk0sSi0CiaeklmUmp8ZnpoCE/fLzUkGCqRUFmUWpxfGZIJONzQwMdBSUipPzIXqLUhNTlGoBOPp6boEAAAA=",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "CF-RAY": [
+            "2c9ce2fa07cb21e0-EWR"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 29 Jul 2016 01:44:36 GMT"
+          ],
+          "Server": [
+            "cloudflare-nginx"
+          ],
+          "Set-Cookie": [
+            "__cfduid=dc84fb09df0aee78169fb6ef9c62d491e1469756676; expires=Sat, 29-Jul-17 01:44:36 GMT; path=/; domain=.reddit.com; HttpOnly"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.reddit.com/api/v1/access_token/"
+      }
+    },
+    {
+      "recorded_at": "2016-07-29T01:44:36",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer sqiuziRgs7Yh9dQ7rW4h7Hs7JPkx"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "PRAW_test_suite PRAW/3.5.0 Python/3.4.3 b'Linux-3.13.0-92-generic-x86_64-with-Ubuntu-14.04-trusty'"
+          ],
+          "custom_header": [
+            "test_auto_refresh_token__refresh__0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/new/.json?limit=5"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"message\": \"Unauthorized\", \"error\": 401}"
+        },
+        "headers": {
+          "CF-RAY": [
+            "2c9ce2fadeca1858-EWR"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "41"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 29 Jul 2016 01:44:36 GMT"
+          ],
+          "Server": [
+            "cloudflare-nginx"
+          ],
+          "Set-Cookie": [
+            "__cfduid=d8d0806ff995307afb43c536240d2540a1469756676; expires=Sat, 29-Jul-17 01:44:36 GMT; path=/; domain=.reddit.com; HttpOnly"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "access-control-allow-origin": [
+            "*"
+          ],
+          "access-control-expose-headers": [
+            "X-Reddit-Tracking, X-Moose"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "www-authenticate": [
+            "Bearer realm=\"reddit\", error=\"invalid_token\""
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-reddit-tracking": [
+            "https://pixel.redditmedia.com/pixel/of_destiny.png?v=0gubd%2FEbAtSswPX%2F7Mth3uV4XKd8qQYXh7iOxA6xt9sghC1IFblQYpT0DSgVFG4lIA6HOHDnhLuNPRjRrcg72AALulRTnWoF"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 401,
+          "message": "Unauthorized"
+        },
+        "url": "https://oauth.reddit.com/new/.json?limit=5"
+      }
+    },
+    {
+      "recorded_at": "2016-07-29T01:44:36",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=refresh_token&refresh_token=7302867-fd_RVSYjT644cKl4J2oRWeRV_mo&redirect_uri=http%3A%2F%2Flocalhost%3A8080"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic SWxRZ044QTVmUENicEE6N2lZTTZUMXJoOFJFaWhIUUVWTmdRc0UxNk9F"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "117"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "PRAW_test_suite PRAW/3.5.0 Python/3.4.3 b'Linux-3.13.0-92-generic-x86_64-with-Ubuntu-14.04-trusty'"
+          ],
+          "custom_header": [
+            "test_auto_refresh_token__refresh__1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://api.reddit.com/api/v1/access_token/"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUIoKywn1cgn1cHXP9MqPKEzL9gyNsDAIMAgIylbSUVACq4svqSxIBSlOSk0sSi0CiaeklmUmp8ZnpoCE/fLzUkGCqRUFmUWpxfGZIJONzQwMdBSUipPzIXqLUhNTlGoBP+P8Y4EAAAA=",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "CF-RAY": [
+            "2c9ce2fb27e121e0-EWR"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 29 Jul 2016 01:44:36 GMT"
+          ],
+          "Server": [
+            "cloudflare-nginx"
+          ],
+          "Set-Cookie": [
+            "__cfduid=dc84fb09df0aee78169fb6ef9c62d491e1469756676; expires=Sat, 29-Jul-17 01:44:36 GMT; path=/; domain=.reddit.com; HttpOnly"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.reddit.com/api/v1/access_token/"
+      }
+    },
+    {
+      "recorded_at": "2016-07-29T01:44:36",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer ZVlUJDUHEGiJoXqfkIUX80P0PRk"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "PRAW_test_suite PRAW/3.5.0 Python/3.4.3 b'Linux-3.13.0-92-generic-x86_64-with-Ubuntu-14.04-trusty'"
+          ],
+          "custom_header": [
+            "test_auto_refresh_token__refresh__2"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/new/.json?limit=5"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAS1mlcC/+1cC2/bxrL+K6wuTtsEtiRS7wRB4KYnje/pTZ3GPT5FXBBLciluTXIZPiSrQf77nZldPiXFipukTk+ABpXIfczzm5kdr970rkTs9R4YvR9Flot42Tsyeh7LGTx604ukF7AsgM9xEYbwxg1E6KU8hiev3lRT81FrlicjJnBIL0nZup9y5uUB96Sb9YXEkQ6LY+7ZzqZeOOKeYDaPHI4rvnkLj7LCSbnniRxXUp9slgg751mOq2Q89HN+ndtBHoX1SuVjnIXDQnHFs8brYrmEBWD7TKY4SD8vMp7aKU/gIY5+9Rst5RYpt4m2emQo4ivbD5lIbb2PfiFIGOOVlYkr3NlPZWRrGekhSxAfcTiELywFca7oq8/CjKN8Q+FetZ4okoAylsm4oowVeSBT3O67kF3xJ0We8xT37NCauTLl8NXEOUmSylVH7vAgtc15Y8NAeB4puHwQF5HtyijiMUkGKc+DInJiJlDsJORKV7YSQj6xrXwip/gOFuR2SUi5KJCZt/hsSNXNMtsNWdbQmuJ3/3tPrkk4SFxTax2LYm1ppzySKxZq4TakloMWRGso6rIeIDIbzazzXvGuhyQ8jRgyheIYpIOOAQ9KiQ6UvQzWqUD3s5mtRzoyt9F/7NFkaIPzFDic5ULGAzJr2TGUmEUoYHBGuzZBF1hTcjbH08VsOh3Nh30UUpGS7oI8Tx4MBjv8dMDjQZYzJ+SDhIHHNAgEyvrkc13FtN3hdcFSFsOcpt5zkYdE5oVazmCG4tf4TubGZWENzbFx9vPJhTHqT/pDo8V4gyO7yN2Sq9FsornyFIYVIguI6RJcpNd17ZXIOgaIZl4PIhkl+Ml8C6ZzANahQfQB2GQRu1w5y9GtoG5rjS7Q9b4O84dfHR8bL5/YPz19ahwff73MH+JDT6wM8oxHl73Iu+yVz5PyQ5anMl7it/MfH37/s3Fs4FNmBCn3YQ6aQwb2IPpITl/kA28jHMsdSi9yrvtJvFRrBjzlhsiMdcByIw/gE/PgO641YOVeg3oz+kpEXMaXcUXRM2EwEMmetxeczGGx4obDeWysZXqFFiNjI5MRN2K+xm0B1LzCzbO+cRHgKD0LCATCYprBHFnk3fFHMNRYg4EauTR4nBU0A/ghphrLkMXhMsBmLONjEedpkQFw48SNLIxlsUFRiJCDLaM54GDAlQK9BwcxD1A2FxBhcBx8R+nFgNgUiOCjkTB474pEbxQDJbAxQEQRi3zT3yOh0xjGxLB2Ru4Bi4s8MCIWb5pbEqMSLCg2As5SxeTPZG4SCAoAFEEN6P0bIwV9APABhWCCnuGAA3ug3LgWG1K2MZY8LsCxw42B4fWIRrS41HK9iuXaCOAfzXJZDKokZoEgIqRvfAeqISviRgYQZuQi4nt1I4u0EovgmZa34aecEw0YxY9BJmB5Yci9fYI7x81kWKDUjlB1btDUOL92ERxw8ywAZR2h6hkZUL5JUJg1s+il2m4aJoNiBEWeQVSQuNIvQJdxJjM003P0l7UIQ4NnGcwWMBjkyEEMcUOIBoRNeOlv8LFMlywWrpHAEmo3EqgPoASrJNxVi6Q85CstNhggUqVBmF7qT6kqUXSplbS1vUzAgiBIgxBBuLVho7GW5gHiRan0CTV2yPUZaBrmoqdmD7bHFKH6hp9DgZ9PNPoDgQrYUc7EJJkyUX9ccYWKBZnQwmp+ey3FbCzBlTgZqloKH4KghEvrg2jQijIW4hfOolqelf46zknSQn2WS+6h4Kf2usCQG8AXBB+lEEOFS2X8mjp4swTd8+sEcj8QHiYOIsvAMvEVSLzBSFb5Dit1qGz+XVSd+s01wfaWgF1g9ruWwNc6whoOOKxMNgS5YJREhtYAiXQlUZyaFZmKpYhZqFeJEfXIYbb36Bvfov+VCZByBcyUSiEpGAjQ5Pr39jCFK7T3pGU0HqxVgIKHILJyGPhHkYSSQQKOTsh3kFYSZUAOidiwTVu1Z0W+Hto3XnIKORmokkUJIL8PmvZ4DmlypoCoycagdIaG++CHOmg+rzw0lkRdSzWl32j5AaySc5IzAw0+lG2KATC4omFeMskhghmqGAA+MHElzipHxAhVblSaXt84CTMJ6YJWuoIMiKa0OXgcyKMg3FmzFCLGFYPsF2GnNb5EMa1bEsONScJTWIUZGVAEgSCQ2vqDTSJhSfB04EEL/Ah0wW9KaNzwOosCGUZL1kloaH/KXsBCa+H/L4+XTMX+nLJV2LCB0mUChGFLW+s2D5DbBtpTwJ/dgMWQUSvZLSXYF0RgENF5UKSZxzZHxkmxLMAax5DT6KCiVAxIzyijUYFeegQ0gJkQ2D3aAKiAgWB5GA8JsAn6lZ0rIyp3VLgPMaLKPrWZbtN/QclNI8CFDDLUQEEiigZTKwCVQhk9ZAc8ValMhJSoZANER0MwuFdMMTQr5CyAEhYnYCVHYlbLNZYCE+apQKfrG4i09Xcljp2KX6+xsMHt++CxUIe1sutGFRatJrP5gPm+CAWYvo1On9ky1uXYQNlJ9Z5AoZHwQhoFjh8DtpAE0Nq1LoD0Wo0gdg+CNQ4j4/KhvMkIYZEhYHWJWY2s8wCdd5IYAXyXaVHxi1NCiSoAdDfAj4Cs5d5c8RyM7ioj4tD5YF2VCgSABCWawMOv9kx/EnBMJfe8bYl+UIBTs9SHIux39B0luc7DWnLbSwbpYOcONVQ8PXlB024Ej/a0Fw+MUzCwWOkCowPIMsIwp6IaISjDfLed3x1RCutJmM1WUqDuRPa4Q8Fl/FxWK5WYnBdpTKhM8bDliBU0U8grnEjgGY4iDWPIVjrQNyCSY1rW5UDhjyRVYmDnsDC4fWMYi7M1PJGYnmwwnKyxVIK1Kodm2dX+dHlLihdou54sk6ySLQfLAYiViRQUC7ZFdIrYrdK0hG2I6jIXVXnfUZmOOjLPITJBuA0wuIAYMTLpsJ7h3K8B9B++LiQQWRNQPzzSIapC6lInSCKMzTCgM5Xo0iuqVTD4gTS3U76+8QTP5shXS+DEI5d2itDK4I8h+KP20AJC6VKNplLnLZi6KT6dhZxB5MD4RjJopBZIDpWsJHUSKcmp9rD3U6vwmy7RSaAwMSaQQ8WRlrEUV3rhYcYfG9+3y12qLim9IEXCNBX9SPaPjQtZhF5lpmTI1XudbV7rWhHtjB/za3XEU+Vf2zb2qyoSNf21E3RTpDW4QhFDtp6RDbAlFpFAIFZiAoe7eMqwK0veJ1DlnxXSaxJhJgK6cnoyObU0lTpbax/teKZThUxAlrPRuZkyNQRtieloI0fFDKNMTuno7u7bnEIuWkfliTrJpuzxsXGKOEMlOOoM6QAGE0glVTn3ewH1Hk2Mi8hBnPMh01eZp1pRaDluG8s5zMKROn+tsuEdtYWDgxI8HdFktuD8yHDwIANzLr018ERnKbtG13lzvarD3O0ygwYLPADwsARDuAQFp9qp0B2Xqcg3pYsAsqoTr3AJS+RB9GH0gFTsll2bUHDNqgjDo647WYUdKowqvtHOOiy1tbg/0J1VAUQ7Pq1GhVKNbx5HLKO4sFVH46YU8bX8oATioa9NDZ4tiTpdMJdv2o7fnq4j847p9KZBy5GqwGGWqiT+Cvw4VFMEDbh6jQ0FrbcSHKM5vmrFAzxD0Trc1poC8Ho0hSOZQa6EC+ukAMEc8heKGa7Lk7xV0ODhinrXsthtKz/YGCGirrEQInTBM206IE455pZEF0UuylUwB8RastCOtJ9TOoSMQGIrlm6Aj1RCGGye7uhHVMSAzIACXyzxHBZTVtJdxK60g0Tk+wAcaHIa21Thhu6ewzgaBrRGaOc/yNAzImyApFkgEuKBTvRZRCCs69iDBXRRx3jl+TGAeQoOoMomlDiZhEqyKy7x//qwXp9zf4uM0xy/AN4pGLRMH+rHZ2C/T2SaSCy3lKF3n9ZWrA7OiDgXWKVDYfrm3dtWyQVvpuwOh+BR5k5cnaoQTPh46IDpFtSxywD50oiScAl4VxYQDgdTECDZMt1xGba5MEg1rPWK8wQzCb6hEwihdO/hGQfVmBjPwIickEeoatA6SyGx26GaXUXbP78/PX+gU0CJ5w45VkER5wSMRIoOrBT7aHXqO8QSiDk737FNta5hgfNTtv8/o8XDSK3AWQoGB+kV0+emACnlkEzZGGgdlEtOrPaqe1gCMqUGaJH70jskP9FtgnpPRXmReOp4QslLV+ohNlp0BHonFyMsSUtdE4H1wR66J6UHRDHVIpgENQ4wyk09gWaBD2SsgLZltu99GJIEf2RikJUdARuPl0AcnFrXmZ2ETM2xwVpsiBxiGesDEhEf+5xjM8igsQ1fKNssFQfYh0ALJYgU7ehMnz2xKh3+K93ufK67nc2+KLZE798vG5qv9jQnf/t2O3B1u5v37t9HFem+5GVsoFdW+fx/exeS5HH6ped4Q8+RxHSOS3/pMKqVtCW9V4eR/LDZTsQH941bNQzVxE/WHcTt/uJWIJLweff9kAMcvqMQv7NNPjLR+3/7vp0Kkk+x8niPvhzF5V1BuFs93rt9+w3p+mx6bUjsZ9FYe9XpetVKPDihvKm7du/u9M9QLYc2y3Cs7ozhx27jCx7Zto2Y8PTkhfKa+/c/bBMKV/38+06VZA5tLCHbH7KXdNlr7HXZu6u9o1e3OFM7DHLbGvjcekBoDp+g7YNCurM9nk9lG/t6BB+8V4NKPQ/+5u2Zw2SL21Ty+LxaLnugnZbW8NwWfQvjzyos/Tu0UT6ai9aZBUkX4+ot2iE6qH66DkhF9odocSj3wFzvbnc1aof4mG2Lbk/iXZ0IlNzn1Hyo8uo/3V/Alapmwjf7mwjffKjmwTeKnAOaBhVpH6tD8Kp7VH+Lsu42fYJ7WhbvaAQccm2z95rhMPSS7t2u213bLBLfND/etc3WRUbcsFUqvuPqJm15y6ubkI0g8PfwppqIME9EGb3pZQA0Li7+pnkRsA4yIidiSPvfrYZO7KXPf+GzXyYX09c/LMOzZy/5yzBh1y+e/bpyf/j5yWI1/nF48gJj0ePs0YRxNmHjhet7vmPNXZPNFo4zxMuHE3fqOsjsWng53is2x9YEKedYGsD32dTEC3GQRenDc03xByfTF/kjCAYJtfPwwyMfjDX7h/WE40l+ov6SkKXBI4s+rR+Zwzl9yh75w+Fw4jNrOPI9a7EYDhcOMDrxJ543dhcj3mJwOG/yN5nRbcI7wI5lTjU71sziljdfMG8xsTw2Hc/G7njk8pm3sIbTMV3iLdmBWU12THNyV/gZWUPNjzm1FoxZvjNamM7U8kfm1J+ORsydj/jMHbbsD2a1+JkN7wo/03HJz9C3TIuPHH9ojRn3J8ycsBGA1dRns5lrzZv8wKwmP6MxutOd4GcxLfmZmCPT86eeC3bnzK0pm40dZ2wxxwNXYn7L3mBWy31M667wA45dKcj0JnPPmjkT0/S86RiY8RdDZ+HMTNOZ80kHD9oczaZv6UIy5DYspiBGV4JVVPqPG63N5cW//vjX7BnLrk83oz+Sf/7b+vUk/b/89U8Xp2Z8fD4Pz37gF/Pe299wXue2vmVZ6LCtC/t0df1o96X9dCh+x3fvvrSP164ns9liNqFr143QuuNu/qe9u49FgQ0VBOUIFaeHX+jPUzxIv/k+/76UiNKIQczXNvNs7OXaZYViU65CZxs33+CvspH2Df7JbD4aW90b/O+Vsx1O4K3v9j+HWvPEM85h8Qe7OtQNvhr3+Cdj+E/x1r3H32NeJOj6/y2u8muS1W3+4fvc5tfe0fzRkVvc59+xSvdGf5ny/dU/XVKAlGe488fJgTs/XXK2OTk7PQeO0DJIEXtS4C+/XvI+CPgRwK5jwk00QYsZZAXMsLGZZhMI2LmkgTaUv3YoIpjrBiw9BPdKC+zg3sg0F1u/XLIT9z4orbeGwJe4i24v4jOqbTk1B/BwgA50cBdsZ+IBjUyx54T9NBodQ2FOhz+OPg3KAxYb8yFNYm6OR0O0eOOYApbyWRHSmV1rJNXTO/B2aI20TLt4WyLb+4PtLX83ZQdGfhykveVvpzjS2/yZP0/E+X8Nog9X1ySIL4j+BdEPQ3S0mIHLkhwQRCGjjG0HjzvtSqwHAHlpeG0gN+czczL+s0B+MIm3xm+9uMJsGRu0eP3XO7sR1ZzMR5q5L4j6d0XU/HXi0RHSJ0HUNcNOzzG1laGY+wKpnyOkkskMqI9Hf1GlEs+bMbQytTaGDscjczj9kxj6DppuDZr1aiqN3Y2SQ3M80uR/JJQkF/LxFzG7glSdeL3T27f/D8Kv9wr+VAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "CF-RAY": [
+            "2c9ce2fc3ef51858-EWR"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "4710"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 29 Jul 2016 01:44:36 GMT"
+          ],
+          "Server": [
+            "cloudflare-nginx"
+          ],
+          "Set-Cookie": [
+            "__cfduid=d8d0806ff995307afb43c536240d2540a1469756676; expires=Sat, 29-Jul-17 01:44:36 GMT; path=/; domain=.reddit.com; HttpOnly"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Vary": [
+            "accept-encoding"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate",
+            "max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "599.0"
+          ],
+          "x-ratelimit-reset": [
+            "324"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-reddit-tracking": [
+            "https://pixel.redditmedia.com/pixel/of_destiny.png?v=dMdpbk5hXbLCe3sZRczXIlJlup%2FR%2BElujpa6ayPVT7%2F8kROrUPAq837SaPNG5D0DhRmQeik5Dp%2F1mVWXuIoXLKDLhFhCKRkX"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/new/.json?limit=5"
+      }
+    },
+    {
+      "recorded_at": "2016-07-29T01:44:36",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer ZVlUJDUHEGiJoXqfkIUX80P0PRk"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "__cfduid=d8d0806ff995307afb43c536240d2540a1469756676"
+          ],
+          "User-Agent": [
+            "PRAW_test_suite PRAW/3.5.0 Python/3.4.3 b'Linux-3.13.0-92-generic-x86_64-with-Ubuntu-14.04-trusty'"
+          ],
+          "custom_header": [
+            "test_auto_refresh_token__after__0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/new/.json?limit=5"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAS1mlcC/+1cC2/bxrL+K6wuTtsEtiRS7wRB4KYnje/pTZ3GPT5FXBBLciluTXIZPiSrQf77nZldPiXFipukTk+ABpXIfczzm5kdr970rkTs9R4YvR9Flot42Tsyeh7LGTx604ukF7AsgM9xEYbwxg1E6KU8hiev3lRT81FrlicjJnBIL0nZup9y5uUB96Sb9YXEkQ6LY+7ZzqZeOOKeYDaPHI4rvnkLj7LCSbnniRxXUp9slgg751mOq2Q89HN+ndtBHoX1SuVjnIXDQnHFs8brYrmEBWD7TKY4SD8vMp7aKU/gIY5+9Rst5RYpt4m2emQo4ivbD5lIbb2PfiFIGOOVlYkr3NlPZWRrGekhSxAfcTiELywFca7oq8/CjKN8Q+FetZ4okoAylsm4oowVeSBT3O67kF3xJ0We8xT37NCauTLl8NXEOUmSylVH7vAgtc15Y8NAeB4puHwQF5HtyijiMUkGKc+DInJiJlDsJORKV7YSQj6xrXwip/gOFuR2SUi5KJCZt/hsSNXNMtsNWdbQmuJ3/3tPrkk4SFxTax2LYm1ppzySKxZq4TakloMWRGso6rIeIDIbzazzXvGuhyQ8jRgyheIYpIOOAQ9KiQ6UvQzWqUD3s5mtRzoyt9F/7NFkaIPzFDic5ULGAzJr2TGUmEUoYHBGuzZBF1hTcjbH08VsOh3Nh30UUpGS7oI8Tx4MBjv8dMDjQZYzJ+SDhIHHNAgEyvrkc13FtN3hdcFSFsOcpt5zkYdE5oVazmCG4tf4TubGZWENzbFx9vPJhTHqT/pDo8V4gyO7yN2Sq9FsornyFIYVIguI6RJcpNd17ZXIOgaIZl4PIhkl+Ml8C6ZzANahQfQB2GQRu1w5y9GtoG5rjS7Q9b4O84dfHR8bL5/YPz19ahwff73MH+JDT6wM8oxHl73Iu+yVz5PyQ5anMl7it/MfH37/s3Fs4FNmBCn3YQ6aQwb2IPpITl/kA28jHMsdSi9yrvtJvFRrBjzlhsiMdcByIw/gE/PgO641YOVeg3oz+kpEXMaXcUXRM2EwEMmetxeczGGx4obDeWysZXqFFiNjI5MRN2K+xm0B1LzCzbO+cRHgKD0LCATCYprBHFnk3fFHMNRYg4EauTR4nBU0A/ghphrLkMXhMsBmLONjEedpkQFw48SNLIxlsUFRiJCDLaM54GDAlQK9BwcxD1A2FxBhcBx8R+nFgNgUiOCjkTB474pEbxQDJbAxQEQRi3zT3yOh0xjGxLB2Ru4Bi4s8MCIWb5pbEqMSLCg2As5SxeTPZG4SCAoAFEEN6P0bIwV9APABhWCCnuGAA3ug3LgWG1K2MZY8LsCxw42B4fWIRrS41HK9iuXaCOAfzXJZDKokZoEgIqRvfAeqISviRgYQZuQi4nt1I4u0EovgmZa34aecEw0YxY9BJmB5Yci9fYI7x81kWKDUjlB1btDUOL92ERxw8ywAZR2h6hkZUL5JUJg1s+il2m4aJoNiBEWeQVSQuNIvQJdxJjM003P0l7UIQ4NnGcwWMBjkyEEMcUOIBoRNeOlv8LFMlywWrpHAEmo3EqgPoASrJNxVi6Q85CstNhggUqVBmF7qT6kqUXSplbS1vUzAgiBIgxBBuLVho7GW5gHiRan0CTV2yPUZaBrmoqdmD7bHFKH6hp9DgZ9PNPoDgQrYUc7EJJkyUX9ccYWKBZnQwmp+ey3FbCzBlTgZqloKH4KghEvrg2jQijIW4hfOolqelf46zknSQn2WS+6h4Kf2usCQG8AXBB+lEEOFS2X8mjp4swTd8+sEcj8QHiYOIsvAMvEVSLzBSFb5Dit1qGz+XVSd+s01wfaWgF1g9ruWwNc6whoOOKxMNgS5YJREhtYAiXQlUZyaFZmKpYhZqFeJEfXIYbb36Bvfov+VCZByBcyUSiEpGAjQ5Pr39jCFK7T3pGU0HqxVgIKHILJyGPhHkYSSQQKOTsh3kFYSZUAOidiwTVu1Z0W+Hto3XnIKORmokkUJIL8PmvZ4DmlypoCoycagdIaG++CHOmg+rzw0lkRdSzWl32j5AaySc5IzAw0+lG2KATC4omFeMskhghmqGAA+MHElzipHxAhVblSaXt84CTMJ6YJWuoIMiKa0OXgcyKMg3FmzFCLGFYPsF2GnNb5EMa1bEsONScJTWIUZGVAEgSCQ2vqDTSJhSfB04EEL/Ah0wW9KaNzwOosCGUZL1kloaH/KXsBCa+H/L4+XTMX+nLJV2LCB0mUChGFLW+s2D5DbBtpTwJ/dgMWQUSvZLSXYF0RgENF5UKSZxzZHxkmxLMAax5DT6KCiVAxIzyijUYFeegQ0gJkQ2D3aAKiAgWB5GA8JsAn6lZ0rIyp3VLgPMaLKPrWZbtN/QclNI8CFDDLUQEEiigZTKwCVQhk9ZAc8ValMhJSoZANER0MwuFdMMTQr5CyAEhYnYCVHYlbLNZYCE+apQKfrG4i09Xcljp2KX6+xsMHt++CxUIe1sutGFRatJrP5gPm+CAWYvo1On9ky1uXYQNlJ9Z5AoZHwQhoFjh8DtpAE0Nq1LoD0Wo0gdg+CNQ4j4/KhvMkIYZEhYHWJWY2s8wCdd5IYAXyXaVHxi1NCiSoAdDfAj4Cs5d5c8RyM7ioj4tD5YF2VCgSABCWawMOv9kx/EnBMJfe8bYl+UIBTs9SHIux39B0luc7DWnLbSwbpYOcONVQ8PXlB024Ej/a0Fw+MUzCwWOkCowPIMsIwp6IaISjDfLed3x1RCutJmM1WUqDuRPa4Q8Fl/FxWK5WYnBdpTKhM8bDliBU0U8grnEjgGY4iDWPIVjrQNyCSY1rW5UDhjyRVYmDnsDC4fWMYi7M1PJGYnmwwnKyxVIK1Kodm2dX+dHlLihdou54sk6ySLQfLAYiViRQUC7ZFdIrYrdK0hG2I6jIXVXnfUZmOOjLPITJBuA0wuIAYMTLpsJ7h3K8B9B++LiQQWRNQPzzSIapC6lInSCKMzTCgM5Xo0iuqVTD4gTS3U76+8QTP5shXS+DEI5d2itDK4I8h+KP20AJC6VKNplLnLZi6KT6dhZxB5MD4RjJopBZIDpWsJHUSKcmp9rD3U6vwmy7RSaAwMSaQQ8WRlrEUV3rhYcYfG9+3y12qLim9IEXCNBX9SPaPjQtZhF5lpmTI1XudbV7rWhHtjB/za3XEU+Vf2zb2qyoSNf21E3RTpDW4QhFDtp6RDbAlFpFAIFZiAoe7eMqwK0veJ1DlnxXSaxJhJgK6cnoyObU0lTpbax/teKZThUxAlrPRuZkyNQRtieloI0fFDKNMTuno7u7bnEIuWkfliTrJpuzxsXGKOEMlOOoM6QAGE0glVTn3ewH1Hk2Mi8hBnPMh01eZp1pRaDluG8s5zMKROn+tsuEdtYWDgxI8HdFktuD8yHDwIANzLr018ERnKbtG13lzvarD3O0ygwYLPADwsARDuAQFp9qp0B2Xqcg3pYsAsqoTr3AJS+RB9GH0gFTsll2bUHDNqgjDo647WYUdKowqvtHOOiy1tbg/0J1VAUQ7Pq1GhVKNbx5HLKO4sFVH46YU8bX8oATioa9NDZ4tiTpdMJdv2o7fnq4j847p9KZBy5GqwGGWqiT+Cvw4VFMEDbh6jQ0FrbcSHKM5vmrFAzxD0Trc1poC8Ho0hSOZQa6EC+ukAMEc8heKGa7Lk7xV0ODhinrXsthtKz/YGCGirrEQInTBM206IE455pZEF0UuylUwB8RastCOtJ9TOoSMQGIrlm6Aj1RCGGye7uhHVMSAzIACXyzxHBZTVtJdxK60g0Tk+wAcaHIa21Thhu6ewzgaBrRGaOc/yNAzImyApFkgEuKBTvRZRCCs69iDBXRRx3jl+TGAeQoOoMomlDiZhEqyKy7x//qwXp9zf4uM0xy/AN4pGLRMH+rHZ2C/T2SaSCy3lKF3n9ZWrA7OiDgXWKVDYfrm3dtWyQVvpuwOh+BR5k5cnaoQTPh46IDpFtSxywD50oiScAl4VxYQDgdTECDZMt1xGba5MEg1rPWK8wQzCb6hEwihdO/hGQfVmBjPwIickEeoatA6SyGx26GaXUXbP78/PX+gU0CJ5w45VkER5wSMRIoOrBT7aHXqO8QSiDk737FNta5hgfNTtv8/o8XDSK3AWQoGB+kV0+emACnlkEzZGGgdlEtOrPaqe1gCMqUGaJH70jskP9FtgnpPRXmReOp4QslLV+ohNlp0BHonFyMsSUtdE4H1wR66J6UHRDHVIpgENQ4wyk09gWaBD2SsgLZltu99GJIEf2RikJUdARuPl0AcnFrXmZ2ETM2xwVpsiBxiGesDEhEf+5xjM8igsQ1fKNssFQfYh0ALJYgU7ehMnz2xKh3+K93ufK67nc2+KLZE798vG5qv9jQnf/t2O3B1u5v37t9HFem+5GVsoFdW+fx/exeS5HH6ped4Q8+RxHSOS3/pMKqVtCW9V4eR/LDZTsQH941bNQzVxE/WHcTt/uJWIJLweff9kAMcvqMQv7NNPjLR+3/7vp0Kkk+x8niPvhzF5V1BuFs93rt9+w3p+mx6bUjsZ9FYe9XpetVKPDihvKm7du/u9M9QLYc2y3Cs7ozhx27jCx7Zto2Y8PTkhfKa+/c/bBMKV/38+06VZA5tLCHbH7KXdNlr7HXZu6u9o1e3OFM7DHLbGvjcekBoDp+g7YNCurM9nk9lG/t6BB+8V4NKPQ/+5u2Zw2SL21Ty+LxaLnugnZbW8NwWfQvjzyos/Tu0UT6ai9aZBUkX4+ot2iE6qH66DkhF9odocSj3wFzvbnc1aof4mG2Lbk/iXZ0IlNzn1Hyo8uo/3V/Alapmwjf7mwjffKjmwTeKnAOaBhVpH6tD8Kp7VH+Lsu42fYJ7WhbvaAQccm2z95rhMPSS7t2u213bLBLfND/etc3WRUbcsFUqvuPqJm15y6ubkI0g8PfwppqIME9EGb3pZQA0Li7+pnkRsA4yIidiSPvfrYZO7KXPf+GzXyYX09c/LMOzZy/5yzBh1y+e/bpyf/j5yWI1/nF48gJj0ePs0YRxNmHjhet7vmPNXZPNFo4zxMuHE3fqOsjsWng53is2x9YEKedYGsD32dTEC3GQRenDc03xByfTF/kjCAYJtfPwwyMfjDX7h/WE40l+ov6SkKXBI4s+rR+Zwzl9yh75w+Fw4jNrOPI9a7EYDhcOMDrxJ543dhcj3mJwOG/yN5nRbcI7wI5lTjU71sziljdfMG8xsTw2Hc/G7njk8pm3sIbTMV3iLdmBWU12THNyV/gZWUPNjzm1FoxZvjNamM7U8kfm1J+ORsydj/jMHbbsD2a1+JkN7wo/03HJz9C3TIuPHH9ojRn3J8ycsBGA1dRns5lrzZv8wKwmP6MxutOd4GcxLfmZmCPT86eeC3bnzK0pm40dZ2wxxwNXYn7L3mBWy31M667wA45dKcj0JnPPmjkT0/S86RiY8RdDZ+HMTNOZ80kHD9oczaZv6UIy5DYspiBGV4JVVPqPG63N5cW//vjX7BnLrk83oz+Sf/7b+vUk/b/89U8Xp2Z8fD4Pz37gF/Pe299wXue2vmVZ6LCtC/t0df1o96X9dCh+x3fvvrSP164ns9liNqFr143QuuNu/qe9u49FgQ0VBOUIFaeHX+jPUzxIv/k+/76UiNKIQczXNvNs7OXaZYViU65CZxs33+CvspH2Df7JbD4aW90b/O+Vsx1O4K3v9j+HWvPEM85h8Qe7OtQNvhr3+Cdj+E/x1r3H32NeJOj6/y2u8muS1W3+4fvc5tfe0fzRkVvc59+xSvdGf5ny/dU/XVKAlGe488fJgTs/XXK2OTk7PQeO0DJIEXtS4C+/XvI+CPgRwK5jwk00QYsZZAXMsLGZZhMI2LmkgTaUv3YoIpjrBiw9BPdKC+zg3sg0F1u/XLIT9z4orbeGwJe4i24v4jOqbTk1B/BwgA50cBdsZ+IBjUyx54T9NBodQ2FOhz+OPg3KAxYb8yFNYm6OR0O0eOOYApbyWRHSmV1rJNXTO/B2aI20TLt4WyLb+4PtLX83ZQdGfhykveVvpzjS2/yZP0/E+X8Nog9X1ySIL4j+BdEPQ3S0mIHLkhwQRCGjjG0HjzvtSqwHAHlpeG0gN+czczL+s0B+MIm3xm+9uMJsGRu0eP3XO7sR1ZzMR5q5L4j6d0XU/HXi0RHSJ0HUNcNOzzG1laGY+wKpnyOkkskMqI9Hf1GlEs+bMbQytTaGDscjczj9kxj6DppuDZr1aiqN3Y2SQ3M80uR/JJQkF/LxFzG7glSdeL3T27f/D8Kv9wr+VAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "CF-RAY": [
+            "2c9ce2fd5f161858-EWR"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "4710"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 29 Jul 2016 01:44:36 GMT"
+          ],
+          "Server": [
+            "cloudflare-nginx"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Vary": [
+            "accept-encoding"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate",
+            "max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "598.0"
+          ],
+          "x-ratelimit-reset": [
+            "324"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-reddit-tracking": [
+            "https://pixel.redditmedia.com/pixel/of_destiny.png?v=I00lvHvx0qODcGhvsrbLRy29Cbq7FiPXRJv5sV8rUKZoIG%2FBHAmFafN6D4ZZnSEDXKB043R61JraCjmvKtlw3OUX0RKaEJa5"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/new/.json?limit=5"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/cassettes/test_cache.json
+++ b/tests/cassettes/test_cache.json
@@ -497,7 +497,7 @@
             "reddit_session=7302867%2C2015-04-28T07%3A57%3A35%2C95e866fc793b75723e53ff54e1be6291797d56ab; __cfduid=dc19bd73cf18348a7ab86d7e35bd059991430233055"
           ],
           "SKIP_BETAMAX": [
-            0
+            "0"
           ],
           "User-Agent": [
             "PRAW_test_suite PRAW/3.0a1 Python/2.7.5 Darwin-13.4.0-x86_64-i386-64bit"

--- a/tests/cassettes/test_empty_captcha_file.json
+++ b/tests/cassettes/test_empty_captcha_file.json
@@ -1,0 +1,304 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2016-07-21T20:43:17",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "refresh_token=10640071-oWSCa5YMSWGQrRCa4fMSO_C1bZg&redirect_uri=https%3A%2F%2F127.0.0.1%3A65010%2Fauthorize_callback&grant_type=refresh_token"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic c3RKbFVTVWJQUWU1bFE6aVUtTHNPenlKSDdCRFZvcS1xT1dORXEyenVJ"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "141"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "PRAW_test_suite PRAW/3.5.0 Python/3.4.3 b'Linux-3.13.0-92-generic-x86_64-with-Ubuntu-14.04-trusty'"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://api.reddit.com/api/v1/access_token/"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUPJJS810dgkKz60MS0suizBwDKv0DoiPCvRxzlbSUVACq4svqSxIBSlOSk0sSi0CiaeklmUmp8ZnpoCE/fLzUkGCqRUFmUWpxfGZIJONzQwMdBSUipPzIXqLS5NyM0uUagES/V3UgwAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "CF-RAY": [
+            "2c617bf844c0215c-EWR"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 21 Jul 2016 20:43:17 GMT"
+          ],
+          "Server": [
+            "cloudflare-nginx"
+          ],
+          "Set-Cookie": [
+            "__cfduid=d4eaafc0ffa299018007c6d2bf0b676351469133797; expires=Fri, 21-Jul-17 20:43:17 GMT; path=/; domain=.reddit.com; HttpOnly"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.reddit.com/api/v1/access_token/"
+      }
+    },
+    {
+      "recorded_at": "2016-07-21T20:43:17",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&kind=self&text=body&title=captcha+test+will+fail&sr=reddit_api_test"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer LfeiCDRWmyVfcvX0AVyKP_ZQLCk"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "81"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "PRAW_test_suite PRAW/3.5.0 Python/3.4.3 b'Linux-3.13.0-92-generic-x86_64-with-Ubuntu-14.04-trusty'"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/submit/.json"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWyirOz1OyUqhWSk4sKEnOSFSyUlDyzQhw8U/2y/EKTg7LtSwvM010qwhwTMuKTEl2CcvwyVXSUVBKLSrKLypWslKIjlZycnSJd3YMCHH2cARJJScWpSqU5CuUFFUqlGSkFqcqJKYnZubZQ+QgtsTG1tYCAIdME6J9AAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "CF-RAY": [
+            "2c617bf90b4f21b6-EWR"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 21 Jul 2016 20:43:17 GMT"
+          ],
+          "Server": [
+            "cloudflare-nginx"
+          ],
+          "Set-Cookie": [
+            "__cfduid=d382cc5fa4c7e968bff7a2f206d84e3df1469133797; expires=Fri, 21-Jul-17 20:43:17 GMT; path=/; domain=.reddit.com; HttpOnly"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate",
+            "max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "599.0"
+          ],
+          "x-ratelimit-reset": [
+            "403"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/submit/.json"
+      }
+    },
+    {
+      "recorded_at": "2016-07-21T20:43:17",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&kind=self&text=body&title=captcha+test+will+fail&sr=reddit_api_test"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer LfeiCDRWmyVfcvX0AVyKP_ZQLCk"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "81"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "__cfduid=d382cc5fa4c7e968bff7a2f206d84e3df1469133797"
+          ],
+          "User-Agent": [
+            "PRAW_test_suite PRAW/3.5.0 Python/3.4.3 b'Linux-3.13.0-92-generic-x86_64-with-Ubuntu-14.04-trusty'"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/submit/.json"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWyirOz1OyUqhWSk4sKEnOSFSyUlAqNymJKLGo9MwsK0v2zPYvCo1Mc/NKLg8NyaxMT3Uvq1TSUVBKLSrKLypWslKIjlZycnSJd3YMCHH2cARJJScWpSqU5CuUFFUqlGSkFqcqJKYnZubZQ+QgtsTG1tYCABRIkjB9AAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "CF-RAY": [
+            "2c617bf96b5621b6-EWR"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 21 Jul 2016 20:43:17 GMT"
+          ],
+          "Server": [
+            "cloudflare-nginx"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate",
+            "max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "598.0"
+          ],
+          "x-ratelimit-reset": [
+            "403"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/submit/.json"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.7.1"
+}

--- a/tests/cassettes/test_error_list.json
+++ b/tests/cassettes/test_error_list.json
@@ -1,0 +1,199 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2016-07-26T01:07:01",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=refresh_token&refresh_token=10640071-oWSCa5YMSWGQrRCa4fMSO_C1bZg&redirect_uri=https%3A%2F%2F127.0.0.1%3A65010%2Fauthorize_callback"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic c3RKbFVTVWJQUWU1bFE6aVUtTHNPenlKSDdCRFZvcS1xT1dORXEyenVJ"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "141"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "PRAW_test_suite PRAW/3.5.0 Python/3.4.3 b'Linux-3.13.0-92-generic-x86_64-with-Ubuntu-14.04-trusty'"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://api.reddit.com/api/v1/access_token/"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUHLzjPctS3RNS4pyKY7KDE+L8g1zSTSqSjIJK1bSUVACq4svqSxIBSlOSk0sSi0CiaeklmUmp8ZnpoCE/fLzUkGCqRUFmUWpxfGZIJONzQwMdBSUipPzIXqLS5NyM0uUagF4W5Z6gwAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "CF-RAY": [
+            "2c83f3cf9f7f06af-EWR"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 26 Jul 2016 01:07:01 GMT"
+          ],
+          "Server": [
+            "cloudflare-nginx"
+          ],
+          "Set-Cookie": [
+            "__cfduid=da270d108f32f2b3a9a068254f4810ce31469495221; expires=Wed, 26-Jul-17 01:07:01 GMT; path=/; domain=.reddit.com; HttpOnly"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.reddit.com/api/v1/access_token/"
+      }
+    },
+    {
+      "recorded_at": "2016-07-26T01:07:01",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "sr=reddit_api_test&text=ratelimit+error+test+call+1&api_type=json&kind=self&title=test+ratelimit+error+1"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer FI_MvaEfbZDsZiWfZMVDa2zb4Vs"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "104"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "PRAW_test_suite PRAW/3.5.0 Python/3.4.3 b'Linux-3.13.0-92-generic-x86_64-with-Ubuntu-14.04-trusty'"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/submit/.json"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA1WOUYuCQBhF/8rlexapTdvyJcwChYKI2d1CJAYbckJn2vETkui/L9bTPh/OufdB19YaivCgUt64rCRFoHSUpWK+P65Ce9iGSShFL/o6OE6/f+8/dfNFHshJVrVuNFOEz6k/CT7ms8ADKeesaylCntMyXp2SeCeSNB6UUjoFtmDXgyvVKsiL1GbxZu/1wkNO+1isN9k2EwPpbYdBPFttLuBKMthaNF1Z+a/UKwJtMEajTcfK//+vKJ7PPwAnC1boAAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "CF-RAY": [
+            "2c83f3d04b7921b6-EWR"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 26 Jul 2016 01:07:01 GMT"
+          ],
+          "Server": [
+            "cloudflare-nginx"
+          ],
+          "Set-Cookie": [
+            "__cfduid=d2845b2596f8ee98872346d6be9b99d891469495221; expires=Wed, 26-Jul-17 01:07:01 GMT; path=/; domain=.reddit.com; HttpOnly"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate",
+            "max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "599.0"
+          ],
+          "x-ratelimit-reset": [
+            "179"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/submit/.json"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/cassettes/test_inject_captcha_into_kwargs_and_raise.json
+++ b/tests/cassettes/test_inject_captcha_into_kwargs_and_raise.json
@@ -1,0 +1,199 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2016-07-22T03:22:49",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "redirect_uri=https%3A%2F%2F127.0.0.1%3A65010%2Fauthorize_callback&grant_type=refresh_token&refresh_token=10640071-oWSCa5YMSWGQrRCa4fMSO_C1bZg"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic c3RKbFVTVWJQUWU1bFE6aVUtTHNPenlKSDdCRFZvcS1xT1dORXEyenVJ"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "141"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "PRAW_test_suite PRAW/3.5.0 Python/3.4.3 b'Linux-3.13.0-92-generic-x86_64-with-Ubuntu-14.04-trusty'"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://api.reddit.com/api/v1/access_token/"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUMpyDi4ID3U2ys/1TnZx9E52yfVLTymL9MoyDlTSUVACq4svqSxIBSlOSk0sSi0CiaeklmUmp8ZnpoCE/fLzUkGCqRUFmUWpxfGZIJONzQwMdBSUipPzIXqLS5NyM0uUagF5KVMcgwAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "CF-RAY": [
+            "2c63c5395d530ed9-EWR"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 22 Jul 2016 03:22:49 GMT"
+          ],
+          "Server": [
+            "cloudflare-nginx"
+          ],
+          "Set-Cookie": [
+            "__cfduid=d10685d693f6ac13f757d61566702d39a1469157769; expires=Sat, 22-Jul-17 03:22:49 GMT; path=/; domain=.reddit.com; HttpOnly"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.reddit.com/api/v1/access_token/"
+      }
+    },
+    {
+      "recorded_at": "2016-07-22T03:22:49",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&sr=reddit_api_test&kind=self&title=captcha+test+will+fail&text=body"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer jCSpWUC2omKcDAKcDmNgdvYJj3Q"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "81"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "PRAW_test_suite PRAW/3.5.0 Python/3.4.3 b'Linux-3.13.0-92-generic-x86_64-with-Ubuntu-14.04-trusty'"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/submit/.json"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWyirOz1OyUqhWSk4sKEnOSFSyUlDKNDZ28SlMy3byMjCKCCgtzK/ytzAo8wvId8zKK8wyCFXSUVBKLSrKLypWslKIjlZycnSJd3YMCHH2cARJJScWpSqU5CuUFFUqlGSkFqcqJKYnZubZQ+QgtsTG1tYCAE5Mcg59AAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "CF-RAY": [
+            "2c63c53a22461882-EWR"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 22 Jul 2016 03:22:49 GMT"
+          ],
+          "Server": [
+            "cloudflare-nginx"
+          ],
+          "Set-Cookie": [
+            "__cfduid=d7c2312bd7d83848b227cf9324d370c531469157769; expires=Sat, 22-Jul-17 03:22:49 GMT; path=/; domain=.reddit.com; HttpOnly"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate",
+            "max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "599.0"
+          ],
+          "x-ratelimit-reset": [
+            "431"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/submit/.json"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/cassettes/test_limit_chars.json
+++ b/tests/cassettes/test_limit_chars.json
@@ -1,0 +1,199 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2016-07-26T03:16:40",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=refresh_token&redirect_uri=https%3A%2F%2F127.0.0.1%3A65010%2Fauthorize_callback&refresh_token=_mmtb8YjDym0eC26G-rTxXUMea0"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic c3RKbFVTVWJQUWU1bFE6aVUtTHNPenlKSDdCRFZvcS1xT1dORXEyenVJ"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "132"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "PRAW_test_suite PRAW/3.5.0 Python/3.4.3 b'Linux-3.13.0-92-generic-x86_64-with-Ubuntu-14.04-trusty'"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://api.reddit.com/api/v1/access_token/"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUPLKrXRL9/LxDCjzcrSICo/IcDc3czQ3yystSlfSUVACq4svqSxIBSlOSk0sSi0CiadWFGQWpRbHZ4IMMTYzMNBRUCpOzocoK0pNTFGqBQA8XWmHbAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "CF-RAY": [
+            "2c84b1b5c6272186-EWR"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 26 Jul 2016 03:16:40 GMT"
+          ],
+          "Server": [
+            "cloudflare-nginx"
+          ],
+          "Set-Cookie": [
+            "__cfduid=dfe124865e8aac9be700d3cc8f351244f1469502999; expires=Wed, 26-Jul-17 03:16:39 GMT; path=/; domain=.reddit.com; HttpOnly"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.reddit.com/api/v1/access_token/"
+      }
+    },
+    {
+      "recorded_at": "2016-07-26T03:16:40",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer JmyFgJLIPvJA8ZWXhG76A76nurg"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "PRAW_test_suite PRAW/3.5.0 Python/3.4.3 b'Linux-3.13.0-92-generic-x86_64-with-Ubuntu-14.04-trusty'"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/comments/4umin7.json"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIABjWllcC/61UTW/bMAz9K4LPRZw0Tdf2tuOAHQpsOxWFIFtMLEQfnkQlK4r+95GyU8fBPg7bzSYfH8lHUk+v1d54XT2I6rNJaPyuuhKVVqjI9Fq5oDuVOvr22VrytJ2xOoIny9MUiutZlA5OGYZUCex2EUFrg1L1RiIkZGijvActm5eJ2YE2SoJrgClf38iUcjPEMtUvWJgd4QfKDp2dmE5mjmKYNXtIZ+682xEBpU8hMmi05wRRRujJyOin50LV5giy1DYhrfF7ubXKRDnmGR2mqHGTnfEfOPM2BidHkUbIjvQrHS7pR0XS81B+t8omYIGtafczy1ASVaZS8O+VqYxdiJzu8eXj46ev1NE3aqAM4qJcrxwwENdyKi21IbJ1xVx9H8PhYh5kiHJ1d1ZIZ7Qukz8ZsMuu8cqw9kXp94HJQQncyGvchFv2UU046+tMxTYl2VqVzqY09Pd7vw7HIgbLSFv6p8FdLJWaCx7BhYOyo75TAjqGdm9mUB7nBDBJ8qaRAWM+uYfGR0QP0Sluk7WoY32xwnUbnAOPqR7GUqdMEdIGv5No0ILEUIASO5DWOIptOxVTXbY6XOwJjQfkaazv60RtDbKvbm7vN+vV6n65YM1yLFPrEPv0UNfH43G80wVV9b9rnQ1zfjLfs4rK08NzXnVh5PK+cBbBWUSxCQyCswjKIkoWUbIIDdS4whCvyGXSiPYAOnFMA8KRMORTXtwtS5BqESiykDfQKrr/Qqthq7JFQSwz5II7GfWUGduTpsvr9UnTnvePLyr3h4AgqSIT2FTcPjt5krEaNvdg0sVVMGjaZcbo4V3OJnUFycK9vZU3gJ45fgJGKRvYDsMfEFfiH972v9M//wT02boXOwYAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "CF-RAY": [
+            "2c84b1b69e022138-EWR"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "661"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 26 Jul 2016 03:16:40 GMT"
+          ],
+          "Server": [
+            "cloudflare-nginx"
+          ],
+          "Set-Cookie": [
+            "__cfduid=d8ee94780440a1390a23085299de1ecde1469503000; expires=Wed, 26-Jul-17 03:16:40 GMT; path=/; domain=.reddit.com; HttpOnly"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Vary": [
+            "accept-encoding"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate",
+            "max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "598.0"
+          ],
+          "x-ratelimit-reset": [
+            "200"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-reddit-tracking": [
+            "https://pixel.redditmedia.com/pixel/of_destiny.png?v=ra7gQMZEj4fGC1ttWPjpEUIyqjjI5qESThczBsx9g8SRZhBo%2F7SaxNUU0jnSYQz0jrpZyOZi%2BJxoMMyc%2BSRxH3Vwl%2F032edm"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/comments/4umin7.json"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/cassettes/test_raise_nonspecific_apiexception.json
+++ b/tests/cassettes/test_raise_nonspecific_apiexception.json
@@ -1,0 +1,199 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2016-07-26T04:20:49",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "redirect_uri=https%3A%2F%2F127.0.0.1%3A65010%2Fauthorize_callback&grant_type=refresh_token&refresh_token=k69WTwa2bEQOQY9t61nItd4twhw"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic c3RKbFVTVWJQUWU1bFE6aVUtTHNPenlKSDdCRFZvcS1xT1dORXEyenVJ"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "132"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "PRAW_test_suite PRAW/3.5.0 Python/3.4.3 b'Linux-3.13.0-92-generic-x86_64-with-Ubuntu-14.04-trusty'"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://api.reddit.com/api/v1/access_token/"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUKo0Nw4ISXV3Dwlxda/Icsww9XMrSHcLMIwv81XSUVACq4svqSxIBSlOSk0sSi0CiadWFGQWpRbHZ4IMMTYzMNBRUCpOzocoKy5Nys0sUaoFAAiA9RNuAAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "CF-RAY": [
+            "2c850fb1960b1882-EWR"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 26 Jul 2016 04:20:49 GMT"
+          ],
+          "Server": [
+            "cloudflare-nginx"
+          ],
+          "Set-Cookie": [
+            "__cfduid=dc354854bc6ec769fdab56eae761bea001469506849; expires=Wed, 26-Jul-17 04:20:49 GMT; path=/; domain=.reddit.com; HttpOnly"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.reddit.com/api/v1/access_token/"
+      }
+    },
+    {
+      "recorded_at": "2016-07-26T04:20:49",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "kind=self&api_type=json&text=BODY&sr=reddit_api_test&title=0000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer y73PTeGGTTEGxjAh5NFpgFP1_vM"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "360"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "PRAW_test_suite PRAW/3.5.0 Python/3.4.3 b'Linux-3.13.0-92-generic-x86_64-with-Ubuntu-14.04-trusty'"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/submit/.json"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWyirOz1OyUqhWSi0qyi8qVrJSiI5WCvH3j/fx93NX0lFQKsnILFbILFYoyc9XyMnPS1fQyE2ssFIwNjDQBEtnluSkKsXG1tYCAKqANltMAAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "CF-RAY": [
+            "2c850fb28edd21b0-EWR"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 26 Jul 2016 04:20:49 GMT"
+          ],
+          "Server": [
+            "cloudflare-nginx"
+          ],
+          "Set-Cookie": [
+            "__cfduid=d1f1a047012202779d5286b4b4ac44a481469506849; expires=Wed, 26-Jul-17 04:20:49 GMT; path=/; domain=.reddit.com; HttpOnly"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate",
+            "max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "599.0"
+          ],
+          "x-ratelimit-reset": [
+            "551"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/submit/.json"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/cassettes/test_raise_not_modified.json
+++ b/tests/cassettes/test_raise_not_modified.json
@@ -1,0 +1,199 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2016-07-25T02:37:16",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "redirect_uri=https%3A%2F%2F127.0.0.1%3A65010%2Fauthorize_callback&refresh_token=_mmtb8YjDym0eC26G-rTxXUMea0&grant_type=refresh_token"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic c3RKbFVTVWJQUWU1bFE6aVUtTHNPenlKSDdCRFZvcS1xT1dORXEyenVJ"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "132"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "PRAW_test_suite PRAW/3.5.0 Python/3.4.3 b'Linux-3.13.0-92-generic-x86_64-with-Ubuntu-14.04-trusty'"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://api.reddit.com/api/v1/access_token/"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUErxNDL3cSs29on0CS0z9cyJ8inNTCuOTCk1TVbSUVACq4svqSxIBSlOSk0sSi0CiadWFGQWpRbHZ4IMMTYzMNBRUCpOzocoK0pNTFGqBQDqusPkbAAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "CF-RAY": [
+            "2c7c3a4f6e6c00ad-EWR"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 25 Jul 2016 02:37:03 GMT"
+          ],
+          "Server": [
+            "cloudflare-nginx"
+          ],
+          "Set-Cookie": [
+            "__cfduid=de5e334179279934d45e118029e04a01e1469414223; expires=Tue, 25-Jul-17 02:37:03 GMT; path=/; domain=.reddit.com; HttpOnly"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.reddit.com/api/v1/access_token/"
+      }
+    },
+    {
+      "recorded_at": "2016-07-25T02:38:07",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer dI27LFs3LYLUv5IlZLuifsYdu5c"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "User-Agent": [
+            "PRAW_test_suite PRAW/3.5.0 Python/3.4.3 b'Linux-3.13.0-92-generic-x86_64-with-Ubuntu-14.04-trusty'"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/reddit_api_test/new.json?limit=25"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAGt7lVcC/+2dC2/bthbHvwpvCmwt0ERvPzoMF21223XPokkxDM0gyJZsq5FEh5TieMu++z2HomRJlm3ZTux1FbAOFkWR5xz++eNDj/x1cu1H7skLcvKTz2M/Gp88JyeuEzuQ9NdJSN2JwyfwO0qCAM4MJ37gMi+ClI9/5ZfGRukql4aOj1lOuBeMzpjnun5sO1Pfjj0eY9aBE0Weaw/mi5JDz/Ud2wsHHhb519+QxJNBei0WVVMKlh57d7E9icMA83wVxN/85/SUXJzbv75+TU5PvxrH32Ci69+SYeBw/u3VSehenWTpU/wxoO4cDxRxdBWJ33BFlikr8RdZYLFqrBWvx7TAv/b4wiGejMdgKLjJKcOMMj3hHrOZN4VEzP3xD1HcMGGeLWKwyBn40bU9Chyf2bIuecIXUTcT9fZOBGLEaGjLxpBZxtBOIpIqHDgM2u1WHI6cgHvYkIE/vC6lpCaBZQ6nUW6Zk8QTyrC6d/OX795egkcfwAHR4BVz+ZAyDw41vGw6ZfS20sSQwGytV6hz4ruuEFOWECWhPaRh6EUiOGh8PEnCQeT4ooVF7DNZ2GkcYsvWY4t28BwU6NmZIVmhYGZccrUQ2CHntlDGwszU5dXnXToT8UHjig1XEa9TDjjzQnrrBDK+hajF0BB+KSs25yKDz21UGyTELMlOp67LHFOPhQ76hNFQmFLpKkoWUCVVjDJ0pvFw4oiTNo3sAU0iUGkWVkWImVbkETkhxhT6ur0Q3hC8SUOrmZ2+1utqlnmGcUmYaK5JHE/5C0WZzWYSA2dgzAOZWGqncge5SRzmRICzogxiPw6EC7JwgoUTGhFROFnQZuGYncTDzDmrZ0jn3JSUic8nwveMYNSt9utbn1ekhwJfZBKhmuIv7W8QTUvUIxM1vpm6g4MRdeZEIKPTKfO4Fw29FqmfI1KFZBQIYOhz7gOqBGY2MzSXWpmhqmloamdPhq6xaWdoLkojadrC9AIlVc00pPnHpKR/5ofjhGGgHg+OmdoK4DoOtEa6SQ8GrQGNR5RxGnozz2cuj5PRqCXX4clVPL8rulA4ikjcjKtMZCVc9Xpdy9CNOlwVuqBCz/UPgx/52aepWF7uzCBcfdRyp9czO5a045jcaWdnjwk6PuO35sFAFycMZDdw/Fhv+XZ4vu0/MxNyUcL5yGc8bka5XGFlylldgEu/jnJbTMrqzdmZhYWC6pFomR1TGn1MJMZeBKa5/MwXw8fjkDCT17GnYjz8lKgHI9QoiYYxTMidwIlSJLeQOiykiud3pRRKRhkNfHsMgrCTKW53cRrcQoe1tX5X5fYU2tezJ/4nB+yKxg0wlsmwjDHTsPodq4oxSbFCP1V4TNlc0TqqZhnWXpR6/eoteQN+kQ9T8mtELlK/iPCLvEO/yPeZX+SUXEoj6olmql1N2t8S7WBEG/XuWqK1RNuGaCAZZUzpOABqOdGYJjG3R+AuNCqjvmuPPUi4hTBS8IpzZ9yQalKKVaoZlrk0OVtHNd3oiSn9zlR7I3wj30vfCPhGXqa+EfSNCN9I7hvhyRSFvwprZlc6cEysfRZr11+8Gd6okTuRZ/ssYytFFekq1x4HoKvuu38ejK6lO7jtovYR6FpYtC7OP+iaFgWjTJkzw5uh2fY+j8GmMM27GaOZ5soY1QzV0pcmh9uucRuZtzN3371/+Ru5WNyIuBAFE5R0PVo1VetKp1q0bkDra+ignkvO5c1xDOo+eK0projYrO88PmK1/vzTwRALdnP818L14eGaZX1EuqJWxA2RAr4aEDWTWIWomqn2evsSdaVJO1MUu2KBovXkVHuWLo1vyfmlkrPjs5acLTkbkRO0UoupDeSUEquSU+8Ze89FV5r02OQ0VWl8S84N5Jx7nPgx8fk+vMwLOQol2U1iJQej5C/zmDktIj9HRAqhKPEEyhRAseGHEzp/Ntr7zFVWAmW3bxkrHr/ZApSbDNsZl1hk+rAgdE4ii6yFZrevm+3zOw2hue/88mgTSnbD+9ctKtMCW1SuIxIIJZ26TSn+LwBrgEvjCCLWBJZSZ1VY6p2+tjcsN5m2My7F7BILfU7SUklaqrg1UYdMoyfdOSYyv6i74Yz2wsPdrxn4g8BXpxM/8FuQHQFkxfO7kgwFo8woC0CUMUDLBs14dx63J/54As1DIzuZDqBv2wm3vSGNaOgPGyAuE2IFcbpudre4F251VMsy96LWb+gbuUDfyNvUN/K98A1frfsgfCMfLsj/pG/kvVB9PdN6faMj7T8m076o10dY0OkJNw/CtMsZ0Iy+B7Ws2+nT8ZoWaf9MpKFeGr41kmurjKle19DVbg2mii+NROfsx+T3eO+XRrL+V0Mb0zSlGY9BG72lTR1tjE+Tg9HmUxL5lDlu6EeXE0ZnL2dO+1Th54odEE5j7EiRVbGj68bS9wkq2On7P8+77nePih3DlGY8BnaaTnLmzp+uA2r/Qrjj3jHRzw7Cnd8xtq+oiMjjswaLalnzkKxBsQjWNNucz7RVxk230++Ztc9/VLvezpDBLaOVe+pdU1Nl/cfkzJe1QTSgN6I5DoKZdoPo80cNCkYJkyD2p4FnD2g4gI7KbYZ7RdxJXN8GAAzAGT8aBnDYCEiZCitAMiyjdtm1anfI1AyjtxegfpaOkcwxgo6RC3SMvBSOPSe5Z+RnaLbIIU7kwj/yMvSYP4QfiKQVjFM71iMu4VrG1TLO9VrGtYzbgnEgGIXPme9EYMooGXtgParD4/bA4xi+Twn2Xjtmies5CcCuCeWkDiuU0/uqunSbby3lLG0/yl0I14h0jUjXSOoa+UG4Ri5T14B25NyJHBevmDLMMIWy3ZWAU3XpTQu4gwFuMBPfNGoB1wKuGeBAMIofO8Hc5qHDkWsM/A088DP0x4iOmDmjERoVje2x02wWJ2VY5VtP6y49HLuWb8aefHuLnhHpGck8I9Kz04JrBF2rJ1mn3zek3S3JDkay/t2gJVlLsuYkA8EoMBEDOUQOvrQPazAbv1AKgQM+gIEOhlC8wR/4I6/hTE3KsEqyrrb89Oo6kqm6IZpxd5LB5As9e05eC9fIu4Jr5CXOxt7gC/w/gWsEMr9jPrQG+RWUSV4xH2Z0+KI/OaeMJVP8UsUq1vWy53Jb1h2KdT1Hv21Z17KuMetQMEo8wcVnRG0+dYbeEKYysViMgnEQOlCNDTm4Z0Mn96bzBqzLZFhmXaenm9Y2e29Gz+z392Ld5QTXnhElC88IekYyz4jwjKSeEY5fQefEYeJr6D8kUxBK8d2sIt4soyOdOSbeUAr/+Kf1pwEEf0KBP4xgcfs8uV8t6zic7YwnNy1nvxDOPsDD/KgXpSDdpl9Iz4VWIallaP2l9e+2j/GvMWpn4Ja6p0hcGF+kp24a0oGWnhvoicXtQ8zMnINT8ubOjw/3VO1hnzdpCfmwhBRaafhoW66rMhQtVTXUpQf/t4RixY6dOZh1umX0mV3Nkma26NuAvnce86kLTvXPdIu4zrz0knyKwtgZBF52FczmHXeByZgVfk8ISHEcQT1DaGuPLeqCBVBtPuaPJ3Ga7SL/4kFqwuYrzqWmlrIrRatw7ZVaLEoS36WvN99daT6PGY3GeHRJYycQxS7S0lqKQVmUVDDXbJhPX8pX8mdrk99D9yBPARTYvM92s10907WGWc3embHs6n4ufIj8m8Qj70U3oCxt8a2dMBrmW/Z0P+vPxVMpsBK+wMFpN9uXI1qfb4N4lFz/6VHWs7OuPmFK6dDAo0s6Tb9HEoOD/CsnnH7zxOh/Q/L0Qq9Nr8iup8Gi6sDPqhVw0ck05s+JXvg6Jn9B8LRDJswbgVsKTpSU8vckUy/LaaJiJ3eqxK56C/IqsvELPyZ4hrsjAAuXDsUeiawKvwb4HR0miBoHN2MX1ZGnGnjxvGL1YqgL/dm1JTsQkcmLq9OumBr1oAbCZGFOClFpYCbL+nkTM5U0qEvplRZOK9UKDVzbvsPwJvGjqN9NLcgPFxaIX7u06hazkuBOj3rprCS1I18TNAqhuFz2wCyEaYc4SAx5TMOhwwKampAfHjaGn67Hs+HyHwSTNi0+qCmSm8dWFPsA8pTpG1EnpxWIOryqCdG2ljR5mvMvc3SlIxsN3oXBx2jnwXw37T60QB4mCpuIUe9tE2ms93Zr1Kxxd5tRZaNr2wzUm5z8p4ycB/F0l8F3IxQkxZoRAU2sHVg2yzWfDvKVLqY9RXGNG95Nkv8OaYQL1281WWbVZ3x2Me9Ly418KFuTOee721pppgFut9wkNJazbUwTo/EbL/IY7l+QmQ+r3IpbymBAvbTqV69ogaWrPMlEP4bCkoFgGOr/1PVuxY+Y0oCnBV5kGwzkAsRfIIiwN5PVxfsL8rPDrj0m9lYs1epone6ZKrIXt0vrPNxmD3V5IwJjd39fGNzuM03fX0UvTl/cn6b/riLbFsty274373U8LC95IR3Xr/diZYqnq8tJyGDca3jmvLRUywq8ik5PT6+iJ0+elJdCX1eXQFeRekbqVzYfy4D442kdSp5dRYRAER+X0fTH03VAe5Zh5mMOEaihwtNna4pPybd3JSzGSkQY6qauH/NOmfmfJ+S2YXda2LHbgLywdDFElkwVedebmk9EMlPzhNzU6lxnJ7NXzKY2BVtclnpQFKfsIiBO4dm6gNfNQavFVbX9yC7DcLsu7k1D8nAyQoPWhrChzOo73abuhrU3wsaGwOS9v96MZn3/AY3JKFEj3FRm6Ri/LvJfczhdU/qqucazbKR+sPLL84NC+TD2LQ/sH3H8xmrEkC6KrwzAi/ivHbyfEbJ6VC7ehDzYn5eht2x+uG/Ttn9e5vO/FSkUg/yXWTjqX3zpkNuiWF3VOqqldeyYpr87qrn5rmUuxNJdy46pdq3O0gPAW44Ku5u88w3OCh9eiK82coK1EazhVLVOtQ6JqTyC/0yi9l+oOnn33WXtrdGO0e11ZSyOeWu0ZoR5vDujmcJXPDp8ME6Kge9fzUn8oFrLyQd8eFhIJv1LV25xxmbDjM3WNxMxl1yJiJbaM/s4XXi+RMSajrkfxFbNNmvxlM9jnrd4OgaersWf4f3X4qmdxj08nq6tGjw1AlMqtiUw9Xq1T93WdMmHBtNKJKnSpEdCkugYI3wNohqcgTdKtYc1/f33/wFpgsULRpMAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "CF-RAY": [
+            "2c7c3aff6851213e-EWR"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "3862"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Mon, 25 Jul 2016 02:37:31 GMT"
+          ],
+          "Server": [
+            "cloudflare-nginx"
+          ],
+          "Set-Cookie": [
+            "__cfduid=d121c98cc91131277cb0bdb53a5cbbb9e1469414251; expires=Tue, 25-Jul-17 02:37:31 GMT; path=/; domain=.reddit.com; HttpOnly"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Vary": [
+            "accept-encoding"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate",
+            "max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "598.0"
+          ],
+          "x-ratelimit-reset": [
+            "149"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-reddit-tracking": [
+            "https://pixel.redditmedia.com/pixel/of_destiny.png?v=g15lyS0W69e4Sz0MBUvPV16jwmRfBZG9mQAjxSORDHYV7XuXCuMpNXgIwKlxNGN13yMOH5A7Jc%2FQpRUla00qRNTqLKJK8efc"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/reddit_api_test/new.json?limit=25"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/cassettes/test_solve_captcha_on_bound_subreddit.json
+++ b/tests/cassettes/test_solve_captcha_on_bound_subreddit.json
@@ -1,0 +1,399 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2016-07-22T03:32:07",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "redirect_uri=https%3A%2F%2F127.0.0.1%3A65010%2Fauthorize_callback&grant_type=refresh_token&refresh_token=10640071-oWSCa5YMSWGQrRCa4fMSO_C1bZg"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "Basic c3RKbFVTVWJQUWU1bFE6aVUtTHNPenlKSDdCRFZvcS1xT1dORXEyenVJ"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "141"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "PRAW_test_suite PRAW/3.5.0 Python/3.4.3 b'Linux-3.13.0-92-generic-x86_64-with-Ubuntu-14.04-trusty'"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://api.reddit.com/api/v1/access_token/"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWSkxOTi0uji/Jz07NU7JSUHJzSg8OLy7IMzQsi6ioKDLJDQjxMS4qMUnyzVbSUVACq4svqSxIBSlOSk0sSi0CiaeklmUmp8ZnpoCE/fLzUkGCqRUFmUWpxfGZIJONzQwMdBSUipPzIXqLS5NyM0uUagHrsTIJgwAAAA==",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "CF-RAY": [
+            "2c63d2d80a42187c-EWR"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 22 Jul 2016 03:32:07 GMT"
+          ],
+          "Server": [
+            "cloudflare-nginx"
+          ],
+          "Set-Cookie": [
+            "__cfduid=df6301b91bb5a46ee6c81b977462c7f8f1469158327; expires=Sat, 22-Jul-17 03:32:07 GMT; path=/; domain=.reddit.com; HttpOnly"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://api.reddit.com/api/v1/access_token/"
+      }
+    },
+    {
+      "recorded_at": "2016-07-22T03:32:07",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "title=captcha+test+on+bound+subreddit&kind=self&sr=reddit_api_test&text=body&api_type=json"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer FBgSWspn11vXxxr4mPTL3rt4bMk"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "90"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "PRAW_test_suite PRAW/3.5.0 Python/3.4.3 b'Linux-3.13.0-92-generic-x86_64-with-Ubuntu-14.04-trusty'"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/submit/.json"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAA6tWyirOz1OyUqhWSk4sKEnOSFSyUlAKSMpOM6vwr8xO83DzqQg1CvUvD0zK9fMITK50zKiMTFfSUVBKLSrKLypWslKIjlZycnSJd3YMCHH2cARJJScWpSqU5CuUFFUqlGSkFqcqJKYnZubZQ+QgtsTG1tYCAJ7Y1tx9AAAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "CF-RAY": [
+            "2c63d2d8dd4d218c-EWR"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 22 Jul 2016 03:32:07 GMT"
+          ],
+          "Server": [
+            "cloudflare-nginx"
+          ],
+          "Set-Cookie": [
+            "__cfduid=df116b8ff49d6122c1d6140cdfef90ce41469158327; expires=Sat, 22-Jul-17 03:32:07 GMT; path=/; domain=.reddit.com; HttpOnly"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate",
+            "max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "599.0"
+          ],
+          "x-ratelimit-reset": [
+            "473"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/submit/.json"
+      }
+    },
+    {
+      "recorded_at": "2016-07-22T03:32:34",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "kind=self&text=body&captcha=DFIRSW&title=captcha+test+on+bound+subreddit&api_type=json&sr=reddit_api_test&iden=Pbkf6xOykfHFLxU2UOwQbmNHQcyAhyYg"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Authorization": [
+            "bearer FBgSWspn11vXxxr4mPTL3rt4bMk"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "143"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "__cfduid=df116b8ff49d6122c1d6140cdfef90ce41469158327"
+          ],
+          "User-Agent": [
+            "PRAW_test_suite PRAW/3.5.0 Python/3.4.3 b'Linux-3.13.0-92-generic-x86_64-with-Ubuntu-14.04-trusty'"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/submit/.json"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIAAAAAAAAAy2NQQrDIBBFryKzDplCu/IqpYhRIZbqiI41ELx7MXb53ufxT3gXiiDFCS5nygWkeL4WAVazvnTNH5ACduZUJGJrbc3OWs+roYAZJyidvGJXGA2F4CIXfNTb92A0OrHZ9TUqimqjGq0qdZshwiLA23Exg8FRBzcM39Vf9t5/LKcTyasAAAA=",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "CF-RAY": [
+            "2c63d383e5d6218c-EWR"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 22 Jul 2016 03:32:34 GMT"
+          ],
+          "Server": [
+            "cloudflare-nginx"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Transfer-Encoding": [
+            "chunked"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate",
+            "max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "598.0"
+          ],
+          "x-ratelimit-reset": [
+            "446"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/submit/.json"
+      }
+    },
+    {
+      "recorded_at": "2016-07-22T03:32:34",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "gzip, deflate"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "__cfduid=df116b8ff49d6122c1d6140cdfef90ce41469158327"
+          ],
+          "User-Agent": [
+            "PRAW_test_suite PRAW/3.5.0 Python/3.4.3 b'Linux-3.13.0-92-generic-x86_64-with-Ubuntu-14.04-trusty'"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://www.reddit.com/r/reddit_api_test/comments/4u0vxt/captcha_test_on_bound_subreddit/.json"
+      },
+      "response": {
+        "body": {
+          "base64_string": "H4sIANKTkVcC/61UTWvcMBD9K64POWXjbJNN04QeSiFQKG2gzWkThGxp12L14Uojb0LIf++MbNdr0w8ovUlvnkYz8560fs53yor8Kss/qQDKbvPjLBccOELPuXGi5qGmMOFVrbTw0uJ+PR6Es8kZ4QxXRMmD1JsTL4VQwHijGMgARC25tVKw8glJNmqNkJFCcSZNKSnl8wtCIZbdWUr1iyyUHeQjsBqMJs6RhutXi0X29QP7cnOTLRZHW7gmUKg2qzQP4d19bsR9PuANLUonnmhTpN29TWs8MZCGjJ/7hIdX0610njCtdjKMDYW43WKh2GZwnog9HoP0zMsGQWKvH1K6KnrJ0gxGplZ2xzaaK8/6u/qASlM/j6ftYxrExjvDejF6yhZ1SpM8xQ33qFubthuugyQhtap2E6QrCSvjwdmDPniE2nm68Pbp/e3Hb9jTHbaQJJ8VbLmRRIQzNhYXKucJXVKupvGunSmPgGfLy4NSaiVE8tgAQB1NablKKqekgzVYNwtYsdewchcUw5pg0tnBHKsQWDLCvL/fx4Xbp3HQIPE1/Em6mX35dOReGtdy3U94vAAfXbVTEyoJOhJUYOQ3BMDHIdw13jMa6Q2nNmkWhS9mj6WonDHSQig6WYqKN1DVPAWZs6x00aJPh6EWyc5uZhBURbJBzb6SCpvphr08v3i7vHyzXJ2f0KSiT1rVAE24Kor9ft//AydYy3+qcKLc9IV8j9xzi78Z1frTRQp08mefPKPkmbNZSp6N383YGItQDc2tLs+G5hqSnwwdm9aBZJ6DcgSlsI2GDf3knXFaFWamJNJopcFr3Q8cVagTmeCXF7IZx++GHmFPLOWm06FjHGf//Iv/PfnDD8D+QvkjBgAA",
+          "encoding": "UTF-8"
+        },
+        "headers": {
+          "CF-RAY": [
+            "2c63d38559f621da-EWR"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Encoding": [
+            "gzip"
+          ],
+          "Content-Length": [
+            "660"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 22 Jul 2016 03:32:34 GMT"
+          ],
+          "Server": [
+            "cloudflare-nginx"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Vary": [
+            "accept-encoding"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "access-control-allow-origin": [
+            "*"
+          ],
+          "access-control-expose-headers": [
+            "X-Reddit-Tracking, X-Moose"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-reddit-tracking": [
+            "https://pixel.redditmedia.com/pixel/of_destiny.png?v=eucwa3TrvGvVF1MFFg0tZHPm9z%2BHkzecJhctrIuL9fhOhlArd1TDzOFZoMgBj0eNQZYeUELqnyAfzt3w%2BDZ0hMwyG6yLUS3h"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/r/reddit_api_test/comments/4u0vxt/captcha_test_on_bound_subreddit/.json"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.5.1"
+}

--- a/tests/helper.py
+++ b/tests/helper.py
@@ -30,8 +30,9 @@ class BodyMatcher(BaseMatcher):
     name = 'PRAWBody'
 
     def match(self, request, recorded_request):
-        if request.headers.get('SKIP_BETAMAX', 0) > 0:
-            request.headers['SKIP_BETAMAX'] -= 1
+        skip_betamax = int(request.headers.get('SKIP_BETAMAX', 0))
+        if skip_betamax > 0:
+            request.headers['SKIP_BETAMAX'] = str(skip_betamax - 1)
             return False
         if not recorded_request['body']['string'] and not request.body:
             return True

--- a/tests/mock_response.py
+++ b/tests/mock_response.py
@@ -1,0 +1,118 @@
+from mock import MagicMock
+from functools import wraps
+from json import dumps
+from requests.structures import CaseInsensitiveDict
+
+
+class MockResponse(MagicMock):
+    """Mock a response.
+
+    This provides an object to mock a response given a real response and values
+    that want to be changed. All attributes passed have priority over the real
+    responses, which are used as a fallback, except when it comes to headers.
+    With headers, any headers that are not set are taken from the real
+    response if they exist. This is to ensure there won't be inconsistencies
+    with the necessary headers.
+
+    Recommended usage is as follows:
+
+    1. Record the request(s) that need to be mocked via the betamax() factory
+        decorator in helper.py
+
+    2. Pass pass_recorder=True to betamax() and add a recorder argument to the
+        test function
+
+    3. The responses that you may wish to mock are available as the
+        'recorded_response' attribute on the recorder's current cassette
+        interaction. It's easiest to determine the interaction that you
+        will need to mock via a debugger.
+
+    The request content is determined from it's json, which is given as a
+    dictionary/list. This is because all reddit api responses are valid json.
+    If you must, you can set the text attribute as well, but this is only used
+    if json is None.
+
+    You can use the `as_context` method to use a context manager, or
+    `as_decorator` to use this as a decorator and pass the mocked response as
+    an extra argument.
+
+    """
+    def __init__(self, real_response, status_code=None, json=None,
+                 raise_for_status=None, close=None, reason=None, cookies=None,
+                 apparent_encoding=None, encoding=None, history=None,
+                 headers=None, elapsed=None, _content_consumed=None,
+                 parent=None, text=None, **kwargs):
+        super(MockResponse, self).__init__(spec=real_response)
+        self.real_response = real_response
+        self.apparent_encoding = apparent_encoding or \
+            real_response.apparent_encoding
+        self.close = close or real_response.close
+        self.json = (lambda: json) if json else real_response.json
+        self.text = dumps(self.json()) if json else text
+        self._content_consumed = _content_consumed or \
+            real_response._content_consumed
+        self.content = self.text.encode()
+        self.parent = parent
+        for k, v in kwargs.items():
+            setattr(self, k, v)
+        self._content = self.content
+        self.history = history if history else \
+            ([] or real_response.history)
+        self.elapsed = elapsed if elapsed else \
+            (type(real_response.elapsed)() or real_response.elapsed)
+        self.cookies = cookies if cookies else \
+            (type(real_response.cookies)() or real_response.cookies)
+        self.encoding = encoding or real_response.encoding
+        self.iter_content = iter(self.content)
+        self.iter_lines = iter([self.content])
+        self.raise_for_status = raise_for_status or \
+            real_response.raise_for_status
+        self.raw = real_response.raw
+        self.status_code = status_code or real_response.status_code
+        self.headers = CaseInsensitiveDict(headers) if headers else \
+            CaseInsensitiveDict()
+        for name, val in real_response.headers.items():
+            self.headers.setdefault(name, val)
+        self.reason = reason or real_response.reason
+        self.is_permanent_redirect = \
+            ('location' in self.headers and self.status_code in [301, 308])
+        self.ok = 200 <= self.status_code < 300
+
+    @classmethod
+    def in_place(cls, holder, attribute='recorded_response',
+                 *args, **kwargs):
+        setattr(holder, attribute, cls(getattr(holder, attribute),
+                                       *args, **kwargs))
+
+    @classmethod
+    def as_context(cls, holder, attribute='recorded_response',
+                   *args, **kwargs):
+        class in_context(object):
+            def __init__(self, holder, attribute, *args, **kwargs):
+                self.holder, self.attribute, self.args, self.kwargs = \
+                    holder, attribute, args, kwargs
+
+            def __enter__(self):
+                cls.in_place(self.holder, self.attribute, *self.args,
+                             **self.kwargs)
+                return getattr(self.holder, self.attribute)
+
+            def __exit__(self, exc_type, exc_val, exc_trace):
+                setattr(self.holder, self.attribute,
+                        getattr(self.holder, self.attribute).real_response)
+        return in_context(holder, attribute, *args, **kwargs)
+
+    @classmethod
+    def as_decorator(cls, holder, attribute='recorded_response',
+                     *args, **kwargs):
+        def factory(func):
+            @wraps(func)
+            def wrapped(*a, **kw):
+                with cls.as_context(holder, attribute,
+                                    *args, **kwargs) as resp:
+                    a = list(a)
+                    a.append(resp)
+                    a = tuple(a)
+                    return func(*a, **kw)
+            return wrapped
+        return factory

--- a/tests/test_authenticated_reddit.py
+++ b/tests/test_authenticated_reddit.py
@@ -23,7 +23,7 @@ class AuthenticatedRedditTest(PRAWTest):
 
         # Headers are not included in the cached key so this will have no
         # affect when the request is cached
-        self.r.http.headers['SKIP_BETAMAX'] = 1
+        self.r.http.headers['SKIP_BETAMAX'] = '1'
 
         cached_listing = list(subreddit.get_new(limit=5))
         self.assertEqual(original_listing, cached_listing)

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -1,11 +1,15 @@
 from __future__ import print_function, unicode_literals
 
-import unittest
+from .helper import OAuthPRAWTest, betamax
+from .mock_response import MockResponse
+from praw import errors
 from praw.decorator_helpers import _make_func_args
 from praw.decorators import restrict_access
+from praw.internal import _modify_relationship
+from six import text_type
 
 
-class DecoratorTest(unittest.TestCase):
+class DecoratorTest(OAuthPRAWTest):
     def test_require_access_failure(self):
         self.assertRaises(TypeError, restrict_access, scope=None,
                           oauth_only=True)
@@ -21,3 +25,100 @@ class DecoratorTest(unittest.TestCase):
 
         self.assertEqual(_make_func_args(foo), arglist)
         self.assertEqual(_make_func_args(bar), arglist)
+
+    def test_restrict_access_permission_errors(self):
+        # PRAW doesn't currently use _modify_relationship for friending but
+        # this same check might be needed in the future, so, lets use this to
+        # our advantage, temporarily bind a custom unfriend function, ensure
+        # the proper error is raised, and then, unbind this function.
+        redditor = self.r.get_redditor(self.un)
+        redditor.temp_make_friend = _modify_relationship('friend')
+        self.assertRaises(errors.LoginRequired, redditor.temp_make_friend,
+                          thing=None, user=self.other_user_name)
+        del redditor.temp_make_friend
+
+        # PRAW doesn't currently use restrict_access for mod duties without
+        # setting a scope but this might be needed in the future, so, lets use
+        # _modify_relationship  to our advantage, temporarily bind a custom
+        # nonsense function, ensure the proper error is raised, and then,
+        # unbind this function. This can also be used to detect the
+        # ModeratorRequired exception from restrict_access as PRAW doesn't have
+        # any functions that would ordinarily end in this outcome, as all
+        # moderator reddit endpoints are oauth compatible.
+        subreddit = self.r.get_subreddit(self.sr)
+        type(subreddit).temp_nonsense = _modify_relationship('nonsense')
+        self.assertRaises(errors.LoginRequired,
+                          subreddit.temp_nonsense, user=self.un)
+        self.r.login(self.other_non_mod_name, self.other_non_mod_pswd,
+                     disable_warning=True)
+        subreddit = self.r.get_subreddit(self.sr)
+        self.assertRaises(errors.ModeratorRequired,
+                          subreddit.temp_nonsense, user=self.un)
+        del type(subreddit).temp_nonsense
+
+        # PRAW doesn't currently have a method in which the subreddit
+        # is taken from function defaults, so, let's write one instead
+        @restrict_access(mod=True, scope=None)
+        def fake_func(obj, **kwargs):
+            return None
+        type(self.r).fake_func = fake_func
+        self.assertRaises(errors.ModeratorRequired, self.r.fake_func)
+        del type(self.r).fake_func
+
+    @betamax()
+    def test_error_list(self):
+        # use the other account to get a InvalidCaptcha
+        self.r.refresh_access_information(self.other_refresh_token['submit'])
+        # implicitly tests the RateLimitExceeded Exception as well
+        err_list = self.assertExceptionList(
+            [errors.InvalidCaptcha, errors.RateLimitExceeded], self.r.submit,
+            self.sr, "test ratelimit error 1", 'ratelimit error test call 1')
+        captcha_err, ratelimit_err = err_list.errors
+        self.assertEqual('`{0}` on field `{1}`'.format(captcha_err.message,
+                                                       captcha_err.field),
+                         str(captcha_err))
+        self.assertEqual('`{0}` on field `{1}`'.format(ratelimit_err.message,
+                                                       ratelimit_err.field),
+                         str(ratelimit_err))
+        expected_list_str = '\n' + "".join(
+            '\tError {0}) {1}\n'.format(i, text_type(error))
+            for i, error in enumerate(err_list.errors))
+        self.assertEqual(expected_list_str, str(err_list))
+
+    @betamax()
+    def test_limit_chars(self):
+        self.r.refresh_access_information(self.refresh_token['read'])
+        submission = self.r.get_submission(
+            submission_id=self.submission_limit_chars_id)
+        before_limit = text_type(
+            '{0} :: {1}').format(
+            submission.score,
+            submission.title.replace('\r\n', ' '))
+        expected = before_limit[:self.r.config.output_chars_limit - 3]
+        expected += '...'
+        self.assertEqual(str(submission), expected)
+        self.assertLess(str(submission), before_limit)
+
+    @betamax()
+    def test_raise_nonspecific_apiexception(self):
+        self.r.refresh_access_information(self.refresh_token['submit'])
+        err = self.assertRaisesAndReturn(errors.APIException,
+                                         self.r.submit, self.sr,
+                                         "".join("0" for i in range(301)),
+                                         "BODY")
+        self.assertEqual('({0}) `{1}` on field `{2}`'.format(err.error_type,
+                                                             err.message,
+                                                             err.field),
+                         str(err))
+
+    @betamax(pass_recorder=True)
+    def test_raise_not_modified(self, recorder):
+        self.r.refresh_access_information(self.refresh_token['read'])
+        with MockResponse.as_context(
+                recorder.current_cassette.interactions[-1], status_code=304,
+                reason="Not Modified", json={'error': 304},
+                headers={"Content-Length": 1}):
+            err = self.assertRaisesAndReturn(
+                errors.NotModified, list, self.r.get_subreddit(
+                    self.sr).get_new(limit=25))
+        self.assertEqual(str(err), 'That page has not been modified.')

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -2,27 +2,11 @@
 
 from __future__ import print_function, unicode_literals
 
-from functools import wraps
 from mock import patch
 from praw import handlers
 from random import choice
 from six.moves import cStringIO
-from .helper import PRAWTest, betamax
-
-
-def replace_handler(new_handler):
-    def factory(func):
-        @wraps(func)
-        def wrapped(obj):
-            old_handler = obj.r.handler
-            obj.r.handler = new_handler
-            try:
-                retval = func(obj)
-            finally:
-                obj.r.handler = old_handler
-            return retval
-        return wrapped
-    return factory
+from .helper import PRAWTest, betamax, replace_handler
 
 
 class HandlerTest(PRAWTest):

--- a/tests/test_oauth2_reddit.py
+++ b/tests/test_oauth2_reddit.py
@@ -35,13 +35,7 @@ class OAuth2RedditTest(PRAWTest):
     # @betamax() is currently broken for this test because the cassettes
     # are caching too aggressively and not performing a token refresh.
     def test_auto_refresh_token(self):
-        self.r.set_oauth_app_info(
-            'IlQgN8A5fPCbpA',
-            '7iYM6T1rh8REihHQEVNgQsE16OE',
-            'http://localhost:8080'
-        )
-        self.r.refresh_access_information(
-            '7302867-l3Gl-kyNxcLJxbr2xn8Q3Ao42UA')
+        self.r.refresh_access_information(self.refresh_token['identity'])
         old_token = self.r.access_token
 
         self.r.access_token += 'x'  # break the token

--- a/tests/test_oauth2_reddit.py
+++ b/tests/test_oauth2_reddit.py
@@ -170,7 +170,7 @@ class OAuth2RedditTest(PRAWTest):
 
         # Test error conditions
         self.assertRaises(TypeError, sub.gild, months=1)
-        for value in (False, 0, -1, '0', '-1'):
+        for value in (False, 0, -1, '0', '-1', 37, '37'):
             self.assertRaises(TypeError, redditor.gild, value)
 
         # Test object gilding


### PR DESCRIPTION
## Feature Summary and Justification

This feature provides various tests and a proper fix to the auto refresh test. Additionally, some convenience methods / classes / another module is added for

* being able to avoid betamax caching too harshly by adding a dummy header value and matching against it sequentially
* tests that need the new tokens because the client ids, secrets, and refresh uris unfortunately have to match or reddit will abort the request
* Mocking a response


respectively. Sorry about being late and this being a tad longer than the previous ones.