### PR TITLE
Fix LiveContributorRelationship.__call__ return type

### DIFF
--- a/praw/models/reddit/live.py
+++ b/praw/models/reddit/live.py
@@ -259,13 +259,17 @@ class LiveThread(RedditBase):
     def contributor(self):
         """An instance of :class:`.LiveContributorRelationship`.
 
-        Usage:
+        You can call the instance to get a list of contributors which is
+        represented as :class:`.RedditorList` instance consists of
+        :class:`.Redditor` instances. Those Redditor instances have
+        `permissions` attributes as contributors:
 
         .. code-block:: python
 
            thread = reddit.live('ukaeu1ik4sw5')
            for contributor in thread.contributor():
-               print(contributor)
+               # prints `(Redditor(name='Acidtwist'), [u'all'])`
+               print(contributor, contributor.permissions)
 
         """
         if self._contributor is None:

--- a/praw/objector.py
+++ b/praw/objector.py
@@ -55,8 +55,10 @@ class Objector(object):
             if len(errors) == 1:
                 raise APIException(*errors[0])
             assert len(errors) == 0
-        elif isinstance(data, dict) and {'date', 'id', 'name'}.issubset(
-                set(data.keys())):
+
+        elif isinstance(data, dict) and (
+                {'date', 'id', 'name'}.issubset(set(data.keys()))
+                or {'id', 'name', 'permissions'}.issubset(set(data.keys()))):
             parser = self.parsers[self._reddit.config.kinds['redditor']]
             return parser.parse(data, self._reddit)
         elif isinstance(data, dict) and 'user' in data:

--- a/tests/integration/models/reddit/test_live.py
+++ b/tests/integration/models/reddit/test_live.py
@@ -16,6 +16,9 @@ class TestLiveThread(IntegrationTest):
             contributors = thread.contributor()
         assert isinstance(contributors, RedditorList)
         assert len(contributors) > 0
+        for contributor in contributors:
+            assert 'permissions' in contributor.__dict__
+            assert isinstance(contributor, Redditor)
 
     @mock.patch('time.sleep', return_value=None)
     def test_contributor__with_manage_permission(self, _):


### PR DESCRIPTION
Fix `LiveContributorRelationship.__call__` return type

After https://github.com/praw-dev/praw/commit/5b743ee50f81c32d5fbc4b43ce4524c028666117, the method returns RedditorList consists of normal dicts
(not Redditor instances):

```
>>> reddit.live("ukaeu1ik4sw5").contributor()
<praw.models.list.redditor.RedditorList object at 0x10c217f90>
>>> _[0]
{u'id': u't2_f3lhp', u'name': u'Acidtwist', u'permissions': [u'all']}
```

This fix changes return type to RedditorList consists of Redditor
instances. Those instances have `permissions` property:

```
>>>reddit.live("ukaeu1ik4sw5").contributor()
<praw.models.list.redditor.RedditorList object at 0x10382ef90>
>>> _[0]
Redditor(name='Acidtwist')
>>> _.permissions
[u'all']
```