### PR TITLE
Add LiveContributorRelationship to interact live thread's contributors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Unreleased
 **Added**
 
 * :meth:`.Subreddit.rules` to get the rules of a subreddit.
+* :class:`.LiveContributorRelationship`, which can be obtained through
+  :attr:`.LiveThread.contributor`, to interact with live threads'
+  contributors.
 
 **Fixed**
 

--- a/docs/code_overview/other.rst
+++ b/docs/code_overview/other.rst
@@ -27,6 +27,7 @@ instances of them bound to an attribute of one of the PRAW models.
    :caption: Relationship Helpers
 
    other/contributorrelationship
+   other/livecontributorrelationship
    other/moderatorrelationship
    other/subredditrelationship
 
@@ -50,5 +51,6 @@ instances of them bound to an attribute of one of the PRAW models.
    other/domainlisting
    other/listinggenerator
    other/redditbase
+   other/redditorlist
    other/sublisting
    other/subredditmessage

--- a/docs/code_overview/other/livecontributorrelationship.rst
+++ b/docs/code_overview/other/livecontributorrelationship.rst
@@ -1,0 +1,5 @@
+LiveContributorRelationship
+===========================
+
+.. autoclass:: praw.models.reddit.live.LiveContributorRelationship
+   :inherited-members:

--- a/docs/code_overview/other/redditorlist.rst
+++ b/docs/code_overview/other/redditorlist.rst
@@ -1,0 +1,5 @@
+RedditorList
+============
+
+.. autoclass:: praw.models.RedditorList
+   :inherited-members:

--- a/praw/const.py
+++ b/praw/const.py
@@ -54,6 +54,7 @@ API_PATH = {
     'list_muted':             'r/{subreddit}/about/muted/',
     'list_wikibanned':        'r/{subreddit}/about/wikibanned/',
     'list_wikicontributor':   'r/{subreddit}/about/wikicontributors/',
+    'live_contributors':      'live/{id}/contributors',
     'live_updates':           'live/{id}',
     'liveabout':              'api/live/{id}/about/',
     'livecreate':             'api/live/create',

--- a/praw/models/reddit/live.py
+++ b/praw/models/reddit/live.py
@@ -10,6 +10,23 @@ class LiveThread(RedditBase):
 
     STR_FIELD = 'id'
 
+    @property
+    def contributor(self):
+        """An instance of :class:`.LiveContributorRelationship`.
+
+        Usage:
+
+        .. code-block:: python
+
+           thread = reddit.live('ukaeu1ik4sw5')
+           for contributor in thread.contributor():
+               print(contributor)
+
+        """
+        if self._contributor is None:
+            self._contributor = LiveContributorRelationship(self)
+        return self._contributor
+
     def __eq__(self, other):
         """Return whether the other instance equals the current.
 
@@ -57,6 +74,7 @@ class LiveThread(RedditBase):
         super(LiveThread, self).__init__(reddit, _data)
         if id:
             self.id = id  # pylint: disable=invalid-name
+        self._contributor = None
 
     def _info_path(self):
         return API_PATH['liveabout'].format(id=self.id)
@@ -74,6 +92,33 @@ class LiveThread(RedditBase):
                                        **generator_kwargs):
             update._thread = self
             yield update
+
+
+class LiveContributorRelationship(object):
+    """Provide methods to interact with live threads' contributors."""
+
+    def __call__(self):
+        """Return a :class:`.RedditorList` for live threads' contributors.
+
+        Usage:
+
+        .. code-block:: python
+
+           thread = reddit.live('ukaeu1ik4sw5')
+           for contributor in thread.contributor():
+               print(contributor)
+
+        """
+        url = API_PATH['live_contributors'].format(id=self.thread.id)
+        return self.thread._reddit.get(url)
+
+    def __init__(self, thread):
+        """Create a LiveContributorRelationship instance.
+
+        :param thread: An instance of :class:`.LiveThread`.
+
+        """
+        self.thread = thread
 
 
 class LiveUpdate(RedditBase):

--- a/tests/integration/cassettes/TestLiveThread_test_contributor.json
+++ b/tests/integration/cassettes/TestLiveThread_test_contributor.json
@@ -1,0 +1,110 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2016-12-29T19:59:12",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=client_credentials"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "29",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "<USER_AGENT> PRAW/4.2.0dev0 prawcore/0.6.0"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Thu, 29 Dec 2016 19:59:12 GMT",
+          "Server": "snooserv",
+          "Set-Cookie": "loid=6VWEzb8X3rbjBiHD0c; Domain=reddit.com; Max-Age=63071999; Path=/;  secure",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-nrt6121-NRT",
+          "X-Timer": "S1483041552.466379,VS0,VE223",
+          "cache-control": "max-age=0, must-revalidate",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2016-12-29T19:59:13",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "loid=6VWEzb8X3rbjBiHD0c; loidcreated=1483041552000",
+          "User-Agent": "<USER_AGENT> PRAW/4.2.0dev0 prawcore/0.6.0"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/live/ukaeu1ik4sw5/contributors?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"permissions\": [\"all\"], \"id\": \"t2_f3lhp\", \"name\": \"Acidtwist\"}, {\"permissions\": [\"all\"], \"id\": \"t2_x3go0\", \"name\": \"BigSeanNorcal\"}, {\"permissions\": [\"all\"], \"id\": \"t2_35xck\", \"name\": \"Deimorz\"}, {\"permissions\": [\"all\"], \"id\": \"t2_56z0c\", \"name\": \"Drunken_Economist\"}, {\"permissions\": [\"all\"], \"id\": \"t2_4qfwd\", \"name\": \"Kaitaan\"}, {\"permissions\": [\"all\"], \"id\": \"t2_7v7al\", \"name\": \"MiamiZ\"}, {\"permissions\": [\"all\"], \"id\": \"t2_3bzrh\", \"name\": \"ajacksified\"}, {\"permissions\": [\"all\"], \"id\": \"t2_iqcik\", \"name\": \"aurora-73\"}, {\"permissions\": [\"all\"], \"id\": \"t2_3c639\", \"name\": \"bsimpson\"}, {\"permissions\": [\"all\"], \"id\": \"t2_gj0o7\", \"name\": \"curioussavage01\"}, {\"permissions\": [\"all\"], \"id\": \"t2_h9tvp\", \"name\": \"fruchtose\"}, {\"permissions\": [\"all\"], \"id\": \"t2_4jieu\", \"name\": \"gooeyblob\"}, {\"permissions\": [\"all\"], \"id\": \"t2_31cmr\", \"name\": \"jase\"}, {\"permissions\": [\"all\"], \"id\": \"t2_8b1zx\", \"name\": \"jophuds\"}, {\"permissions\": [\"all\"], \"id\": \"t2_387de\", \"name\": \"lev\"}, {\"permissions\": [\"all\"], \"id\": \"t2_3q98d\", \"name\": \"madlee\"}, {\"permissions\": [\"all\"], \"id\": \"t2_tklrq\", \"name\": \"nr4madas\"}, {\"permissions\": [\"all\"], \"id\": \"t2_5wqa4\", \"name\": \"powerlanguage\"}, {\"permissions\": [\"all\"], \"id\": \"t2_5wfps\", \"name\": \"rram\"}, {\"permissions\": [\"all\"], \"id\": \"t2_fa0tm\", \"name\": \"rrmckinley\"}, {\"permissions\": [\"all\"], \"id\": \"t2_3imtq\", \"name\": \"spladug\"}, {\"permissions\": [\"all\"], \"id\": \"t2_xjb3u\", \"name\": \"thephilthe\"}, {\"permissions\": [\"all\"], \"id\": \"t2_118y3e\", \"name\": \"therealandytuba\"}, {\"permissions\": [\"all\"], \"id\": \"t2_wfz1t\", \"name\": \"toasties\"}, {\"permissions\": [\"all\"], \"id\": \"t2_1jsxv\", \"name\": \"umbrae\"}, {\"permissions\": [\"all\"], \"id\": \"t2_8idfg\", \"name\": \"wting\"}, {\"permissions\": [\"all\"], \"id\": \"t2_2fb8r\", \"name\": \"zeantsoi\"}]}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1791",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Thu, 29 Dec 2016 19:59:12 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-nrt6129-NRT",
+          "X-Timer": "S1483041552.794479,VS0,VE194",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "X-Reddit-Tracking, X-Moose",
+          "cache-control": "max-age=0, must-revalidate",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=vZ%2FbSUCzXOPOLOFFn1QcWtLnc6joPbiuXwdZeM44EMsa0vOGkfAywmanD5lJZU%2FI61ATRzkPGPgo6q1yCIeoW8ffEW3IKl5W",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/live/ukaeu1ik4sw5/contributors?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/tests/integration/models/reddit/test_live.py
+++ b/tests/integration/models/reddit/test_live.py
@@ -1,11 +1,19 @@
 """Test praw.models.LiveThread"""
-from praw.models import LiveThread
+from praw.models import LiveThread, RedditorList
 import mock
 
 from ... import IntegrationTest
 
 
 class TestLiveThread(IntegrationTest):
+    @mock.patch('time.sleep', return_value=None)
+    def test_contributor(self, _):
+        thread = LiveThread(self.reddit, 'ukaeu1ik4sw5')
+        with self.recorder.use_cassette('TestLiveThread_test_contributor'):
+            contributors = thread.contributor()
+        assert isinstance(contributors, RedditorList)
+        assert len(contributors) > 0
+
     @mock.patch('time.sleep', return_value=None)
     def test_init(self, _):
         thread = LiveThread(self.reddit, 'ukaeu1ik4sw5')

--- a/tests/unit/models/reddit/test_live.py
+++ b/tests/unit/models/reddit/test_live.py
@@ -2,6 +2,7 @@ import pickle
 
 import pytest
 from praw.models import LiveThread, LiveUpdate, Redditor
+from praw.models.reddit.live import LiveContributorRelationship
 
 from ... import UnitTest
 
@@ -29,6 +30,11 @@ class TestLiveThread(UnitTest):
         with pytest.raises(TypeError) as excinfo:
             LiveThread(self.reddit, id='dummy', _data={'id': 'dummy'})
         assert str(excinfo.value) == message
+
+    def test_contributor(self):
+        thread_id = 'ukaeu1ik4sw5'
+        thread = LiveThread(self.reddit, thread_id)
+        assert isinstance(thread.contributor, LiveContributorRelationship)
 
     def test_equality(self):
         thread1 = LiveThread(self.reddit, id='dummy1')


### PR DESCRIPTION
## Feature Summary and Justification

This feature provides interface for live thread's contributors. Usage:

```
thread = reddit.live('ukaeu1ik4sw5')
rel = thread.contributor  # LiveContributorRelationship
redditors = rel()  # RedditorList
```

LiveContributorRedditorList returns RedditorList rather than ListingGernarator because /live/:thread_id/contributors doesn't implement listing interface, e.g., https://www.reddit.com/live/ta535s1hq2je/contributors.json

## References

* #676 
* https://www.reddit.com/dev/api#GET_live_{thread}_contributors

## Concerns

I got warning when I ran `pre_push.py`

```
Warning, treated as error:
docstring of praw.models.LiveThread.contributor:1: WARNING: py:class reference target notfound: LiveContributorRelationship
```

How can I resolve this error?