### PR TITLE
Fix LiveContributorRelationship callable return type

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,7 @@ Unreleased
 * Working with contributors on :class:`.SubredditWiki` is done consistently
   through ``contributor`` not ``contributors``.
 * ``Subreddit.moderator()`` works.
+* ``live_thread.contributor()`` now returns :class:`.RedditorList` correctly.
 
 **Removed**
 

--- a/praw/models/reddit/live.py
+++ b/praw/models/reddit/live.py
@@ -1,6 +1,7 @@
 """Provide the LiveThread class."""
 from ...const import API_PATH
 from ..listing.generator import ListingGenerator
+from ..list.redditor import RedditorList
 from .base import RedditBase
 from .redditor import Redditor
 
@@ -110,7 +111,8 @@ class LiveContributorRelationship(object):
 
         """
         url = API_PATH['live_contributors'].format(id=self.thread.id)
-        return self.thread._reddit.get(url)
+        temp = self.thread._reddit.get(url)
+        return temp if isinstance(temp, RedditorList) else temp[0]
 
     def __init__(self, thread):
         """Create a LiveContributorRelationship instance.

--- a/tests/integration/cassettes/TestLiveThread_test_contributor__with_manage_permission.json
+++ b/tests/integration/cassettes/TestLiveThread_test_contributor__with_manage_permission.json
@@ -1,0 +1,166 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-01-05T15:55:22",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "83",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "<USER_AGENT> PRAW/4.2.0dev0 prawcore/0.6.0"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Thu, 05 Jan 2017 15:55:22 GMT",
+          "Server": "snooserv",
+          "Set-Cookie": "loid=mmxca2C57zW0WQ0jyd; Domain=reddit.com; Max-Age=63071999; Path=/;  secure",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-nrt6124-NRT",
+          "X-Timer": "S1483631722.274661,VS0,VE537",
+          "cache-control": "max-age=0, must-revalidate",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2017-01-05T15:55:22",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "loid=mmxca2C57zW0WQ0jyd; loidcreated=1483631722000",
+          "User-Agent": "<USER_AGENT> PRAW/4.2.0dev0 prawcore/0.6.0"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/live/xyu8kmjvfrww/contributors?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"UserList\", \"data\": {\"children\": [{\"permissions\": [\"all\"], \"id\": \"t2_12xwv0\", \"name\": \"<USERNAME>\"}, {\"permissions\": [\"all\"], \"id\": \"t2_ll32z\", \"name\": \"nmtake\"}]}}, {\"kind\": \"UserList\", \"data\": {\"children\": []}}]"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "231",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Thu, 05 Jan 2017 15:55:23 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-nrt6127-NRT",
+          "X-Timer": "S1483631722.967007,VS0,VE235",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "599.0",
+          "x-ratelimit-reset": "277",
+          "x-ratelimit-used": "1",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=U2JDXf60BeMcAgCHtLMdipf%2B4%2FbR0MUzy0RXZIhDY7ERATSK9j4G5fyvumED%2F%2B98DUiiND%2FU14KSmFEWyDaKa8mVLZyyW0yw",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/live/xyu8kmjvfrww/contributors?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-01-05T15:55:22",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "loid=mmxca2C57zW0WQ0jyd; loidcreated=1483631722000",
+          "User-Agent": "<USER_AGENT> PRAW/4.2.0dev0 prawcore/0.6.0"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/live/xyu8kmjvfrww/contributors?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"UserList\", \"data\": {\"children\": [{\"permissions\": [\"all\"], \"id\": \"t2_12xwv0\", \"name\": \"<USERNAME>\"}, {\"permissions\": [\"all\"], \"id\": \"t2_ll32z\", \"name\": \"nmtake\"}]}}, {\"kind\": \"UserList\", \"data\": {\"children\": []}}]"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "231",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Thu, 05 Jan 2017 15:55:23 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-nrt6127-NRT",
+          "X-Timer": "S1483631723.218005,VS0,VE236",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "598.0",
+          "x-ratelimit-reset": "277",
+          "x-ratelimit-used": "2",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=bQqV56n6d8e4WTmWVAM7vuucZQIYwuOpagPLC20rOkzrnVPLrripvkH5gfYKHKaP9ykq8JruIrNp3MAlWtXKlzva6OYjfXsa",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/live/xyu8kmjvfrww/contributors?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/tests/integration/models/reddit/test_live.py
+++ b/tests/integration/models/reddit/test_live.py
@@ -1,4 +1,5 @@
 """Test praw.models.LiveThread"""
+from praw.const import API_PATH
 from praw.models import LiveThread, RedditorList
 import mock
 
@@ -11,6 +12,20 @@ class TestLiveThread(IntegrationTest):
         thread = LiveThread(self.reddit, 'ukaeu1ik4sw5')
         with self.recorder.use_cassette('TestLiveThread_test_contributor'):
             contributors = thread.contributor()
+        assert isinstance(contributors, RedditorList)
+        assert len(contributors) > 0
+
+    @mock.patch('time.sleep', return_value=None)
+    def test_contributor__with_manage_permission(self, _):
+        # see issue #710 for more info
+        self.reddit.read_only = False
+        thread = LiveThread(self.reddit, 'xyu8kmjvfrww')
+        url = API_PATH['live_contributors'].format(id=thread.id)
+        with self.recorder.use_cassette(
+                'TestLiveThread_test_contributor__with_manage_permission'):
+            data = thread._reddit.request('GET', url)
+            contributors = thread.contributor()
+        assert isinstance(data, list)
         assert isinstance(contributors, RedditorList)
         assert len(contributors) > 0
 


### PR DESCRIPTION
Fixes #710 

``live_thread.contributor()`` now returns `RedditorList` correctly. Information about pending invitations, which is included when caller have 'manage' permission,  are dropped.