### PR TITLE
Documented comment sorting and limits in Submission class

### DIFF
--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -53,6 +53,14 @@ class Submission(RedditBase, SubmissionListingMixin, UserContentMixin):
            submission.comments.replace_more(limit=0)
            comments = submission.comments.list()
 
+        Sort order and comment limit can be set with the ``comment_sort`` and
+        ``comment_limit`` attributes before comments are fetched:
+
+        .. code:: python
+
+           submission.comment_sort = 'new'
+           comments = submission.comments.list()
+
         See :ref:`extracting_comments` for more on working with a
         :class:`.CommentForest`.
 


### PR DESCRIPTION
This adds documentation to `Submission.comments` showing how to use `Submission.comment_sort` and `Submission.comment_limit`. This is [already documented](http://praw.readthedocs.io/en/latest/getting_started/quick_start.html#obtain-comment-instances), but this way the information can also be found in the Code Overview as well.

I also wonder if the note in the section linked above would be helpful to include in the tutorial on [Comment Extraction and Parsing](http://praw.readthedocs.io/en/latest/tutorials/comments.html).