### PR TITLE
Add LiveContributorRelationship.accept_invite

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,8 @@ Unreleased
 * :attr:`.LiveUpdate.contrib` to obtain an instance of
   :class:`.LiveUpdateContribution`.
 * :meth:`.LiveUpdateContribution.remove` to remove a live update.
+* :meth:`.LiveContributorRelationship.accept_invite` to accept an invite to
+  contribute the live thread.
 
 **Fixed**
 

--- a/praw/const.py
+++ b/praw/const.py
@@ -56,6 +56,7 @@ API_PATH = {
     'list_muted':             'r/{subreddit}/about/muted/',
     'list_wikibanned':        'r/{subreddit}/about/wikibanned/',
     'list_wikicontributor':   'r/{subreddit}/about/wikicontributors/',
+    'live_accept_invite':     'api/live/{id}/accept_contributor_invite',
     'live_add_update':        'api/live/{id}/update',
     'live_close':             'api/live/{id}/close_thread',
     'live_contributors':      'live/{id}/contributors',

--- a/praw/models/reddit/live.py
+++ b/praw/models/reddit/live.py
@@ -33,6 +33,11 @@ class LiveContributorRelationship(object):
         """
         self.thread = thread
 
+    def accept_invite(self):
+        """Accept an invite to contribute the live thread."""
+        url = API_PATH['live_accept_invite'].format(id=self.thread.id)
+        self.thread._reddit.post(url)
+
     def invite(self, redditor, permissions=None):
         """Invite a redditor to be a contributor of the live thread.
 

--- a/tests/integration/cassettes/TestLiveContributorRelationship_test_accept_invite.json
+++ b/tests/integration/cassettes/TestLiveContributorRelationship_test_accept_invite.json
@@ -1,0 +1,112 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-01-18T21:19:24",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "83",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "<USER_AGENT> PRAW/4.2.1dev0 prawcore/0.7.0"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Wed, 18 Jan 2017 21:19:25 GMT",
+          "Server": "snooserv",
+          "Set-Cookie": "loid=4115CrT5jjrNEL1Zoj; Domain=reddit.com; Max-Age=63071999; Path=/;  secure",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-nrt6125-NRT",
+          "X-Timer": "S1484774364.534929,VS0,VE515",
+          "cache-control": "max-age=0, must-revalidate",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2017-01-18T21:19:25",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "13",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "loid=4115CrT5jjrNEL1Zoj; loidcreated=1484774364000",
+          "User-Agent": "<USER_AGENT> PRAW/4.2.1dev0 prawcore/0.7.0"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/live/xyu8kmjvfrww/accept_contributor_invite?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Wed, 18 Jan 2017 21:19:25 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-nrt6132-NRT",
+          "X-Timer": "S1484774365.269140,VS0,VE238",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "598.0",
+          "x-ratelimit-reset": "35",
+          "x-ratelimit-used": "2",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/live/xyu8kmjvfrww/accept_contributor_invite?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/tests/integration/models/reddit/test_live.py
+++ b/tests/integration/models/reddit/test_live.py
@@ -45,6 +45,13 @@ class TestLiveThread(IntegrationTest):
 
 
 class TestLiveContributorRelationship(IntegrationTest):
+    def test_accept_invite(self):
+        self.reddit.read_only = False
+        thread = LiveThread(self.reddit, 'xyu8kmjvfrww')
+        with self.recorder.use_cassette(
+                'TestLiveContributorRelationship_test_accept_invite'):
+            thread.contributor.accept_invite()
+
     @mock.patch('time.sleep', return_value=None)
     def test_invite__already_invited(self, _):
         self.reddit.read_only = False


### PR DESCRIPTION
## Feature Summary

This feature provides intaface to `POST /api/live/thread/accept_contributor_invite` which accepts an invite to contribute the live thread.

## References
* https://www.reddit.com/dev/api#POST_api_live_{thread}_accept_contributor_invite
* #676 - feature request for reddit live
* nmtake@e147a37 - API design discussion