### PR TITLE
Add praw.models.LiveHelper.__call__

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -23,4 +23,5 @@ Source Contributors
 
 - William McKinnerney <me@williammck.net> `@williammck <https://github.com/williammck>`_
 - Katharine Jarmul <katharine@kjamistan.com> `@kjam <https://github.com/kjam>`_
+- nmtake `@nmtake <https://github.com/nmtake>`_
 - Add "Name <email (optional)> and github profile link" above this line.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,8 @@ Unreleased
 
 * :meth:`praw.models.Subreddits.search_by_topic` to search subreddits by topic.
   (see: https://www.reddit.com/dev/api/#GET_api_subreddits_by_topic).
+* :meth:`praw.models.LiveHelper.__call__` to provide interface to
+  `praw.models.LiveThread.__init__`.
 * :class:`.SubredditFilters` to work with filters for special subreddits, like
   ``/r/all``.
 * Added callables for :class:`.SubredditRelationship` so that ``limit`` and

--- a/praw/models/helpers.py
+++ b/praw/models/helpers.py
@@ -3,11 +3,25 @@ from json import dumps
 
 from ..const import API_PATH
 from .base import PRAWBase
+from .reddit.live import LiveThread
 from .reddit.multi import Multireddit, Subreddit
 
 
 class LiveHelper(PRAWBase):
     """Provide a set of functions to interact with LiveThreads."""
+
+    def __call__(self, id):  # pylint: disable=invalid-name,redefined-builtin
+        """Return a new lazy instance of :class:`~.LiveThread`.
+
+        This method is intended to be used as:
+
+        .. code:: python
+
+            livethread = reddit.live('ukaeu1ik4sw5')
+
+        :param id: A live thread ID, e.g., ``ukaeu1ik4sw5``.
+        """
+        return LiveThread(self._reddit, id=id)
 
     def create(self, title, description=None, nsfw=False, resources=None):
         """Create a new LiveThread.

--- a/praw/models/reddit/live.py
+++ b/praw/models/reddit/live.py
@@ -8,5 +8,32 @@ class LiveThread(RedditBase):
 
     STR_FIELD = 'id'
 
+    def __eq__(self, other):
+        """Return whether the other instance equals the current.
+
+        Note that this comparison is case sensitive.
+        """
+        if isinstance(other, str):
+            return other == str(self)
+        return (isinstance(other, self.__class__) and
+                str(self) == str(other))
+
+    def __hash__(self):
+        """Return the hash of the current instance."""
+        return hash(self.__class__.__name__) ^ hash(str(self))
+
+    def __init__(self, reddit, id=None,  # pylint: disable=redefined-builtin
+                 _data=None):
+        """Initialize a lazy :class:``LiveThread`` instance.
+
+        :param reddit: An instance of :class:`.Reddit`.
+        :param id: A live thread ID, e.g., ``ukaeu1ik4sw5``
+        """
+        if bool(id) == bool(_data):
+            raise TypeError('Either `id` or `_data` must be provided.')
+        super(LiveThread, self).__init__(reddit, _data)
+        if id:
+            self.id = id  # pylint: disable=invalid-name
+
     def _info_path(self):
         return API_PATH['liveabout'].format(id=self.id)

--- a/tests/integration/cassettes/TestLiveThread_test_init.json
+++ b/tests/integration/cassettes/TestLiveThread_test_init.json
@@ -1,0 +1,110 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2016-12-07T13:19:43",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=client_credentials"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "29",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "<USER_AGENT> PRAW/4.0.0 prawcore/0.3.0"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"G3zyP28RIGbbTocu0s9pcj9KWI0\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Wed, 07 Dec 2016 13:18:22 GMT",
+          "Server": "snooserv",
+          "Set-Cookie": "loid=AFJaYzUOC19PMMpeZ5; Domain=reddit.com; Max-Age=63071999; Path=/;  secure",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-nrt6135-NRT",
+          "X-Timer": "S1481116702.528734,VS0,VE193",
+          "cache-control": "max-age=0, must-revalidate",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2016-12-07T13:19:43",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer G3zyP28RIGbbTocu0s9pcj9KWI0",
+          "Connection": "keep-alive",
+          "Cookie": "loid=AFJaYzUOC19PMMpeZ5; loidcreated=1481116702000",
+          "User-Agent": "<USER_AGENT> PRAW/4.0.0 prawcore/0.3.0"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/api/live/ukaeu1ik4sw5/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"LiveUpdateEvent\", \"data\": {\"description\": \"A reddit-official thread detailing smaller site changes and links to larger ones (like in /r/changelog or /r/blog).\", \"description_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EA reddit-official thread detailing smaller site changes and links to larger ones (like in \\u003Ca href=\\\"/r/changelog\\\" rel=\\\"nofollow\\\"\\u003E/r/changelog\\u003C/a\\u003E or \\u003Ca href=\\\"/r/blog\\\" rel=\\\"nofollow\\\"\\u003E/r/blog\\u003C/a\\u003E).\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"title\": \"reddit updates\", \"created\": 1426290512.0, \"created_utc\": 1426261712.0, \"websocket_url\": \"wss://wss.redditmedia.com/live/ukaeu1ik4sw5?m=AQAAn11JWDTuVuoWUCLUGEt19ueG5hxBLOXFxdS02jKfe8wwqCAf\", \"state\": \"live\", \"nsfw\": false, \"viewer_count\": 5, \"viewer_count_fuzzed\": true, \"resources_html\": \"\", \"id\": \"ukaeu1ik4sw5\", \"resources\": \"\", \"name\": \"LiveUpdateEvent_ukaeu1ik4sw5\"}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "891",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Wed, 07 Dec 2016 13:18:23 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-nrt6123-NRT",
+          "X-Timer": "S1481116702.832260,VS0,VE393",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "X-Reddit-Tracking, X-Moose",
+          "cache-control": "max-age=0, must-revalidate",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=smRKukE%2B2Mf9fSN0cOVgvlmWmtLI%2F8qKmUZ7xsPuIgWs7Vxt4QEeOePAjQcUeXxbLXGsD%2FUTs6Y%3D",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/live/ukaeu1ik4sw5/about/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/tests/integration/cassettes/TestReddit.test_live_call.json
+++ b/tests/integration/cassettes/TestReddit.test_live_call.json
@@ -1,0 +1,110 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2016-12-07T13:19:34",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=client_credentials"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "29",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "<USER_AGENT> PRAW/4.0.0 prawcore/0.3.0"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"h8LDFStOnS4o7jKmH6i5PpiJEhc\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Wed, 07 Dec 2016 13:18:13 GMT",
+          "Server": "snooserv",
+          "Set-Cookie": "loid=MVgNu0QX6rRJWWIK0L; Domain=reddit.com; Max-Age=63071999; Path=/;  secure",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-nrt6131-NRT",
+          "X-Timer": "S1481116693.347316,VS0,VE188",
+          "cache-control": "max-age=0, must-revalidate",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2016-12-07T13:19:34",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer h8LDFStOnS4o7jKmH6i5PpiJEhc",
+          "Connection": "keep-alive",
+          "Cookie": "loid=MVgNu0QX6rRJWWIK0L; loidcreated=1481116693000",
+          "User-Agent": "<USER_AGENT> PRAW/4.0.0 prawcore/0.3.0"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/api/live/ukaeu1ik4sw5/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"LiveUpdateEvent\", \"data\": {\"description\": \"A reddit-official thread detailing smaller site changes and links to larger ones (like in /r/changelog or /r/blog).\", \"description_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EA reddit-official thread detailing smaller site changes and links to larger ones (like in \\u003Ca href=\\\"/r/changelog\\\" rel=\\\"nofollow\\\"\\u003E/r/changelog\\u003C/a\\u003E or \\u003Ca href=\\\"/r/blog\\\" rel=\\\"nofollow\\\"\\u003E/r/blog\\u003C/a\\u003E).\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"title\": \"reddit updates\", \"created\": 1426290512.0, \"created_utc\": 1426261712.0, \"websocket_url\": \"wss://wss.redditmedia.com/live/ukaeu1ik4sw5?m=AQAAlV1JWE2gRu6tsPT5tRve3qG2mwsggezv1GnU-_dkUNriVPkT\", \"state\": \"live\", \"nsfw\": false, \"viewer_count\": 9, \"viewer_count_fuzzed\": true, \"resources_html\": \"\", \"id\": \"ukaeu1ik4sw5\", \"resources\": \"\", \"name\": \"LiveUpdateEvent_ukaeu1ik4sw5\"}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "891",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Wed, 07 Dec 2016 13:18:13 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-nrt6125-NRT",
+          "X-Timer": "S1481116693.605186,VS0,VE179",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "X-Reddit-Tracking, X-Moose",
+          "cache-control": "max-age=0, must-revalidate",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=Z8y1zynAG5QQpI8PLa7h1eezWGKG0bHvWhq6oAXwf2fh1l1u%2Fxi%2BdqKB65MLGSzllBPA4BNq3aw%3D",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/live/ukaeu1ik4sw5/about/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/tests/integration/models/reddit/test_live.py
+++ b/tests/integration/models/reddit/test_live.py
@@ -1,0 +1,13 @@
+"""Test praw.models.LiveThread"""
+from praw.models import LiveThread
+import mock
+
+from ... import IntegrationTest
+
+
+class TestLiveThread(IntegrationTest):
+    @mock.patch('time.sleep', return_value=None)
+    def test_init(self, _):
+        thread = LiveThread(self.reddit, 'ukaeu1ik4sw5')
+        with self.recorder.use_cassette('TestLiveThread_test_init'):
+            assert thread.title == 'reddit updates'

--- a/tests/integration/test_reddit.py
+++ b/tests/integration/test_reddit.py
@@ -23,6 +23,13 @@ class TestReddit(IntegrationTest):
             assert isinstance(item, RedditBase)
 
     @mock.patch('time.sleep', return_value=None)
+    def test_live_call(self, _):
+        thread_id = 'ukaeu1ik4sw5'
+        thread = self.reddit.live(thread_id)
+        with self.recorder.use_cassette('TestReddit.test_live_call'):
+            assert thread.title == 'reddit updates'
+
+    @mock.patch('time.sleep', return_value=None)
     def test_live_create(self, _):
         self.reddit.read_only = False
         with self.recorder.use_cassette('TestReddit.test_live_create'):

--- a/tests/unit/models/reddit/test_live.py
+++ b/tests/unit/models/reddit/test_live.py
@@ -1,0 +1,70 @@
+import pickle
+
+import pytest
+from praw.models import LiveThread
+
+from ... import UnitTest
+
+
+class TestLiveThread(UnitTest):
+
+    def test_construct_success(self):
+        thread_id = 'ukaeu1ik4sw5'
+        data = {'id': thread_id}
+
+        thread = LiveThread(self.reddit, thread_id)
+        assert isinstance(thread, LiveThread)
+        assert thread.id == thread_id
+
+        thread = LiveThread(self.reddit, _data=data)
+        assert isinstance(thread, LiveThread)
+        assert thread.id == thread_id
+
+    def test_construct_failure(self):
+        message = 'Either `id` or `_data` must be provided.'
+        with pytest.raises(TypeError) as excinfo:
+            LiveThread(self.reddit)
+        assert str(excinfo.value) == message
+
+        with pytest.raises(TypeError) as excinfo:
+            LiveThread(self.reddit, id='dummy', _data={'id': 'dummy'})
+        assert str(excinfo.value) == message
+
+    def test_equality(self):
+        thread1 = LiveThread(self.reddit, id='dummy1')
+        thread2 = LiveThread(self.reddit, id='Dummy1')
+        thread3 = LiveThread(self.reddit, id='dummy3')
+        assert thread1 == thread1
+        assert thread2 == thread2
+        assert thread3 == thread3
+        assert thread1 != thread2  # live thread ID in a URL is case sensitive
+        assert thread2 != thread3
+        assert thread1 != thread3
+        assert 'dummy1' == thread1
+        assert thread2 != 'dummy1'
+        assert thread2 == 'Dummy1'
+
+    def test_hash(self):
+        thread1 = LiveThread(self.reddit, id='dummy1')
+        thread2 = LiveThread(self.reddit, id='Dummy1')
+        thread3 = LiveThread(self.reddit, id='dummy3')
+        assert hash(thread1) == hash(thread1)
+        assert hash(thread2) == hash(thread2)
+        assert hash(thread3) == hash(thread3)
+        assert hash(thread1) != hash(thread2)
+        assert hash(thread2) != hash(thread3)
+        assert hash(thread1) != hash(thread3)
+
+    def test_pickle(self):
+        thread = LiveThread(self.reddit, id='dummy')
+        for level in range(pickle.HIGHEST_PROTOCOL + 1):
+            other = pickle.loads(pickle.dumps(thread, protocol=level))
+            assert thread == other
+
+    def test_repr(self):
+        thread = LiveThread(self.reddit, id='dummy')
+        assert repr(thread) == 'LiveThread(id=\'dummy\')'
+
+    def test_str(self):
+        thread = LiveThread(self.reddit, id='dummy')
+        assert str(thread) == 'dummy'


### PR DESCRIPTION
## Feature Summary and Justification

This feature provides explicit interface to initialize a `praw.models.LiveThread` instance, e.g.,

```python
>>> import praw
>>> from  praw.models import LiveThread
>>> reddit = praw.Reddit(...)
>>> thread = LiveThread(reddit, 'ukaeu1ik4sw5')
>>> thread.title
u'reddit updates'
```

## References

* nmtake/praw@e147a37

## Concerns

Access tokens are visible in the cassettes. I think it would be better if we could filter out those tokens with `before_record` hook.  Any thoughts?