### PR TITLE
Change Auth.authorize method to set Authorizer on Reddit

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -21,4 +21,5 @@ Documentation Contributors
 Source Contributors
 ===================
 
+- William McKinnerney <me@williammck.net> `@williammck <https://github.com/williammck>`_
 - Add "Name <email (optional)> and github profile link" above this line.

--- a/praw/models/auth.py
+++ b/praw/models/auth.py
@@ -24,7 +24,7 @@ class Auth(PRAWBase):
             raise ClientException('authorize can only be used with web apps.')
         authorizer = Authorizer(authenticator)
         authorizer.authorize(code)
-        self._core = self._authorized_core = session(authorizer)
+        self._reddit._core = self._reddit._authorized_core = session(authorizer)
         return authorizer.refresh_token
 
     def implicit(self, access_token, expires_in, scope):

--- a/praw/models/auth.py
+++ b/praw/models/auth.py
@@ -24,7 +24,8 @@ class Auth(PRAWBase):
             raise ClientException('authorize can only be used with web apps.')
         authorizer = Authorizer(authenticator)
         authorizer.authorize(code)
-        self._reddit._core = self._reddit._authorized_core = session(authorizer)
+        authorized_session = session(authorizer)
+        self._reddit._core = self._reddit._authorized_core = authorized_session
         return authorizer.refresh_token
 
     def implicit(self, access_token, expires_in, scope):


### PR DESCRIPTION
Currently, the `Auth.authorize` method sets the Authorizer on the Auth instance, not the Reddit instance. This prevents Reddit.read_only from being set to False, and does not initialize a session on the Reddit instance.