### PR TITLE
Add LiveHelper.now

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,6 +20,7 @@ Unreleased
   invite permissions for a redditor.
 * :meth:`.LiveThread.discussions` to get submissions linking to the thread.
 * :meth:`.LiveThread.report` to report the thread violating the Reddit rules.
+* :meth:`.LiveHelper.now` to get the currently featured live thread.
 
 **Fixed**
 

--- a/praw/const.py
+++ b/praw/const.py
@@ -65,6 +65,7 @@ API_PATH = {
     'live_discussions':       'live/{id}/discussions',
     'live_invite':            'api/live/{id}/invite_contributor',
     'live_leave':             'api/live/{id}/leave_contributor',
+    'live_now':               'api/live/happening_now',
     'live_remove_update':     'api/live/{id}/delete_update',
     'live_remove_contrib':    'api/live/{id}/rm_contributor',
     'live_remove_invite':     'api/live/{id}/rm_contributor_invite',

--- a/praw/models/helpers.py
+++ b/praw/models/helpers.py
@@ -39,6 +39,21 @@ class LiveHelper(PRAWBase):
             'description': description, 'nsfw': nsfw, 'resources': resources,
             'title': title})
 
+    def now(self):
+        """Get the currently featured live thread.
+
+        :returns: The :class:`.LiveThread` object, or ``None`` if there is
+            no currently featured live thread.
+
+        Usage:
+
+        .. code-block:: python
+
+        thread = reddit.live.now()  # LiveThread object or None
+
+        """
+        return self._reddit.get(API_PATH['live_now'])
+
 
 class MultiredditHelper(PRAWBase):
     """Provide a set of functions to interact with Multireddits."""

--- a/praw/objector.py
+++ b/praw/objector.py
@@ -28,8 +28,13 @@ class Objector(object):
         """Create RedditBase objects from data.
 
         :param data: The structured data.
+        :returns: An instance of :class:`~.RedditBase`, or ``None`` if
+            given ``data`` is ``None``.
 
         """
+        # pylint: disable=too-many-return-statements
+        if data is None:  # 204 no content
+            return
         if isinstance(data, list):
             return [self.objectify(item) for item in data]
         if 'kind' in data and data['kind'] in self.parsers:

--- a/tests/integration/cassettes/TestReddit.test_live_now__no_featured.json
+++ b/tests/integration/cassettes/TestReddit.test_live_now__no_featured.json
@@ -1,0 +1,108 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-02-16T16:11:04",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=client_credentials"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "29",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "<USER_AGENT> PRAW/4.3.1.dev0 prawcore/0.8.0"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Thu, 16 Feb 2017 16:11:07 GMT",
+          "Server": "snooserv",
+          "Set-Cookie": "loid=dzEJwqV1Xbmbp1TxVQ; Domain=reddit.com; Max-Age=63071999; Path=/;  secure",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-nrt6129-NRT",
+          "X-Timer": "S1487261467.715573,VS0,VE198",
+          "cache-control": "max-age=0, must-revalidate",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2017-02-16T16:11:04",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "loid=dzEJwqV1Xbmbp1TxVQ; loidcreated=1487261467000",
+          "User-Agent": "<USER_AGENT> PRAW/4.3.1.dev0 prawcore/0.8.0"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/api/live/happening_now?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Thu, 16 Feb 2017 16:11:08 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-nrt6134-NRT",
+          "X-Timer": "S1487261468.054475,VS0,VE182",
+          "access-control-allow-origin": "*",
+          "access-control-expose-headers": "X-Reddit-Tracking, X-Moose",
+          "cache-control": "max-age=0, must-revalidate",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=YcwQRLyZ%2FuT7JwqZptyf4PztjeDdfFxNougyY9av%2FH%2B26sw7qFkqskiV4emqCNcSfDoOKBcPHnOFNkTAa4tO9giGNShdTHde",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 204,
+          "message": "No Content"
+        },
+        "url": "https://oauth.reddit.com/api/live/happening_now?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/tests/integration/test_reddit.py
+++ b/tests/integration/test_reddit.py
@@ -37,6 +37,11 @@ class TestReddit(IntegrationTest):
             assert isinstance(live, LiveThread)
             assert live.title == 'PRAW Create Test'
 
+    def test_live_now__no_featured(self):
+        with self.recorder.use_cassette('TestReddit.test_live_now'
+                                        '__no_featured'):
+            assert self.reddit.live.now() is None
+
     def test_random_subreddit(self):
         names = set()
         with self.recorder.use_cassette(

--- a/tests/unit/test_objector.py
+++ b/tests/unit/test_objector.py
@@ -1,0 +1,7 @@
+from . import UnitTest
+
+
+class TestObjector(UnitTest):
+
+    def test_objectify_returns_None_for_None(self):
+        assert self.reddit._objector.objectify(None) is None


### PR DESCRIPTION
## Feature Summary

This feature provides interface to `POST /api/live/happening_now` which gets currently featured live thread.

This commit doesn't contain test for 200 OK (the endpoint returns 200 if there is a featured live thread, 204 no content if there is no featured). So the test for latter should be added in the future.

## References

* #676 - feature request for reddit live
* https://www.reddit.com/dev/api#GET_api_live_happening_now
* nmtake@e147a37 - API design discussion