### PR TITLE
Pin test dep versions for tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -4,10 +4,10 @@ skip_missing_interpreters = true
 
 [testenv]
 deps =
-    betamax
-    betamax-matchers
+    betamax<0.8,>=0.7.1
+    betamax-matchers<0.3,>=0.2.0
     flake8
-    mock
+    mock==1.0.1
 commands =
     python setup.py test
     flake8 praw


### PR DESCRIPTION
## Feature Summary and Justification

This patch fixes an error when running tox against the project. If these versions are not pinned, then tox encounters errors when creating the virtualenv for tests.