### PR TITLE
Use before_record hook to filter out acceess tokens from cassettes.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 """Prepare py.test."""
+import json
 import os
 import socket
 import time
@@ -22,6 +23,18 @@ def b64_string(input_string):
     return b64encode(input_string.encode('utf-8')).decode('utf-8')
 
 
+def before_record(interaction, current_cassette):
+    try:
+        body = interaction.data['response']['body']
+        data = json.loads(body['string'], encoding=body['encoding'])
+        token = data['access_token']
+        current_cassette.placeholders.append(
+            betamax.cassette.cassette.Placeholder(
+                placeholder='<ACCESS_TOKEN>', replace=token))
+    except (KeyError, TypeError):
+        pass
+
+
 def env_default(key):
     """Return environment variable or placeholder string."""
     return os.environ.get('prawtest_{}'.format(key),
@@ -42,6 +55,7 @@ betamax.Betamax.register_serializer(pretty_json.PrettyJSONSerializer)
 with betamax.Betamax.configure() as config:
     config.cassette_library_dir = 'tests/integration/cassettes'
     config.default_cassette_options['serialize_with'] = 'prettyjson'
+    config.before_record(callback=before_record)
     for key, value in placeholders.items():
         config.define_cassette_placeholder('<{}>'.format(key.upper()), value)
 


### PR DESCRIPTION
## Feature Summary and Justification

This feature filters out access tokens from betamax cassettes. `before_record` hook is added in betamax 0.7.0.

## References

* http://betamax.readthedocs.io/en/latest/configuring.html#filtering-sensitive-data
* https://github.com/praw-dev/praw/pull/680#discussion_r90765774