### PR TITLE
Add LiveThreadContributorRelationship.update_invite to update contributor invite permissions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,9 @@ Unreleased
 * :meth:`.LiveUpdateContribution.strike` to strike a content of a live thread.
 * :meth:`.LiveContributorRelationship.update` to update contributor
   permissions for a redditor.
+* :meth:`.LiveContributorRelationship.update_invite` to update contributor
+  invite permissions for a redditor.
+
 
 **Fixed**
 

--- a/praw/models/reddit/live.py
+++ b/praw/models/reddit/live.py
@@ -173,6 +173,44 @@ class LiveContributorRelationship(object):
                 'permissions': self._handle_permissions(permissions)}
         self.thread._reddit.post(url, data=data)
 
+    def update_invite(self, redditor, permissions=None):
+        """Update the contributor invite permissions for ``redditor``.
+
+        :param redditor: A redditor name (e.g., ``'spez'``) or
+            :class:`~.Redditor` instance.
+        :param permissions: When provided (not ``None``), permissions should
+            be a list of strings specifying which subset of permissions to
+            grant (other permissions are removed). An empty list ``[]``
+            indicates no permissions, and when not provided (``None``),
+            indicates full permissions.
+
+        For example, to set all permissions to the invitation, try:
+
+        .. code:: python
+
+           thread = reddit.live('ukaeu1ik4sw5')
+           thread.contributor.update_invite('spez')
+
+        To set 'access' and 'edit' permissions (and to remove other
+        permissions) to the invitation, try:
+
+        .. code:: python
+
+           thread.contributor.update_invite('spez', ['access', 'edit'])
+
+        To remove all permissions from the invitation, try:
+
+        .. code:: python
+
+           thread.contributor.update_invite('spez', [])
+
+        """
+        url = API_PATH['live_update_perms'].format(id=self.thread.id)
+        data = {'name': str(redditor),
+                'type': 'liveupdate_contributor_invite',
+                'permissions': self._handle_permissions(permissions)}
+        self.thread._reddit.post(url, data=data)
+
 
 class LiveThread(RedditBase):
     """An individual LiveThread object."""

--- a/tests/integration/cassettes/TestLiveContributorRelationship_test_update_invite__empty_list.json
+++ b/tests/integration/cassettes/TestLiveContributorRelationship_test_update_invite__empty_list.json
@@ -1,0 +1,112 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-02-07T13:44:20",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "83",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "<USER_AGENT> PRAW/4.3.1.dev0 prawcore/0.8.0"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Tue, 07 Feb 2017 13:44:21 GMT",
+          "Server": "snooserv",
+          "Set-Cookie": "loid=mfmBYOfK2Zept4Quhw; Domain=reddit.com; Max-Age=63071999; Path=/;  secure",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-nrt6130-NRT",
+          "X-Timer": "S1486475060.991154,VS0,VE527",
+          "cache-control": "max-age=0, must-revalidate",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2017-02-07T13:44:20",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=nmtake&permissions=&type=liveupdate_contributor_invite"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "73",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "loid=mfmBYOfK2Zept4Quhw; loidcreated=1486475060000",
+          "User-Agent": "<USER_AGENT> PRAW/4.3.1.dev0 prawcore/0.8.0"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/live/ydwwxneu7vsa/set_contributor_permissions?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Tue, 07 Feb 2017 13:44:21 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-nrt6132-NRT",
+          "X-Timer": "S1486475061.758133,VS0,VE184",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "599.0",
+          "x-ratelimit-reset": "339",
+          "x-ratelimit-used": "1",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/live/ydwwxneu7vsa/set_contributor_permissions?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/tests/integration/cassettes/TestLiveContributorRelationship_test_update_invite__limited.json
+++ b/tests/integration/cassettes/TestLiveContributorRelationship_test_update_invite__limited.json
@@ -1,0 +1,112 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-02-07T13:45:17",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "83",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "<USER_AGENT> PRAW/4.3.1.dev0 prawcore/0.8.0"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Tue, 07 Feb 2017 13:45:18 GMT",
+          "Server": "snooserv",
+          "Set-Cookie": "loid=EeZrFpn5AhbxNzp6rH; Domain=reddit.com; Max-Age=63071999; Path=/;  secure",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-nrt6121-NRT",
+          "X-Timer": "S1486475118.107448,VS0,VE530",
+          "cache-control": "max-age=0, must-revalidate",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2017-02-07T13:45:17",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=nmtake&permissions=%2Bedit%2C%2Bmanage&type=liveupdate_contributor_invite"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "92",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "loid=EeZrFpn5AhbxNzp6rH; loidcreated=1486475118000",
+          "User-Agent": "<USER_AGENT> PRAW/4.3.1.dev0 prawcore/0.8.0"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/live/ydwwxneu7vsa/set_contributor_permissions?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Tue, 07 Feb 2017 13:45:19 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-nrt6132-NRT",
+          "X-Timer": "S1486475118.821319,VS0,VE200",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "598.0",
+          "x-ratelimit-reset": "282",
+          "x-ratelimit-used": "2",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/live/ydwwxneu7vsa/set_contributor_permissions?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/tests/integration/cassettes/TestLiveContributorRelationship_test_update_invite__none.json
+++ b/tests/integration/cassettes/TestLiveContributorRelationship_test_update_invite__none.json
@@ -1,0 +1,112 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-02-07T13:46:12",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "83",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "<USER_AGENT> PRAW/4.3.1.dev0 prawcore/0.8.0"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Tue, 07 Feb 2017 13:46:13 GMT",
+          "Server": "snooserv",
+          "Set-Cookie": "loid=MoBfnNBAJTBs0ceYag; Domain=reddit.com; Max-Age=63071999; Path=/;  secure",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-nrt6125-NRT",
+          "X-Timer": "S1486475173.043547,VS0,VE606",
+          "cache-control": "max-age=0, must-revalidate",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2017-02-07T13:46:13",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&name=nmtake&permissions=%2Ball&type=liveupdate_contributor_invite"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "79",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "loid=MoBfnNBAJTBs0ceYag; loidcreated=1486475173000",
+          "User-Agent": "<USER_AGENT> PRAW/4.3.1.dev0 prawcore/0.8.0"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/live/ydwwxneu7vsa/set_contributor_permissions?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Tue, 07 Feb 2017 13:46:14 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-nrt6134-NRT",
+          "X-Timer": "S1486475173.916502,VS0,VE208",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "597.0",
+          "x-ratelimit-reset": "226",
+          "x-ratelimit-used": "3",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/live/ydwwxneu7vsa/set_contributor_permissions?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/tests/integration/models/reddit/test_live.py
+++ b/tests/integration/models/reddit/test_live.py
@@ -156,6 +156,30 @@ class TestLiveContributorRelationship(IntegrationTest):
                 'TestLiveContributorRelationship_test_update__none'):
             thread.contributor.update('nmtake', None)
 
+    def test_update_invite__empty_list(self):
+        self.reddit.read_only = False
+        thread = LiveThread(self.reddit, 'ydwwxneu7vsa')
+        with self.recorder.use_cassette(
+                'TestLiveContributorRelationship_'
+                'test_update_invite__empty_list'):
+            thread.contributor.update_invite('nmtake', [])
+
+    def test_update_invite__limited(self):
+        self.reddit.read_only = False
+        thread = LiveThread(self.reddit, 'ydwwxneu7vsa')
+        with self.recorder.use_cassette(
+                'TestLiveContributorRelationship_'
+                'test_update_invite__limited'):
+            thread.contributor.update_invite('nmtake', ['manage', 'edit'])
+
+    def test_update_invite__none(self):
+        self.reddit.read_only = False
+        thread = LiveThread(self.reddit, 'ydwwxneu7vsa')
+        with self.recorder.use_cassette(
+                'TestLiveContributorRelationship_'
+                'test_update_invite__none'):
+            thread.contributor.update_invite('nmtake', None)
+
 
 class TestLiveThreadContribution(IntegrationTest):
     def test_add(self):


### PR DESCRIPTION
## Feature Summary

This feature provides interface to `POST /api/live/:thread/set_contributor_permissions` with `type=liveupdate_contributor_invite` data which updates contributor invite permissions.

The difference between this `update_invite()` and `update()` is `type` data (`type=liveupdate_contributor_invite` and `type=liveupdate_contributor`, respectively). 
`ModeratorRelationship` [has same interfaces](https://github.com/praw-dev/praw/blob/7f4863b2a2dd8643adf5336287f04b3ad11e2c0e/praw/models/reddit/subreddit.py#L1349-L1398).

## References

* #676 - feature request for reddit live
* https://www.reddit.com/dev/api#POST_api_live_{thread}_set_contributor_permissions
* nmtake@e147a37 - API design discussion