### PR TITLE
Add LiveUpdateContribution.strike to strike a content of a live thread.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Unreleased
 * :meth:`.upload_mobile_icon` to upload subreddit mobile icon.
 * :meth:`.delete_mobile_header` to remove subreddit mobile header.
 * :meth:`.delete_mobile_icon` to remove subreddit mobile icon.
+* :meth:`.LiveUpdateContribution.strike` to strike a content of a live thread.
 
 **Fixed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,7 @@ Unreleased
 
 **Added**
 
+* :meth:`.LiveThreadContribution.update` to update settings of a live thread.
 * ``reset_timestamp`` to :attr:`.limits` to provide insight into when the
   current rate limit window will expire.
 * :meth:`.upload_mobile_header` to upload subreddit mobile header.
@@ -18,7 +19,6 @@ Unreleased
 * Uploading an image resulting in too large of a request (>500 KB) now
   raises ``prawcore.TooLarge`` instead of an ``AssertionError``.
 * Uploading an invalid image raises :class:`.APIException`.
-
 
 4.3.0 (2017/01/19)
 ------------------

--- a/praw/const.py
+++ b/praw/const.py
@@ -67,6 +67,7 @@ API_PATH = {
     'live_remove_update':     'api/live/{id}/delete_update',
     'live_remove_contrib':    'api/live/{id}/rm_contributor',
     'live_remove_invite':     'api/live/{id}/rm_contributor_invite',
+    'live_strike':            'api/live/{id}/strike_update',
     'live_update_thread':     'api/live/{id}/edit',
     'live_updates':           'live/{id}',
     'liveabout':              'api/live/{id}/about/',

--- a/praw/models/reddit/live.py
+++ b/praw/models/reddit/live.py
@@ -431,3 +431,9 @@ class LiveUpdateContribution(object):
         url = API_PATH['live_remove_update'].format(id=self.update.thread.id)
         data = {'id': self.update.fullname}
         self.update.thread._reddit.post(url, data=data)
+
+    def strike(self):
+        """Strike a content of a live update."""
+        url = API_PATH['live_strike'].format(id=self.update.thread.id)
+        data = {'id': self.update.fullname}
+        self.update.thread._reddit.post(url, data=data)

--- a/praw/models/reddit/live.py
+++ b/praw/models/reddit/live.py
@@ -184,7 +184,7 @@ class LiveThread(RedditBase):
     def __getitem__(self, update_id):
         """Return a lazy :class:`.LiveUpdate` instance.
 
-        .. warning:: At this time, accesing lazy attributes, whose value
+        .. warning:: At this time, accessing lazy attributes, whose value
            have not loaded, raises ``AttributeError``.
 
         :param update_id: A live update ID, e.g.,
@@ -335,7 +335,31 @@ class LiveThreadContribution(object):
 
 
 class LiveUpdate(RedditBase):
-    """An individual :class:`.LiveUpdate` object."""
+    """An individual :class:`.LiveUpdate` object.
+
+    .. warning:: At this time, accessing lazy attributes on this class
+       may raises ``AttributeError``: if an update is instantiated
+       through :meth:`.LiveThread.updates`, the exception is not
+       thrown. For example:
+
+       .. code-block:: python
+
+          thread = reddit.live('xyu8kmjvfrww')
+          for update in thread.updates(limit=None):
+              if update.id == 'cb5fe532-dbee-11e6-9a91-0e6d74fabcc4':
+                  print(update.stricken)  # True
+                  break
+
+       But the update is instantiated through ``thread[update_id]``
+       or ``LiveUpdate(reddit, update_id)``, ``AttributeError`` is thrown:
+
+       .. code-block:: python
+
+          thread = reddit.live('xyu8kmjvfrww')
+          update = thread['cb5fe532-dbee-11e6-9a91-0e6d74fabcc4']
+          update.stricken  # raise AttributeError
+
+    """
 
     STR_FIELD = 'id'
 
@@ -367,8 +391,9 @@ class LiveUpdate(RedditBase):
         Either ``thread_id`` and ``update_id``, or ``_data`` must be
         provided.
 
-        .. warning:: At this time, accesing lazy attributes, whose value
-           have not loaded, raises ``AttributeError``.
+        .. warning:: At this time, accessing lazy attributes, whose value
+           have not loaded, raises ``AttributeError``. See :class:`.LiveUpdate`
+           for details.
 
         :param reddit: An instance of :class:`.Reddit`.
         :param thread_id: A live thread ID, e.g., ``'ukaeu1ik4sw5'``.
@@ -433,7 +458,20 @@ class LiveUpdateContribution(object):
         self.update.thread._reddit.post(url, data=data)
 
     def strike(self):
-        """Strike a content of a live update."""
+        """Strike a content of a live update.
+
+        .. code-block:: python
+
+           thread = reddit.live('xyu8kmjvfrww')
+           update = thread['cb5fe532-dbee-11e6-9a91-0e6d74fabcc4']
+           update.contrib.strike()
+
+        To check whether the update is stricken or not, use ``update.stricken``
+        attribute. But note that accessing lazy attributes on updates
+        (includes ``update.stricken``) may raises ``AttributeError``.
+        See :class:`.LiveUpdate` for details.
+
+        """
         url = API_PATH['live_strike'].format(id=self.update.thread.id)
         data = {'id': self.update.fullname}
         self.update.thread._reddit.post(url, data=data)

--- a/tests/integration/cassettes/TestLiveUpdateContribution_strike.json
+++ b/tests/integration/cassettes/TestLiveUpdateContribution_strike.json
@@ -1,0 +1,112 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-01-25T21:16:24",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "83",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "<USER_AGENT> PRAW/4.3.1.dev0 prawcore/0.7.0"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Wed, 25 Jan 2017 21:16:25 GMT",
+          "Server": "snooserv",
+          "Set-Cookie": "loid=V9qNGV7JvApRNcAy3k; Domain=reddit.com; Max-Age=63071999; Path=/;  secure",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-nrt6123-NRT",
+          "X-Timer": "S1485378984.495840,VS0,VE592",
+          "cache-control": "max-age=0, must-revalidate",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2017-01-25T21:16:25",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=LiveUpdate_cb5fe532-dbee-11e6-9a91-0e6d74fabcc4"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "64",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "loid=V9qNGV7JvApRNcAy3k; loidcreated=1485378984000",
+          "User-Agent": "<USER_AGENT> PRAW/4.3.1.dev0 prawcore/0.7.0"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/live/xyu8kmjvfrww/strike_update?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Wed, 25 Jan 2017 21:16:25 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-nrt6127-NRT",
+          "X-Timer": "S1485378985.349568,VS0,VE184",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "599.0",
+          "x-ratelimit-reset": "215",
+          "x-ratelimit-used": "1",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/live/xyu8kmjvfrww/strike_update?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/tests/integration/models/reddit/test_live.py
+++ b/tests/integration/models/reddit/test_live.py
@@ -210,3 +210,11 @@ class TestLiveUpdateContribution(IntegrationTest):
         with self.recorder.use_cassette(
                 'TestLiveUpdateContribution_remove'):
             update.contrib.remove()
+
+    def test_strike(self):
+        self.reddit.read_only = False
+        update = LiveUpdate(self.reddit, 'xyu8kmjvfrww',
+                            'cb5fe532-dbee-11e6-9a91-0e6d74fabcc4')
+        with self.recorder.use_cassette(
+                'TestLiveUpdateContribution_strike'):
+            update.contrib.strike()


### PR DESCRIPTION
## Feature Summary

This feature provides interface to `POST /api/live/:thread/strike_update` which strikes a content of live update ([example](https://www.reddit.com/live/xyu8kmjvfrww/updates/cb5fe532-dbee-11e6-9a91-0e6d74fabcc4)).

## References

* #676 - feature request for reddit live
* https://www.reddit.com/dev/api#POST_api_live_{thread}_strike_update
* nmtake@e147a37 - API design discussion