### PR TITLE
Use before_record hook to filter out acceess tokens from cassettes (fixes #682)

### DIFF
--- a/tests/integration/cassettes/TestLiveThread_test_init.json
+++ b/tests/integration/cassettes/TestLiveThread_test_init.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2016-12-07T13:19:43",
+      "recorded_at": "2016-12-11T16:33:16",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -22,23 +22,23 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"access_token\": \"G3zyP28RIGbbTocu0s9pcj9KWI0\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
           "Content-Length": "105",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Wed, 07 Dec 2016 13:18:22 GMT",
+          "Date": "Sun, 11 Dec 2016 16:31:41 GMT",
           "Server": "snooserv",
-          "Set-Cookie": "loid=AFJaYzUOC19PMMpeZ5; Domain=reddit.com; Max-Age=63071999; Path=/;  secure",
+          "Set-Cookie": "loid=3gQy5vpDZz0B0IaMps; Domain=reddit.com; Max-Age=63071999; Path=/;  secure",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Via": "1.1 varnish",
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-nrt6135-NRT",
-          "X-Timer": "S1481116702.528734,VS0,VE193",
+          "X-Served-By": "cache-nrt6123-NRT",
+          "X-Timer": "S1481473900.430640,VS0,VE729",
           "cache-control": "max-age=0, must-revalidate",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
@@ -52,7 +52,7 @@
       }
     },
     {
-      "recorded_at": "2016-12-07T13:19:43",
+      "recorded_at": "2016-12-11T16:33:17",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -61,9 +61,9 @@
         "headers": {
           "Accept": "*/*",
           "Accept-Encoding": "identity",
-          "Authorization": "bearer G3zyP28RIGbbTocu0s9pcj9KWI0",
+          "Authorization": "bearer <ACCESS_TOKEN>",
           "Connection": "keep-alive",
-          "Cookie": "loid=AFJaYzUOC19PMMpeZ5; loidcreated=1481116702000",
+          "Cookie": "loid=3gQy5vpDZz0B0IaMps; loidcreated=1481473900000",
           "User-Agent": "<USER_AGENT> PRAW/4.0.0 prawcore/0.3.0"
         },
         "method": "GET",
@@ -72,14 +72,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"kind\": \"LiveUpdateEvent\", \"data\": {\"description\": \"A reddit-official thread detailing smaller site changes and links to larger ones (like in /r/changelog or /r/blog).\", \"description_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EA reddit-official thread detailing smaller site changes and links to larger ones (like in \\u003Ca href=\\\"/r/changelog\\\" rel=\\\"nofollow\\\"\\u003E/r/changelog\\u003C/a\\u003E or \\u003Ca href=\\\"/r/blog\\\" rel=\\\"nofollow\\\"\\u003E/r/blog\\u003C/a\\u003E).\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"title\": \"reddit updates\", \"created\": 1426290512.0, \"created_utc\": 1426261712.0, \"websocket_url\": \"wss://wss.redditmedia.com/live/ukaeu1ik4sw5?m=AQAAn11JWDTuVuoWUCLUGEt19ueG5hxBLOXFxdS02jKfe8wwqCAf\", \"state\": \"live\", \"nsfw\": false, \"viewer_count\": 5, \"viewer_count_fuzzed\": true, \"resources_html\": \"\", \"id\": \"ukaeu1ik4sw5\", \"resources\": \"\", \"name\": \"LiveUpdateEvent_ukaeu1ik4sw5\"}}"
+          "string": "{\"kind\": \"LiveUpdateEvent\", \"data\": {\"description\": \"A reddit-official thread detailing smaller site changes and links to larger ones (like in /r/changelog or /r/blog).\", \"description_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EA reddit-official thread detailing smaller site changes and links to larger ones (like in \\u003Ca href=\\\"/r/changelog\\\" rel=\\\"nofollow\\\"\\u003E/r/changelog\\u003C/a\\u003E or \\u003Ca href=\\\"/r/blog\\\" rel=\\\"nofollow\\\"\\u003E/r/blog\\u003C/a\\u003E).\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"title\": \"reddit updates\", \"created\": 1426290512.0, \"created_utc\": 1426261712.0, \"websocket_url\": \"wss://wss.redditmedia.com/live/ukaeu1ik4sw5?m=AQAA7dBOWHWGpM_AA66ExBXVzKVK1pJKWwtGGsA-U8518tZSEzVT\", \"state\": \"live\", \"nsfw\": false, \"viewer_count\": 9, \"viewer_count_fuzzed\": true, \"resources_html\": \"\", \"id\": \"ukaeu1ik4sw5\", \"resources\": \"\", \"name\": \"LiveUpdateEvent_ukaeu1ik4sw5\"}}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
           "Content-Length": "891",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Wed, 07 Dec 2016 13:18:23 GMT",
+          "Date": "Sun, 11 Dec 2016 16:31:41 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -87,14 +87,14 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-nrt6123-NRT",
-          "X-Timer": "S1481116702.832260,VS0,VE393",
+          "X-Served-By": "cache-nrt6131-NRT",
+          "X-Timer": "S1481473901.383310,VS0,VE197",
           "access-control-allow-origin": "*",
           "access-control-expose-headers": "X-Reddit-Tracking, X-Moose",
           "cache-control": "max-age=0, must-revalidate",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=smRKukE%2B2Mf9fSN0cOVgvlmWmtLI%2F8qKmUZ7xsPuIgWs7Vxt4QEeOePAjQcUeXxbLXGsD%2FUTs6Y%3D",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=0tilFlaLUie8qe%2FCL8TkOLeioejS7HsiQAtAOl8Ff3WJOjqC9CQJpjkxuzvBq9mUjb5IyjQfApo%3D",
           "x-ua-compatible": "IE=edge",
           "x-xss-protection": "1; mode=block"
         },

--- a/tests/integration/cassettes/TestMultireddit.test_remove.json
+++ b/tests/integration/cassettes/TestMultireddit.test_remove.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2016-07-17T14:34:06",
+      "recorded_at": "2016-12-11T16:33:18",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -12,9 +12,9 @@
           "Accept-Encoding": "identity",
           "Authorization": "Basic <BASIC_AUTH>",
           "Connection": "keep-alive",
-          "Content-Length": "57",
+          "Content-Length": "83",
           "Content-Type": "application/x-www-form-urlencoded",
-          "User-Agent": "<USER_AGENT> PRAW/4.0.0b9 prawcore/0.0.12"
+          "User-Agent": "<USER_AGENT> PRAW/4.0.0 prawcore/0.3.0"
         },
         "method": "POST",
         "uri": "https://www.reddit.com/api/v1/access_token"
@@ -22,18 +22,23 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"access_token\": \"isZivspicz-cEAvZ0dXaqbGX3xw\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
         },
         "headers": {
-          "CF-RAY": "2c3e69a77b3f228e-LAX",
+          "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
           "Content-Length": "105",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sun, 17 Jul 2016 14:34:06 GMT",
-          "Server": "cloudflare-nginx",
-          "Set-Cookie": "__cfduid=d158f2ad1f63daa31cc3b9faa239281d81468766045; expires=Mon, 17-Jul-17 14:34:05 GMT; path=/; domain=.reddit.com; HttpOnly",
+          "Date": "Sun, 11 Dec 2016 16:31:42 GMT",
+          "Server": "snooserv",
+          "Set-Cookie": "loid=ynU9ZHhrU4lrr1AKRU; Domain=reddit.com; Max-Age=63071999; Path=/;  secure",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
           "X-Moose": "majestic",
+          "X-Served-By": "cache-nrt6128-NRT",
+          "X-Timer": "S1481473902.014691,VS0,VE527",
           "cache-control": "max-age=0, must-revalidate",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
@@ -47,7 +52,7 @@
       }
     },
     {
-      "recorded_at": "2016-07-17T14:34:06",
+      "recorded_at": "2016-12-11T16:33:18",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -56,10 +61,10 @@
         "headers": {
           "Accept": "*/*",
           "Accept-Encoding": "identity",
-          "Authorization": "bearer isZivspicz-cEAvZ0dXaqbGX3xw",
+          "Authorization": "bearer <ACCESS_TOKEN>",
           "Connection": "keep-alive",
-          "Cookie": "__cfduid=d158f2ad1f63daa31cc3b9faa239281d81468766045; loid=n4MXfxcLV47PJUbHgB; loidcreated=2016-07-17T14%3A34%3A05.589Z",
-          "User-Agent": "<USER_AGENT> PRAW/4.0.0b9 prawcore/0.0.12"
+          "Cookie": "loid=ynU9ZHhrU4lrr1AKRU; loidcreated=1481473902000",
+          "User-Agent": "<USER_AGENT> PRAW/4.0.0 prawcore/0.3.0"
         },
         "method": "GET",
         "uri": "https://oauth.reddit.com/api/multi/mine/?raw_json=1"
@@ -67,26 +72,31 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "[{\"kind\": \"LabeledMulti\", \"data\": {\"can_edit\": true, \"display_name\": \"praw_z2ggpt0vkr\", \"name\": \"praw_z2ggpt0vkr\", \"description_html\": \"\", \"created\": 1432649032.0, \"copied_from\": null, \"icon_url\": null, \"subreddits\": [{\"name\": \"redditdev\"}], \"created_utc\": 1432620232.0, \"key_color\": \"#cee3f8\", \"visibility\": \"private\", \"icon_name\": \"\", \"weighting_scheme\": \"classic\", \"path\": \"/user/<USERNAME>/m/praw_z2ggpt0vkr\", \"description_md\": \"\"}}, {\"kind\": \"LabeledMulti\", \"data\": {\"can_edit\": true, \"display_name\": \"PRAW_7IJJLETR54\", \"name\": \"praw_zwategsdje\", \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Ecopied from \\u003Ca href=\\\"/user/<USERNAME>/m/praw_32dm76iiu0\\\"\\u003E/user/<USERNAME>/m/praw_32dm76iiu0\\u003C/a\\u003E\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"created\": 1432647766.0, \"copied_from\": \"/user/<USERNAME>/m/praw_7ijjletr54\", \"icon_url\": null, \"subreddits\": [{\"name\": \"<TEST_SUBREDDIT>\"}], \"created_utc\": 1432618966.0, \"key_color\": \"#cee3f8\", \"visibility\": \"private\", \"icon_name\": \"\", \"weighting_scheme\": \"classic\", \"path\": \"/user/<USERNAME>/m/praw_zwategsdje\", \"description_md\": \"copied from [/user/<USERNAME>/m/praw_32dm76iiu0](/user/<USERNAME>/m/praw_32dm76iiu0)\"}}, {\"kind\": \"LabeledMulti\", \"data\": {\"can_edit\": true, \"display_name\": \"publicempty\", \"name\": \"publicempty\", \"description_html\": \"\", \"created\": 1416450706.0, \"copied_from\": null, \"icon_url\": null, \"subreddits\": [], \"created_utc\": 1416421906.0, \"key_color\": \"#cee3f8\", \"visibility\": \"public\", \"icon_name\": \"\", \"weighting_scheme\": \"classic\", \"path\": \"/user/<USERNAME>/m/publicempty\", \"description_md\": \"\"}}, {\"kind\": \"LabeledMulti\", \"data\": {\"can_edit\": true, \"display_name\": \"PRAW_vyqqgesbgf\", \"name\": \"renamed_2e9nfvc\", \"description_html\": \"\", \"created\": 1432649270.0, \"copied_from\": \"/user/<USERNAME>/m/praw_vyqqgesbgf\", \"icon_url\": null, \"subreddits\": [], \"created_utc\": 1432620470.0, \"key_color\": \"#cee3f8\", \"visibility\": \"private\", \"icon_name\": \"\", \"weighting_scheme\": \"classic\", \"path\": \"/user/<USERNAME>/m/renamed_2e9nfvc\", \"description_md\": \"\"}}, {\"kind\": \"LabeledMulti\", \"data\": {\"can_edit\": true, \"display_name\": \"praw_ivatd8q8uk\", \"name\": \"renamed_6bty6x0\", \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EPRAW_gxgpobcx2q\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"created\": 1432648343.0, \"copied_from\": \"/user/pyapitestuser2/m/praw_ivatd8q8uk\", \"icon_url\": null, \"subreddits\": [], \"created_utc\": 1432619543.0, \"key_color\": \"#cee3f8\", \"visibility\": \"private\", \"icon_name\": \"\", \"weighting_scheme\": \"classic\", \"path\": \"/user/<USERNAME>/m/renamed_6bty6x0\", \"description_md\": \"PRAW_gxgpobcx2q\"}}, {\"kind\": \"LabeledMulti\", \"data\": {\"can_edit\": true, \"display_name\": \"praw_jmbeafjsgb\", \"name\": \"renamed_8usb6x1\", \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EPRAW_qnkboqko2k\\u003C/p\\u003E\\n\\n\\u003Cp\\u003Ecopied from \\u003Ca href=\\\"/user/<USERNAME>/m/praw_otefaapb78\\\"\\u003E/user/<USERNAME>/m/praw_otefaapb78\\u003C/a\\u003E\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"created\": 1432648343.0, \"copied_from\": \"/user/pyapitestuser2/m/praw_jmbeafjsgb\", \"icon_url\": null, \"subreddits\": [], \"created_utc\": 1432619543.0, \"key_color\": \"#cee3f8\", \"visibility\": \"private\", \"icon_name\": \"\", \"weighting_scheme\": \"classic\", \"path\": \"/user/<USERNAME>/m/renamed_8usb6x1\", \"description_md\": \"PRAW_qnkboqko2k\\n\\ncopied from [/user/<USERNAME>/m/praw_otefaapb78](/user/<USERNAME>/m/praw_otefaapb78)\"}}, {\"kind\": \"LabeledMulti\", \"data\": {\"can_edit\": true, \"display_name\": \"renamed_d2xvrt2\", \"name\": \"renamed_d2xvrt2\", \"description_html\": \"\", \"created\": 1432648863.0, \"copied_from\": \"/user/<USERNAME>/m/praw_i5xfu909bv\", \"icon_url\": null, \"subreddits\": [], \"created_utc\": 1432620063.0, \"key_color\": \"#cee3f8\", \"visibility\": \"private\", \"icon_name\": \"\", \"weighting_scheme\": \"classic\", \"path\": \"/user/<USERNAME>/m/renamed_d2xvrt2\", \"description_md\": \"\"}}, {\"kind\": \"LabeledMulti\", \"data\": {\"can_edit\": true, \"display_name\": \"praw_rzcnhcf14r\", \"name\": \"renamed_eylvv7z\", \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EPRAW_i2e1xmlmp8\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"created\": 1432648343.0, \"copied_from\": \"/user/pyapitestuser2/m/praw_rzcnhcf14r\", \"icon_url\": null, \"subreddits\": [], \"created_utc\": 1432619543.0, \"key_color\": \"#cee3f8\", \"visibility\": \"private\", \"icon_name\": \"\", \"weighting_scheme\": \"classic\", \"path\": \"/user/<USERNAME>/m/renamed_eylvv7z\", \"description_md\": \"PRAW_i2e1xmlmp8\"}}, {\"kind\": \"LabeledMulti\", \"data\": {\"can_edit\": true, \"display_name\": \"PRAW_a01plsdh6k\", \"name\": \"renamed_mne1m9w\", \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EBLAH\\u003C/p\\u003E\\n\\n\\u003Cp\\u003Ecopied from \\u003Ca href=\\\"/user/<USERNAME>/m/praw_32dm76iiu0\\\"\\u003E/user/<USERNAME>/m/praw_32dm76iiu0\\u003C/a\\u003E\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"created\": 1432647766.0, \"copied_from\": \"/user/<USERNAME>/m/praw_a01plsdh6k\", \"icon_url\": null, \"subreddits\": [{\"name\": \"<TEST_SUBREDDIT>\"}], \"created_utc\": 1432618966.0, \"key_color\": \"#cee3f8\", \"visibility\": \"private\", \"icon_name\": \"\", \"weighting_scheme\": \"classic\", \"path\": \"/user/<USERNAME>/m/renamed_mne1m9w\", \"description_md\": \"BLAH\\n\\ncopied from [/user/<USERNAME>/m/praw_32dm76iiu0](/user/<USERNAME>/m/praw_32dm76iiu0)\"}}, {\"kind\": \"LabeledMulti\", \"data\": {\"can_edit\": true, \"display_name\": \"praw_48e2k784z0\", \"name\": \"renamed_o71kopk\", \"description_html\": \"\", \"created\": 1432648527.0, \"copied_from\": \"/user/<USERNAME>/m/praw_ln88ua1fd6\", \"icon_url\": null, \"subreddits\": [], \"created_utc\": 1432619727.0, \"key_color\": \"#cee3f8\", \"visibility\": \"private\", \"icon_name\": \"\", \"weighting_scheme\": \"classic\", \"path\": \"/user/<USERNAME>/m/renamed_o71kopk\", \"description_md\": \"\"}}, {\"kind\": \"LabeledMulti\", \"data\": {\"can_edit\": true, \"display_name\": \"praw_otefaapb78\", \"name\": \"renamed_p93yyel\", \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EPRAW_kifa24b018\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"created\": 1432648343.0, \"copied_from\": \"/user/pyapitestuser2/m/praw_otefaapb78\", \"icon_url\": null, \"subreddits\": [{\"name\": \"<TEST_SUBREDDIT>\"}], \"created_utc\": 1432619543.0, \"key_color\": \"#cee3f8\", \"visibility\": \"private\", \"icon_name\": \"\", \"weighting_scheme\": \"classic\", \"path\": \"/user/<USERNAME>/m/renamed_p93yyel\", \"description_md\": \"PRAW_kifa24b018\"}}, {\"kind\": \"LabeledMulti\", \"data\": {\"can_edit\": true, \"display_name\": \"PRAW_hrgjtlofk9\", \"name\": \"renamed_ppil2bq\", \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EPRAW_xd2vmw4py7\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"created\": 1432647766.0, \"copied_from\": \"/user/<USERNAME>/m/praw_hrgjtlofk9\", \"icon_url\": null, \"subreddits\": [{\"name\": \"<TEST_SUBREDDIT>\"}], \"created_utc\": 1432618966.0, \"key_color\": \"#cee3f8\", \"visibility\": \"public\", \"icon_name\": \"\", \"weighting_scheme\": \"classic\", \"path\": \"/user/<USERNAME>/m/renamed_ppil2bq\", \"description_md\": \"PRAW_xd2vmw4py7\"}}, {\"kind\": \"LabeledMulti\", \"data\": {\"can_edit\": true, \"display_name\": \"PRAW_7gcyw6pl0d\", \"name\": \"renamed_rwgn0us\", \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Ecopied from \\u003Ca href=\\\"/user/<USERNAME>/m/praw_32dm76iiu0\\\"\\u003E/user/<USERNAME>/m/praw_32dm76iiu0\\u003C/a\\u003E\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"created\": 1432647766.0, \"copied_from\": \"/user/<USERNAME>/m/praw_ky972wv5uk\", \"icon_url\": null, \"subreddits\": [{\"name\": \"<TEST_SUBREDDIT>\"}], \"created_utc\": 1432618966.0, \"key_color\": \"#cee3f8\", \"visibility\": \"private\", \"icon_name\": \"\", \"weighting_scheme\": \"classic\", \"path\": \"/user/<USERNAME>/m/renamed_rwgn0us\", \"description_md\": \"copied from [/user/<USERNAME>/m/praw_32dm76iiu0](/user/<USERNAME>/m/praw_32dm76iiu0)\"}}, {\"kind\": \"LabeledMulti\", \"data\": {\"can_edit\": true, \"display_name\": \"tmp\", \"name\": \"tmp\", \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Ecopied from \\u003Ca href=\\\"/user/<USERNAME>/m/publicempty\\\"\\u003E/user/<USERNAME>/m/publicempty\\u003C/a\\u003E\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"created\": 1416450706.0, \"copied_from\": \"/user/<USERNAME>/m/publicempty\", \"icon_url\": null, \"subreddits\": [], \"created_utc\": 1416421906.0, \"key_color\": \"#cee3f8\", \"visibility\": \"private\", \"icon_name\": \"\", \"weighting_scheme\": \"classic\", \"path\": \"/user/<USERNAME>/m/tmp\", \"description_md\": \"copied from [/user/<USERNAME>/m/publicempty](/user/<USERNAME>/m/publicempty)\"}}]"
+          "string": "[{\"kind\": \"LabeledMulti\", \"data\": {\"can_edit\": true, \"display_name\": \"praw multi test\", \"name\": \"praw_multi_test\", \"description_html\": \"\", \"created\": 1480913123.0, \"copied_from\": null, \"icon_url\": null, \"subreddits\": [{\"name\": \"aww\"}], \"created_utc\": 1480884323.0, \"key_color\": \"\", \"visibility\": \"private\", \"icon_name\": \"\", \"weighting_scheme\": \"classic\", \"path\": \"/user/<USERNAME>/m/praw_multi_test/\", \"description_md\": \"\"}}, {\"kind\": \"LabeledMulti\", \"data\": {\"can_edit\": true, \"display_name\": \"praw multi test\", \"name\": \"praw_multi_test1\", \"description_html\": \"\", \"created\": 1480913167.0, \"copied_from\": null, \"icon_url\": null, \"subreddits\": [{\"name\": \"aww\"}], \"created_utc\": 1480884367.0, \"key_color\": \"\", \"visibility\": \"private\", \"icon_name\": \"\", \"weighting_scheme\": \"classic\", \"path\": \"/user/<USERNAME>/m/praw_multi_test1/\", \"description_md\": \"\"}}, {\"kind\": \"LabeledMulti\", \"data\": {\"can_edit\": true, \"display_name\": \"praw multi test\", \"name\": \"praw_multi_test2\", \"description_html\": \"\", \"created\": 1480913200.0, \"copied_from\": null, \"icon_url\": null, \"subreddits\": [{\"name\": \"aww\"}], \"created_utc\": 1480884400.0, \"key_color\": \"\", \"visibility\": \"private\", \"icon_name\": \"\", \"weighting_scheme\": \"classic\", \"path\": \"/user/<USERNAME>/m/praw_multi_test2/\", \"description_md\": \"\"}}]"
         },
         "headers": {
-          "CF-RAY": "2c3e69ac9cca07d9-LAX",
+          "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
+          "Content-Length": "1303",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sun, 17 Jul 2016 14:34:06 GMT",
-          "Server": "cloudflare-nginx",
+          "Date": "Sun, 11 Dec 2016 16:31:43 GMT",
+          "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
-          "Transfer-Encoding": "chunked",
           "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate",
+          "X-Served-By": "cache-nrt6127-NRT",
+          "X-Timer": "S1481473902.736106,VS0,VE280",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "596.0",
-          "x-ratelimit-reset": "354",
-          "x-ratelimit-used": "4",
-          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=bJ3zyspf2K6iHgNO6iILcb3omKwi1w4LRCYA7Dc2C5%2Fn%2BFRnyGeoAGK%2FKxiLnJYJz4L4l05dfMdmvA1JDtcEjyBqDKDOAgxj",
+          "x-ratelimit-remaining": "599.0",
+          "x-ratelimit-reset": "498",
+          "x-ratelimit-used": "1",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=kqU73oeHCptVsDlq%2BoaJGuI48ZRcHTZAJelyTPcNy%2BWQX8vgnJU0eG2fJEIOLsYfve495y27GHDMxhSfhALdm3F%2Bz7t5c2%2Fz",
           "x-ua-compatible": "IE=edge",
           "x-xss-protection": "1; mode=block"
         },
@@ -98,7 +108,7 @@
       }
     },
     {
-      "recorded_at": "2016-07-17T14:34:06",
+      "recorded_at": "2016-12-11T16:33:18",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -107,15 +117,15 @@
         "headers": {
           "Accept": "*/*",
           "Accept-Encoding": "identity",
-          "Authorization": "bearer isZivspicz-cEAvZ0dXaqbGX3xw",
+          "Authorization": "bearer <ACCESS_TOKEN>",
           "Connection": "keep-alive",
           "Content-Length": "55",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "__cfduid=d158f2ad1f63daa31cc3b9faa239281d81468766045; loid=n4MXfxcLV47PJUbHgB; loidcreated=2016-07-17T14%3A34%3A05.589Z",
-          "User-Agent": "<USER_AGENT> PRAW/4.0.0b9 prawcore/0.0.12"
+          "Cookie": "loid=ynU9ZHhrU4lrr1AKRU; loidcreated=1481473902000",
+          "User-Agent": "<USER_AGENT> PRAW/4.0.0 prawcore/0.3.0"
         },
         "method": "DELETE",
-        "uri": "https://oauth.reddit.com/api/multi/user/<USERNAME>/m/praw_z2ggpt0vkr/r/redditdev?raw_json=1"
+        "uri": "https://oauth.reddit.com/api/multi/user/<USERNAME>/m/praw_multi_test/r/redditdev?raw_json=1"
       },
       "response": {
         "body": {
@@ -123,21 +133,26 @@
           "string": ""
         },
         "headers": {
-          "CF-RAY": "2c3e69addcd307d9-LAX",
+          "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
           "Content-Length": "0",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sun, 17 Jul 2016 14:34:06 GMT",
-          "Server": "cloudflare-nginx",
+          "Date": "Sun, 11 Dec 2016 16:31:43 GMT",
+          "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate",
+          "X-Served-By": "cache-nrt6127-NRT",
+          "X-Timer": "S1481473903.123497,VS0,VE230",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "595.0",
-          "x-ratelimit-reset": "354",
-          "x-ratelimit-used": "5",
+          "x-ratelimit-remaining": "598.0",
+          "x-ratelimit-reset": "497",
+          "x-ratelimit-used": "2",
           "x-ua-compatible": "IE=edge",
           "x-xss-protection": "1; mode=block"
         },
@@ -145,11 +160,11 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://oauth.reddit.com/api/multi/user/<USERNAME>/m/praw_z2ggpt0vkr/r/redditdev?raw_json=1"
+        "url": "https://oauth.reddit.com/api/multi/user/<USERNAME>/m/praw_multi_test/r/redditdev?raw_json=1"
       }
     },
     {
-      "recorded_at": "2016-07-17T14:34:06",
+      "recorded_at": "2016-12-11T16:33:19",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -158,36 +173,41 @@
         "headers": {
           "Accept": "*/*",
           "Accept-Encoding": "identity",
-          "Authorization": "bearer isZivspicz-cEAvZ0dXaqbGX3xw",
+          "Authorization": "bearer <ACCESS_TOKEN>",
           "Connection": "keep-alive",
-          "Cookie": "__cfduid=d158f2ad1f63daa31cc3b9faa239281d81468766045; loid=n4MXfxcLV47PJUbHgB; loidcreated=2016-07-17T14%3A34%3A05.589Z",
-          "User-Agent": "<USER_AGENT> PRAW/4.0.0b9 prawcore/0.0.12"
+          "Cookie": "loid=ynU9ZHhrU4lrr1AKRU; loidcreated=1481473902000",
+          "User-Agent": "<USER_AGENT> PRAW/4.0.0 prawcore/0.3.0"
         },
         "method": "GET",
-        "uri": "https://oauth.reddit.com/api/multi/user/<USERNAME>/m/praw_z2ggpt0vkr/?raw_json=1"
+        "uri": "https://oauth.reddit.com/api/multi/user/<USERNAME>/m/praw_multi_test/?raw_json=1"
       },
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"kind\": \"LabeledMulti\", \"data\": {\"can_edit\": true, \"display_name\": \"praw_z2ggpt0vkr\", \"name\": \"praw_z2ggpt0vkr\", \"description_html\": \"\", \"created\": 1432649032.0, \"copied_from\": null, \"icon_url\": null, \"subreddits\": [], \"created_utc\": 1432620232.0, \"key_color\": \"#cee3f8\", \"visibility\": \"private\", \"icon_name\": \"\", \"weighting_scheme\": \"classic\", \"path\": \"/user/<USERNAME>/m/praw_z2ggpt0vkr\", \"description_md\": \"\"}}"
+          "string": "{\"kind\": \"LabeledMulti\", \"data\": {\"can_edit\": true, \"display_name\": \"praw multi test\", \"name\": \"praw_multi_test\", \"description_html\": \"\", \"created\": 1480913123.0, \"copied_from\": null, \"icon_url\": null, \"subreddits\": [{\"name\": \"aww\"}], \"created_utc\": 1480884323.0, \"key_color\": \"\", \"visibility\": \"private\", \"icon_name\": \"\", \"weighting_scheme\": \"classic\", \"path\": \"/user/<USERNAME>/m/praw_multi_test/\", \"description_md\": \"\"}}"
         },
         "headers": {
-          "CF-RAY": "2c3e69b0ad0107d9-LAX",
+          "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "418",
+          "Content-Length": "431",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sun, 17 Jul 2016 14:34:06 GMT",
-          "Server": "cloudflare-nginx",
+          "Date": "Sun, 11 Dec 2016 16:31:43 GMT",
+          "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate",
+          "X-Served-By": "cache-nrt6127-NRT",
+          "X-Timer": "S1481473903.369060,VS0,VE238",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "594.0",
-          "x-ratelimit-reset": "354",
-          "x-ratelimit-used": "6",
-          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=aeHGiyaOBP79t87OFb4Q1QEhfEP9xqcfMWGt11%2FhTHljrEUg4cQ0XYe8Mz02KtZR39jKLyeyWoAf2Y%2FqgKmA4fb7wdGt7gLk",
+          "x-ratelimit-remaining": "597.0",
+          "x-ratelimit-reset": "497",
+          "x-ratelimit-used": "3",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=gtWA86isSXzd7VJklfOpE0sI0FIeSY1A%2Fvtik%2Fhz%2BSglcUGj8VMIilYxajHny5elJvI3bRMsBYiiVOiQjVKZOfrN439S%2FThl",
           "x-ua-compatible": "IE=edge",
           "x-xss-protection": "1; mode=block"
         },
@@ -195,9 +215,9 @@
           "code": 200,
           "message": "OK"
         },
-        "url": "https://oauth.reddit.com/api/multi/user/<USERNAME>/m/praw_z2ggpt0vkr/?raw_json=1"
+        "url": "https://oauth.reddit.com/api/multi/user/<USERNAME>/m/praw_multi_test/?raw_json=1"
       }
     }
   ],
-  "recorded_with": "betamax/0.7.1"
+  "recorded_with": "betamax/0.8.0"
 }

--- a/tox.ini
+++ b/tox.ini
@@ -14,3 +14,10 @@ commands =
     python setup.py test
     flake8 praw
     flake8 tests
+passenv =
+    prawtest_client_id
+    prawtest_client_secret
+    prawtest_password
+    prawtest_test_subreddit
+    prawtest_username
+    prawtest_user_agent


### PR DESCRIPTION
Fixes reverted PR #682 

## Feature Summary and Justification

This feature filters out access tokens from betamax cassettes. `before_record` hook is added in betamax 0.7.0. 

I added cassettes failed to create in #682, and some fixes (`prawtest_*` envvars are missing in test environment which is invoked from tox, ~~and pylint compliance~~ (edit: alrady solved in https://github.com/praw-dev/praw/commit/ec9b648a3668a06428f65646d7fe61408268b191).

## References

* #682 
* http://betamax.readthedocs.io/en/latest/configuring.html#filtering-sensitive-data
* https://github.com/praw-dev/praw/pull/680#discussion_r90765774
* http://tox.readthedocs.io/en/latest/example/basic.html#passing-down-environment-variables