### PR TITLE
Add LiveContributorRelationship.update to update permissions for a live thread contributor

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ Unreleased
 * :meth:`.delete_mobile_header` to remove subreddit mobile header.
 * :meth:`.delete_mobile_icon` to remove subreddit mobile icon.
 * :meth:`.LiveUpdateContribution.strike` to strike a content of a live thread.
+* :meth:`.LiveContributorRelationship.update` to update contributor
+  permissions for a redditor.
 
 **Fixed**
 

--- a/praw/const.py
+++ b/praw/const.py
@@ -68,6 +68,7 @@ API_PATH = {
     'live_remove_contrib':    'api/live/{id}/rm_contributor',
     'live_remove_invite':     'api/live/{id}/rm_contributor_invite',
     'live_strike':            'api/live/{id}/strike_update',
+    'live_update_perms':      'api/live/{id}/set_contributor_permissions',
     'live_update_thread':     'api/live/{id}/edit',
     'live_updates':           'live/{id}',
     'liveabout':              'api/live/{id}/about/',

--- a/praw/models/reddit/live.py
+++ b/praw/models/reddit/live.py
@@ -9,6 +9,14 @@ from .redditor import Redditor
 class LiveContributorRelationship(object):
     """Provide methods to interact with live threads' contributors."""
 
+    @staticmethod
+    def _handle_permissions(permissions):
+        if permissions is None:
+            permissions = {'all'}
+        else:
+            permissions = set(permissions)
+        return ','.join('+{}'.format(x) for x in permissions)
+
     def __call__(self):
         """Return a :class:`.RedditorList` for live threads' contributors.
 
@@ -65,15 +73,10 @@ class LiveContributorRelationship(object):
             remove the invite for redditor.
 
         """
-        if permissions is None:
-            permissions = {'all'}
-        else:
-            permissions = set(permissions)
-        encoded = ','.join('+{}'.format(x) for x in permissions)
+        url = API_PATH['live_invite'].format(id=self.thread.id)
         data = {'name': str(redditor),
                 'type': 'liveupdate_contributor_invite',
-                'permissions': encoded}
-        url = API_PATH['live_invite'].format(id=self.thread.id)
+                'permissions': self._handle_permissions(permissions)}
         self.thread._reddit.post(url, data=data)
 
     def leave(self):

--- a/praw/models/reddit/live.py
+++ b/praw/models/reddit/live.py
@@ -135,6 +135,44 @@ class LiveContributorRelationship(object):
         url = API_PATH['live_remove_invite'].format(id=self.thread.id)
         self.thread._reddit.post(url, data=data)
 
+    def update(self, redditor, permissions=None):
+        """Update the contributor permissions for ``redditor``.
+
+        :param redditor: A redditor name (e.g., ``'spez'``) or
+            :class:`~.Redditor` instance.
+        :param permissions: When provided (not ``None``), permissions should
+            be a list of strings specifying which subset of permissions to
+            grant (other permissions are removed). An empty list ``[]``
+            indicates no permissions, and when not provided (``None``),
+            indicates full permissions.
+
+        For example, to grant all permissions to the contributor, try:
+
+        .. code:: python
+
+           thread = reddit.live('ukaeu1ik4sw5')
+           thread.contributor.update('spez')
+
+        To grant 'access' and 'edit' permissions (and to remove other
+        permissions), try:
+
+        .. code:: python
+
+           thread.contributor.update('spez', ['access', 'edit'])
+
+        To remove all permissions from the contributor, try:
+
+        .. code:: python
+
+           subreddit.moderator.update('spez', [])
+
+        """
+        url = API_PATH['live_update_perms'].format(id=self.thread.id)
+        data = {'name': str(redditor),
+                'type': 'liveupdate_contributor',
+                'permissions': self._handle_permissions(permissions)}
+        self.thread._reddit.post(url, data=data)
+
 
 class LiveThread(RedditBase):
     """An individual LiveThread object."""

--- a/tests/integration/cassettes/TestLiveContributorRelationship_test_update__empty_list.json
+++ b/tests/integration/cassettes/TestLiveContributorRelationship_test_update__empty_list.json
@@ -1,0 +1,112 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-02-04T22:07:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "83",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "<USER_AGENT> PRAW/4.3.1.dev0 prawcore/0.8.0"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 04 Feb 2017 22:07:24 GMT",
+          "Server": "snooserv",
+          "Set-Cookie": "loid=vBXPiJSMW6StynEC5x; Domain=reddit.com; Max-Age=63071999; Path=/;  secure",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-nrt6131-NRT",
+          "X-Timer": "S1486246043.688969,VS0,VE488",
+          "cache-control": "max-age=0, must-revalidate",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2017-02-04T22:07:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=nmtake&permissions=&type=liveupdate_contributor"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "66",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "loid=vBXPiJSMW6StynEC5x; loidcreated=1486246043000",
+          "User-Agent": "<USER_AGENT> PRAW/4.3.1.dev0 prawcore/0.8.0"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/live/ydwwxneu7vsa/set_contributor_permissions?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 04 Feb 2017 22:07:24 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-nrt6122-NRT",
+          "X-Timer": "S1486246044.355719,VS0,VE198",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "597.0",
+          "x-ratelimit-reset": "156",
+          "x-ratelimit-used": "3",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/live/ydwwxneu7vsa/set_contributor_permissions?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/tests/integration/cassettes/TestLiveContributorRelationship_test_update__limited.json
+++ b/tests/integration/cassettes/TestLiveContributorRelationship_test_update__limited.json
@@ -1,0 +1,112 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-02-04T22:10:32",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "83",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "<USER_AGENT> PRAW/4.3.1.dev0 prawcore/0.8.0"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 04 Feb 2017 22:10:33 GMT",
+          "Server": "snooserv",
+          "Set-Cookie": "loid=dvYBCObu1zZkL9vHm3; Domain=reddit.com; Max-Age=63071999; Path=/;  secure",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-nrt6121-NRT",
+          "X-Timer": "S1486246233.196261,VS0,VE502",
+          "cache-control": "max-age=0, must-revalidate",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2017-02-04T22:10:33",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=nmtake&permissions=%2Bedit%2C%2Bmanage&type=liveupdate_contributor"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "85",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "loid=dvYBCObu1zZkL9vHm3; loidcreated=1486246233000",
+          "User-Agent": "<USER_AGENT> PRAW/4.3.1.dev0 prawcore/0.8.0"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/live/ydwwxneu7vsa/set_contributor_permissions?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 04 Feb 2017 22:10:33 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-nrt6125-NRT",
+          "X-Timer": "S1486246233.785203,VS0,VE207",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "599.0",
+          "x-ratelimit-reset": "567",
+          "x-ratelimit-used": "1",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/live/ydwwxneu7vsa/set_contributor_permissions?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/tests/integration/cassettes/TestLiveContributorRelationship_test_update__none.json
+++ b/tests/integration/cassettes/TestLiveContributorRelationship_test_update__none.json
@@ -1,0 +1,112 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-02-04T22:12:14",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "83",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "<USER_AGENT> PRAW/4.3.1.dev0 prawcore/0.8.0"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 04 Feb 2017 22:12:15 GMT",
+          "Server": "snooserv",
+          "Set-Cookie": "loid=tpv2kiW6Rs2yl89m4S; Domain=reddit.com; Max-Age=63071999; Path=/;  secure",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-nrt6123-NRT",
+          "X-Timer": "S1486246334.615481,VS0,VE506",
+          "cache-control": "max-age=0, must-revalidate",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2017-02-04T22:12:15",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=nmtake&permissions=%2Ball&type=liveupdate_contributor"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "72",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "loid=tpv2kiW6Rs2yl89m4S; loidcreated=1486246334000",
+          "User-Agent": "<USER_AGENT> PRAW/4.3.1.dev0 prawcore/0.8.0"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/live/ydwwxneu7vsa/set_contributor_permissions?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 04 Feb 2017 22:12:16 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-nrt6128-NRT",
+          "X-Timer": "S1486246335.515625,VS0,VE695",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "598.0",
+          "x-ratelimit-reset": "465",
+          "x-ratelimit-used": "2",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/live/ydwwxneu7vsa/set_contributor_permissions?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/tests/integration/models/reddit/test_live.py
+++ b/tests/integration/models/reddit/test_live.py
@@ -135,6 +135,27 @@ class TestLiveContributorRelationship(IntegrationTest):
                 'test_remove_invite__redditor'):
             thread.contributor.remove_invite(redditor)
 
+    def test_update__empty_list(self):
+        self.reddit.read_only = False
+        thread = LiveThread(self.reddit, 'ydwwxneu7vsa')
+        with self.recorder.use_cassette(
+                'TestLiveContributorRelationship_test_update__empty_list'):
+            thread.contributor.update('nmtake', [])
+
+    def test_update__limited(self):
+        self.reddit.read_only = False
+        thread = LiveThread(self.reddit, 'ydwwxneu7vsa')
+        with self.recorder.use_cassette(
+                'TestLiveContributorRelationship_test_update__limited'):
+            thread.contributor.update('nmtake', ['manage', 'edit'])
+
+    def test_update__none(self):
+        self.reddit.read_only = False
+        thread = LiveThread(self.reddit, 'ydwwxneu7vsa')
+        with self.recorder.use_cassette(
+                'TestLiveContributorRelationship_test_update__none'):
+            thread.contributor.update('nmtake', None)
+
 
 class TestLiveThreadContribution(IntegrationTest):
     def test_add(self):


### PR DESCRIPTION
## Feature Summary

This feature provides interface to `POST /api/live/:thread/set_contributor_permissions`
which updates permissions for a live thread contributor. 

## References

* #676 - feature request for reddit live
* https://www.reddit.com/dev/api#POST_api_live_{thread}_set_contributor_permissions
* nmtake@e147a37 - API design discussion