### PR TITLE
Add sticky parameter to SubredditModeration.distinguish

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -24,4 +24,5 @@ Source Contributors
 - William McKinnerney <me@williammck.net> `@williammck <https://github.com/williammck>`_
 - Katharine Jarmul <katharine@kjamistan.com> `@kjam <https://github.com/kjam>`_
 - nmtake `@nmtake <https://github.com/nmtake>`_
+- Levi Roth <levimroth@gmail.com> `@leviroth <https://github.com/leviroth`_
 - Add "Name <email (optional)> and github profile link" above this line.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Unreleased
   other parameters can be passed.
 * Add :meth:`~praw.models.Message.reply` to :class:`.Message` which was
   accidentally missed previously.
+* Add `sticky` parameter to :meth:`.SubredditModeration.distinguish` to sticky
+  comments.
 
 **Changed**
 

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -11,6 +11,7 @@ from ..util import stream_generator
 from ..listing.generator import ListingGenerator
 from ..listing.mixins import SubredditListingMixin
 from .base import RedditBase
+from .comment import Comment
 from .mixins import MessageableMixin
 from .wikipage import WikiPage
 
@@ -724,7 +725,7 @@ class SubredditModeration(object):
         self.subreddit._reddit.post(API_PATH['approve'],
                                     data={'id': thing.fullname})
 
-    def distinguish(self, thing, how='yes'):
+    def distinguish(self, thing, how='yes', sticky=False):
         """Distinguish a Comment or Submission.
 
         :param thing: An instance of Comment or Submission.
@@ -733,9 +734,14 @@ class SubredditModeration(object):
             moderator level distinguish. 'no' removes any distinction. 'admin'
             and 'special' require special user priviliges to use.
 
+        :param sticky: Comment is stickied if True, placing it at the top of
+            the comment page regardless of score. If thing is not a top-level
+            comment, this parameter is silently ignored.
         """
-        return self.subreddit._reddit.post(
-            API_PATH['distinguish'], data={'how': how, 'id': thing.fullname})
+        data = {'how': how, 'id': thing.fullname}
+        if sticky and isinstance(thing, Comment) and thing.is_root:
+            data['sticky'] = True
+        return self.subreddit._reddit.post(API_PATH['distinguish'], data=data)
 
     def edited(self, only=None, **generator_kwargs):
         """Return a ListingGenerator for edited comments and submissions.

--- a/tests/integration/cassettes/TestSubredditModeration.test_distinguish__sticky.json
+++ b/tests/integration/cassettes/TestSubredditModeration.test_distinguish__sticky.json
@@ -1,0 +1,169 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2016-12-16T21:24:04",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "57",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "<USER_AGENT> PRAW/4.0.0 prawcore/0.5.0"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Fri, 16 Dec 2016 21:24:04 GMT",
+          "Server": "snooserv",
+          "Set-Cookie": "loid=rPmTvziRqE2kbgffJU; Domain=reddit.com; Max-Age=63071999; Path=/;  secure",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1743-ORD",
+          "X-Timer": "S1481923444.418776,VS0,VE367",
+          "cache-control": "max-age=0, must-revalidate",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2016-12-16T21:24:05",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "loid=rPmTvziRqE2kbgffJU; loidcreated=1481923444000",
+          "User-Agent": "<USER_AGENT> PRAW/4.0.0 prawcore/0.5.0"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/api/info/?raw_json=1&id=t1_dba9bzn"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t1\", \"data\": {\"subreddit_id\": \"t5_390u2\", \"banned_by\": null, \"removal_reason\": null, \"link_id\": \"t3_5e7xv3\", \"likes\": true, \"replies\": \"\", \"user_reports\": [], \"saved\": false, \"id\": \"dba9bzn\", \"gilded\": 0, \"archived\": false, \"report_reasons\": [], \"author\": \"BJO_test_mod\", \"parent_id\": \"t3_5e7xv3\", \"score\": 1, \"approved_by\": null, \"controversiality\": 0, \"body\": \"test comment\", \"edited\": false, \"author_flair_css_class\": \"\", \"downs\": 0, \"body_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Etest comment\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"subreddit\": \"ThirdRealm\", \"name\": \"t1_dba9bzn\", \"score_hidden\": false, \"stickied\": false, \"created\": 1481952157.0, \"author_flair_text\": \"ayy lmao\", \"created_utc\": 1481923357.0, \"distinguished\": null, \"mod_reports\": [], \"num_reports\": 0, \"ups\": 1}}], \"after\": null, \"before\": null}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "890",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Fri, 16 Dec 2016 21:24:05 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1740-ORD",
+          "X-Timer": "S1481923445.057226,VS0,VE67",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "596.0",
+          "x-ratelimit-reset": "355",
+          "x-ratelimit-used": "4",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=AixMu78wcusPME5hqbTVuNCTDU0ChzyKBBZJ8pNe8kE4qhUnEYosXeU0XpLnz318wua2k2Xf6Z22nHXTvuLM0DK2IldiiwvR",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/info/?raw_json=1&id=t1_dba9bzn"
+      }
+    },
+    {
+      "recorded_at": "2016-12-16T21:24:05",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&how=yes&id=t1_dba9bzn&sticky=True"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "47",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "loid=rPmTvziRqE2kbgffJU; loidcreated=1481923444000",
+          "User-Agent": "<USER_AGENT> PRAW/4.0.0 prawcore/0.5.0"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/distinguish/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"things\": [{\"kind\": \"t1\", \"data\": {\"subreddit_id\": \"t5_390u2\", \"banned_by\": null, \"removal_reason\": null, \"link_id\": \"t3_5e7xv3\", \"likes\": true, \"replies\": \"\", \"user_reports\": [], \"saved\": false, \"id\": \"dba9bzn\", \"gilded\": 0, \"archived\": false, \"report_reasons\": [], \"author\": \"BJO_test_mod\", \"parent_id\": \"t3_5e7xv3\", \"score\": 1, \"approved_by\": null, \"controversiality\": 0, \"body\": \"test comment\", \"edited\": false, \"author_flair_css_class\": \"\", \"downs\": 0, \"body_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Etest comment\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"subreddit\": \"ThirdRealm\", \"name\": \"t1_dba9bzn\", \"score_hidden\": false, \"stickied\": true, \"created\": 1481952157.0, \"author_flair_text\": \"ayy lmao\", \"created_utc\": 1481923357.0, \"distinguished\": \"moderator\", \"mod_reports\": [], \"num_reports\": 0, \"ups\": 1}}]}}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "851",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Fri, 16 Dec 2016 21:24:05 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1740-ORD",
+          "X-Timer": "S1481923445.190286,VS0,VE165",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "595.0",
+          "x-ratelimit-reset": "355",
+          "x-ratelimit-used": "5",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/distinguish/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/tests/integration/models/reddit/test_subreddit.py
+++ b/tests/integration/models/reddit/test_subreddit.py
@@ -453,6 +453,14 @@ class TestSubredditModeration(IntegrationTest):
             submission = self.reddit.submission('4b536h')
             self.subreddit.mod.distinguish(submission)
 
+    @mock.patch('time.sleep', return_value=None)
+    def test_distinguish__sticky(self, _):
+        self.reddit.read_only = False
+        with self.recorder.use_cassette(
+                'TestSubredditModeration.test_distinguish__sticky'):
+            comment = Comment(self.reddit, 'dba9bzn')
+            self.subreddit.mod.distinguish(comment, sticky=True)
+
     def test_edited(self):
         self.reddit.read_only = False
         with self.recorder.use_cassette('TestSubredditModeration.test_edited'):


### PR DESCRIPTION
## Feature Summary and Justification

This provides a `sticky` parameter for `SubredditModeration.distinguish()`. This allows comments to be stickied.

If the user tries to sticky a submission or a non-root comment, the parameter is ignored and the target is just distinguished. This matches the behavior of PRAW 3.