### PR TITLE
Add `LiveThreadContribution.close`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,6 +15,7 @@ Unreleased
 * :attr:`.LiveThread.contrib` to obtain an instance of
   :class:`.LiveThreadContribution`.
 * :meth:`.LiveThreadContribution.add` to add an update to the live thread.
+* :meth:`.LiveThreadContribution.close` to close the live thread permanently.
 
 **Fixed**
 

--- a/praw/const.py
+++ b/praw/const.py
@@ -57,6 +57,7 @@ API_PATH = {
     'list_wikibanned':        'r/{subreddit}/about/wikibanned/',
     'list_wikicontributor':   'r/{subreddit}/about/wikicontributors/',
     'live_add_update':        'api/live/{id}/update',
+    'live_close':             'api/live/{id}/close_thread',
     'live_contributors':      'live/{id}/contributors',
     'live_invite':            'api/live/{id}/invite_contributor',
     'live_leave':             'api/live/{id}/leave_contributor',

--- a/praw/models/reddit/live.py
+++ b/praw/models/reddit/live.py
@@ -262,6 +262,20 @@ class LiveThreadContribution(object):
         url = API_PATH['live_add_update'].format(id=self.thread.id)
         self.thread._reddit.post(url, data={'body': body})
 
+    def close(self):
+        """Close the live thread permanently (cannot be undone).
+
+        Usage:
+
+        .. code-block:: python
+
+           thread = reddit.live('ukaeu1ik4sw5')
+           thread.contrib.close()
+
+        """
+        url = API_PATH['live_close'].format(id=self.thread.id)
+        self.thread._reddit.post(url)
+
 
 class LiveUpdate(RedditBase):
     """An individual :class:`.LiveUpdate` object."""

--- a/tests/integration/cassettes/TestLiveThreadContribution_add.json
+++ b/tests/integration/cassettes/TestLiveThreadContribution_add.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2017-01-15T11:09:57",
+      "recorded_at": "2017-01-16T13:22:13",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -29,16 +29,16 @@
           "Connection": "keep-alive",
           "Content-Length": "105",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sun, 15 Jan 2017 11:09:57 GMT",
+          "Date": "Mon, 16 Jan 2017 13:22:14 GMT",
           "Server": "snooserv",
-          "Set-Cookie": "loid=f7OvvP9F5zSGjU02XL; Domain=reddit.com; Max-Age=63071999; Path=/;  secure",
+          "Set-Cookie": "loid=hhMfgZMxwj9PGpU0zy; Domain=reddit.com; Max-Age=63071999; Path=/;  secure",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Via": "1.1 varnish",
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
           "X-Served-By": "cache-nrt6130-NRT",
-          "X-Timer": "S1484478596.941706,VS0,VE480",
+          "X-Timer": "S1484572933.534884,VS0,VE509",
           "cache-control": "max-age=0, must-revalidate",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
@@ -52,20 +52,20 @@
       }
     },
     {
-      "recorded_at": "2017-01-15T11:09:57",
+      "recorded_at": "2017-01-16T13:22:13",
       "request": {
         "body": {
           "encoding": "utf-8",
-          "string": "api_type=json&body=%2A+%60LiveThreadContrib.add%28%29+test%60"
+          "string": "api_type=json&body=%2A+%60LiveThreadContribution.add%28%29+test%60"
         },
         "headers": {
           "Accept": "*/*",
           "Accept-Encoding": "identity",
           "Authorization": "bearer <ACCESS_TOKEN>",
           "Connection": "keep-alive",
-          "Content-Length": "61",
+          "Content-Length": "66",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "loid=f7OvvP9F5zSGjU02XL; loidcreated=1484478596000",
+          "Cookie": "loid=hhMfgZMxwj9PGpU0zy; loidcreated=1484572933000",
           "User-Agent": "<USER_AGENT> PRAW/4.2.1dev0 prawcore/0.6.0"
         },
         "method": "POST",
@@ -81,21 +81,21 @@
           "Connection": "keep-alive",
           "Content-Length": "24",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sun, 15 Jan 2017 11:09:57 GMT",
+          "Date": "Mon, 16 Jan 2017 13:22:14 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Via": "1.1 varnish",
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-nrt6127-NRT",
-          "X-Timer": "S1484478597.637939,VS0,VE206",
+          "X-Served-By": "cache-nrt6120-NRT",
+          "X-Timer": "S1484572934.114219,VS0,VE195",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
           "x-ratelimit-remaining": "599.0",
-          "x-ratelimit-reset": "3",
+          "x-ratelimit-reset": "466",
           "x-ratelimit-used": "1",
           "x-ua-compatible": "IE=edge",
           "x-xss-protection": "1; mode=block"

--- a/tests/integration/cassettes/TestLiveThreadContribution_close.json
+++ b/tests/integration/cassettes/TestLiveThreadContribution_close.json
@@ -1,0 +1,112 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-01-16T13:38:20",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "83",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "<USER_AGENT> PRAW/4.2.1dev0 prawcore/0.6.0"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 16 Jan 2017 13:38:21 GMT",
+          "Server": "snooserv",
+          "Set-Cookie": "loid=GvMynZhCtVMVhRw8qf; Domain=reddit.com; Max-Age=63071999; Path=/;  secure",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-nrt6121-NRT",
+          "X-Timer": "S1484573900.513909,VS0,VE515",
+          "cache-control": "max-age=0, must-revalidate",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2017-01-16T13:38:20",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "13",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "loid=GvMynZhCtVMVhRw8qf; loidcreated=1484573900000",
+          "User-Agent": "<USER_AGENT> PRAW/4.2.1dev0 prawcore/0.6.0"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/live/ya2tmqiyb064/close_thread?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 16 Jan 2017 13:38:21 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-nrt6127-NRT",
+          "X-Timer": "S1484573901.276643,VS0,VE186",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "597.0",
+          "x-ratelimit-reset": "99",
+          "x-ratelimit-used": "3",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/live/ya2tmqiyb064/close_thread?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/tests/integration/models/reddit/test_live.py
+++ b/tests/integration/models/reddit/test_live.py
@@ -148,3 +148,11 @@ class TestLiveThreadContribution(IntegrationTest):
         with self.recorder.use_cassette(
                 'TestLiveThreadContribution_add'):
             thread.contrib.add('* `LiveThreadContribution.add() test`')
+
+    @mock.patch('time.sleep', return_value=None)
+    def test_close(self, _):
+        self.reddit.read_only = False
+        thread = LiveThread(self.reddit, 'ya2tmqiyb064')
+        with self.recorder.use_cassette(
+                'TestLiveThreadContribution_close'):
+            thread.contrib.close()

--- a/tests/integration/models/reddit/test_live.py
+++ b/tests/integration/models/reddit/test_live.py
@@ -140,11 +140,11 @@ class TestLiveContributorRelationship(IntegrationTest):
             thread.contributor.remove_invite(redditor)
 
 
-class TestLiveThreadContrib(IntegrationTest):
+class TestLiveThreadContribution(IntegrationTest):
     @mock.patch('time.sleep', return_value=None)
     def test_add(self, _):
         self.reddit.read_only = False
         thread = LiveThread(self.reddit, 'xyu8kmjvfrww')
         with self.recorder.use_cassette(
-                'TestLiveThreadContrib_add'):
-            thread.contrib.add('* `LiveThreadContrib.add() test`')
+                'TestLiveThreadContribution_add'):
+            thread.contrib.add('* `LiveThreadContribution.add() test`')


### PR DESCRIPTION
## Feature Summary

This feature provides intaface to POST /api/live/thread/close_thread which closes the live thread permanently.

## References

* https://www.reddit.com/dev/api#POST_api_live_{thread}_close_thread
* #676 - feature request for reddit live
* nmtake@e147a37#commitcomment-19895733 - API design discussion