### PR TITLE
Add LiveUpdateContribution.remove

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Unreleased
   :class:`.LiveThreadContribution`.
 * :meth:`.LiveThreadContribution.add` to add an update to the live thread.
 * :meth:`.LiveThreadContribution.close` to close the live thread permanently.
+* :attr:`.LiveUpdate.contrib` to obtain an instance of
+  :class:`.LiveUpdateContribution`.
 
 **Fixed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,7 @@ Unreleased
 * :meth:`.LiveThreadContribution.close` to close the live thread permanently.
 * :attr:`.LiveUpdate.contrib` to obtain an instance of
   :class:`.LiveUpdateContribution`.
+* :meth:`.LiveUpdateContribution.remove` to remove a live update.
 
 **Fixed**
 

--- a/docs/code_overview/other.rst
+++ b/docs/code_overview/other.rst
@@ -19,6 +19,7 @@ instances of them bound to an attribute of one of the PRAW models.
 
    other/livecontributorrelationship
    other/livethreadcontribution
+   other/liveupdatecontribution
 
 .. toctree::
    :maxdepth: 2

--- a/docs/code_overview/other/liveupdatecontribution.rst
+++ b/docs/code_overview/other/liveupdatecontribution.rst
@@ -1,0 +1,5 @@
+LiveUpdateContribution
+======================
+
+.. autoclass:: praw.models.reddit.live.LiveUpdateContribution
+   :inherited-members:

--- a/praw/const.py
+++ b/praw/const.py
@@ -61,6 +61,7 @@ API_PATH = {
     'live_contributors':      'live/{id}/contributors',
     'live_invite':            'api/live/{id}/invite_contributor',
     'live_leave':             'api/live/{id}/leave_contributor',
+    'live_remove_update':     'api/live/{id}/delete_update',
     'live_remove_contrib':    'api/live/{id}/rm_contributor',
     'live_remove_invite':     'api/live/{id}/rm_contributor_invite',
     'live_updates':           'live/{id}',

--- a/praw/models/reddit/live.py
+++ b/praw/models/reddit/live.py
@@ -283,6 +283,23 @@ class LiveUpdate(RedditBase):
     STR_FIELD = 'id'
 
     @property
+    def contrib(self):
+        """An instance of :class:`.LiveUpdateContribution`.
+
+        Usage:
+
+        .. code-block:: python
+
+           thread = reddit.live('ukaeu1ik4sw5')
+           update = thread['7827987a-c998-11e4-a0b9-22000b6a88d2']
+           update.contrib  # LiveUpdateContribution instance
+
+        """
+        if self._contrib is None:
+            self._contrib = LiveUpdateContribution(self)
+        return self._contrib
+
+    @property
     def thread(self):
         """Return :class:`.LiveThread` object the update object belongs to."""
         return self._thread
@@ -319,6 +336,7 @@ class LiveUpdate(RedditBase):
             self._thread = LiveThread(self._reddit, thread_id)
             self.id = update_id  # pylint: disable=invalid-name
             self._fetched = True
+            self._contrib = None
         else:
             raise TypeError('Either `thread_id` and `update_id`, or '
                             '`_data` must be provided.')
@@ -328,3 +346,25 @@ class LiveUpdate(RedditBase):
         if attribute == 'author':
             value = Redditor(self._reddit, name=value)
         super(LiveUpdate, self).__setattr__(attribute, value)
+
+
+class LiveUpdateContribution(object):
+    """Provides a set of contribution functions to LiveUpdate."""
+
+    def __init__(self, update):
+        """Create an instance of :class:`.LiveUpdateContribution`.
+
+        :param update: An instance of :class:`.LiveUpdate`.
+
+        This instance can be retrieved through ``update.contrib``
+        where update is a :class:`.LiveUpdate` instance. E.g.,
+
+        .. code-block:: python
+
+           thread = reddit.live('ukaeu1ik4sw5')
+           update = thread['7827987a-c998-11e4-a0b9-22000b6a88d2']
+           update.contrib  # LiveUpdateContribution instance
+           update.contrib.remove()
+
+        """
+        self.update = update

--- a/praw/models/reddit/live.py
+++ b/praw/models/reddit/live.py
@@ -368,3 +368,9 @@ class LiveUpdateContribution(object):
 
         """
         self.update = update
+
+    def remove(self):
+        """Remove a live update."""
+        url = API_PATH['live_remove_update'].format(id=self.update.thread.id)
+        data = {'id': self.update.fullname}
+        self.update.thread._reddit.post(url, data=data)

--- a/tests/integration/cassettes/TestLiveUpdateContribution_remove.json
+++ b/tests/integration/cassettes/TestLiveUpdateContribution_remove.json
@@ -1,0 +1,112 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-01-16T21:06:12",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "83",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "<USER_AGENT> PRAW/4.2.1dev0 prawcore/0.6.0"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 16 Jan 2017 21:06:14 GMT",
+          "Server": "snooserv",
+          "Set-Cookie": "loid=m14oqgW0HHoTNVn5Xl; Domain=reddit.com; Max-Age=63071999; Path=/;  secure",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-nrt6123-NRT",
+          "X-Timer": "S1484600773.655336,VS0,VE512",
+          "cache-control": "max-age=0, must-revalidate",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2017-01-16T21:06:13",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=LiveUpdate_5d556760-dbee-11e6-9f46-0e78de675452"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "64",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "loid=m14oqgW0HHoTNVn5Xl; loidcreated=1484600773000",
+          "User-Agent": "<USER_AGENT> PRAW/4.2.1dev0 prawcore/0.6.0"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/live/xyu8kmjvfrww/delete_update?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 16 Jan 2017 21:06:15 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-nrt6130-NRT",
+          "X-Timer": "S1484600774.453529,VS0,VE695",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "599.0",
+          "x-ratelimit-reset": "225",
+          "x-ratelimit-used": "1",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/live/xyu8kmjvfrww/delete_update?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/tests/integration/models/reddit/test_live.py
+++ b/tests/integration/models/reddit/test_live.py
@@ -9,8 +9,7 @@ from ... import IntegrationTest
 
 
 class TestLiveThread(IntegrationTest):
-    @mock.patch('time.sleep', return_value=None)
-    def test_contributor(self, _):
+    def test_contributor(self):
         thread = LiveThread(self.reddit, 'ukaeu1ik4sw5')
         with self.recorder.use_cassette('TestLiveThread_test_contributor'):
             contributors = thread.contributor()
@@ -31,8 +30,7 @@ class TestLiveThread(IntegrationTest):
         assert isinstance(contributors, RedditorList)
         assert len(contributors) > 0
 
-    @mock.patch('time.sleep', return_value=None)
-    def test_init(self, _):
+    def test_init(self):
         thread = LiveThread(self.reddit, 'ukaeu1ik4sw5')
         with self.recorder.use_cassette('TestLiveThread_test_init'):
             assert thread.title == 'reddit updates'
@@ -59,32 +57,28 @@ class TestLiveContributorRelationship(IntegrationTest):
                 thread.contributor.invite('nmtake')
         assert excinfo.value.error_type == 'LIVEUPDATE_ALREADY_CONTRIBUTOR'
 
-    @mock.patch('time.sleep', return_value=None)
-    def test_invite__empty_list(self, _):
+    def test_invite__empty_list(self):
         self.reddit.read_only = False
         thread = LiveThread(self.reddit, 'xyu8kmjvfrww')
         with self.recorder.use_cassette(
                 'TestLiveContributorRelationship_test_invite__empty_list'):
             thread.contributor.invite('nmtake', [])
 
-    @mock.patch('time.sleep', return_value=None)
-    def test_invite__limited(self, _):
+    def test_invite__limited(self):
         self.reddit.read_only = False
         thread = LiveThread(self.reddit, 'xyu8kmjvfrww')
         with self.recorder.use_cassette(
                 'TestLiveContributorRelationship_test_invite__limited'):
             thread.contributor.invite('nmtake', ['manage', 'edit'])
 
-    @mock.patch('time.sleep', return_value=None)
-    def test_invite__none(self, _):
+    def test_invite__none(self):
         self.reddit.read_only = False
         thread = LiveThread(self.reddit, 'xyu8kmjvfrww')
         with self.recorder.use_cassette(
                 'TestLiveContributorRelationship_test_invite__none'):
             thread.contributor.invite('nmtake', None)
 
-    @mock.patch('time.sleep', return_value=None)
-    def test_invite__redditor(self, _):
+    def test_invite__redditor(self):
         self.reddit.read_only = False
         thread = LiveThread(self.reddit, 'xyu8kmjvfrww')
         redditor = Redditor(self.reddit,
@@ -93,24 +87,21 @@ class TestLiveContributorRelationship(IntegrationTest):
                 'TestLiveContributorRelationship_test_invite__redditor'):
             thread.contributor.invite(redditor)
 
-    @mock.patch('time.sleep', return_value=None)
-    def test_leave(self, _):
+    def test_leave(self):
         self.reddit.read_only = False
         thread = LiveThread(self.reddit, 'xyu8kmjvfrww')
         with self.recorder.use_cassette(
                 'TestLiveContributorRelationship_test_leave'):
             thread.contributor.leave()
 
-    @mock.patch('time.sleep', return_value=None)
-    def test_remove__fullname(self, _):
+    def test_remove__fullname(self):
         self.reddit.read_only = False
         thread = LiveThread(self.reddit, 'xyu8kmjvfrww')
         with self.recorder.use_cassette(
                 'TestLiveContributorRelationship_test_remove__fullname'):
             thread.contributor.remove('t2_ll32z')
 
-    @mock.patch('time.sleep', return_value=None)
-    def test_remove__redditor(self, _):
+    def test_remove__redditor(self):
         self.reddit.read_only = False
         thread = LiveThread(self.reddit, 'xyu8kmjvfrww')
         redditor = Redditor(self.reddit,
@@ -119,8 +110,7 @@ class TestLiveContributorRelationship(IntegrationTest):
                 'TestLiveContributorRelationship_test_remove__redditor'):
             thread.contributor.remove(redditor)
 
-    @mock.patch('time.sleep', return_value=None)
-    def test_remove_invite__fullname(self, _):
+    def test_remove_invite__fullname(self):
         self.reddit.read_only = False
         thread = LiveThread(self.reddit, 'xyu8kmjvfrww')
         with self.recorder.use_cassette(
@@ -128,8 +118,7 @@ class TestLiveContributorRelationship(IntegrationTest):
                 'test_remove_invite__fullname'):
             thread.contributor.remove_invite('t2_ll32z')
 
-    @mock.patch('time.sleep', return_value=None)
-    def test_remove_invite__redditor(self, _):
+    def test_remove_invite__redditor(self):
         self.reddit.read_only = False
         thread = LiveThread(self.reddit, 'xyu8kmjvfrww')
         redditor = Redditor(self.reddit,
@@ -141,16 +130,14 @@ class TestLiveContributorRelationship(IntegrationTest):
 
 
 class TestLiveThreadContribution(IntegrationTest):
-    @mock.patch('time.sleep', return_value=None)
-    def test_add(self, _):
+    def test_add(self):
         self.reddit.read_only = False
         thread = LiveThread(self.reddit, 'xyu8kmjvfrww')
         with self.recorder.use_cassette(
                 'TestLiveThreadContribution_add'):
             thread.contrib.add('* `LiveThreadContribution.add() test`')
 
-    @mock.patch('time.sleep', return_value=None)
-    def test_close(self, _):
+    def test_close(self):
         self.reddit.read_only = False
         thread = LiveThread(self.reddit, 'ya2tmqiyb064')
         with self.recorder.use_cassette(

--- a/tests/integration/models/reddit/test_live.py
+++ b/tests/integration/models/reddit/test_live.py
@@ -1,7 +1,7 @@
 """Test praw.models.LiveThread"""
 from praw.const import API_PATH
 from praw.exceptions import APIException
-from praw.models import LiveThread, Redditor, RedditorList
+from praw.models import LiveThread, LiveUpdate, Redditor, RedditorList
 import mock
 import pytest
 
@@ -156,3 +156,14 @@ class TestLiveThreadContribution(IntegrationTest):
         with self.recorder.use_cassette(
                 'TestLiveThreadContribution_close'):
             thread.contrib.close()
+
+
+class TestLiveUpdateContribution(IntegrationTest):
+    @mock.patch('time.sleep', return_value=None)
+    def test_remove(self, _):
+        self.reddit.read_only = False
+        update = LiveUpdate(self.reddit, 'xyu8kmjvfrww',
+                            '5d556760-dbee-11e6-9f46-0e78de675452')
+        with self.recorder.use_cassette(
+                'TestLiveUpdateContribution_remove'):
+            update.contrib.remove()

--- a/tests/unit/models/reddit/test_live.py
+++ b/tests/unit/models/reddit/test_live.py
@@ -4,6 +4,7 @@ import pytest
 from praw.models import LiveThread, LiveUpdate, Redditor
 from praw.models.reddit.live import LiveContributorRelationship
 from praw.models.reddit.live import LiveThreadContribution
+from praw.models.reddit.live import LiveUpdateContribution
 
 from ... import UnitTest
 
@@ -134,6 +135,12 @@ class TestLiveUpdate(UnitTest):
         with pytest.raises(TypeError) as excinfo:
             LiveUpdate(self.reddit, update_id=update_id)
         assert str(excinfo.value) == message
+
+    def test_contrib(self):
+        thread_id = 'dummy_thread_id'
+        update_id = 'dummy_update_id'
+        update = LiveUpdate(self.reddit, thread_id, update_id)
+        assert isinstance(update.contrib, LiveUpdateContribution)
 
     def test_setattr(self):
         data = {'id': 'dummy_update_id', 'author': 'dummy_author'}


### PR DESCRIPTION
## Feature Summary

This feature provides intaface to POST /api/live/thread/delete_udpate which removes a live update.

## References
* https://www.reddit.com/dev/api#POST_api_live_{thread}_delete_update
* #676 - feature request for reddit live
* nmtake@e147a37 - API design discussion