### PR TITLE
Add help message for NoSectionError

### DIFF
--- a/praw/reddit.py
+++ b/praw/reddit.py
@@ -1,5 +1,4 @@
 """Provide the Reddit class."""
-import configparser
 import os
 
 try:
@@ -15,7 +14,7 @@ from prawcore import (Authorizer, DeviceIDAuthorizer, ReadOnlyAuthorizer,
 
 from .exceptions import ClientException
 from .config import Config
-from .const import __version__, API_PATH, USER_AGENT_FORMAT
+from .const import __version__, API_PATH, USER_AGENT_FORMAT, configparser
 from .objector import Objector
 from . import models
 

--- a/praw/reddit.py
+++ b/praw/reddit.py
@@ -1,4 +1,5 @@
 """Provide the Reddit class."""
+import configparser
 import os
 
 try:
@@ -99,8 +100,22 @@ class Reddit(object):
         self._core = self._authorized_core = self._read_only_core = None
         self._objector = None
         self._unique_counter = 0
-        self.config = Config(site_name or os.getenv('praw_site') or 'DEFAULT',
-                             **config_settings)
+
+        try:
+            config_section = site_name or os.getenv('praw_site') or 'DEFAULT'
+            self.config = Config(config_section, **config_settings)
+        except configparser.NoSectionError as exc:
+            help_message = ('You provided the name of a praw.ini '
+                            'configuration which does not exist.\n\nFor help '
+                            'with creating a Reddit instance, visit\n'
+                            'https://praw.readthedocs.io/en/latest/code_overvi'
+                            'ew/reddit_instance.html\n\n'
+                            'For help on configuring PRAW, visit\n'
+                            'https://praw.readthedocs.io/en/latest/getting_sta'
+                            'rted/configuration.html')
+            if site_name is not None:
+                exc.message += '\n' + help_message
+            raise
 
         required_message = ('Required configuration setting {!r} missing. \n'
                             'This setting can be provided in a praw.ini file, '

--- a/tests/unit/test_reddit.py
+++ b/tests/unit/test_reddit.py
@@ -1,3 +1,4 @@
+import configparser
 import types
 
 import mock
@@ -116,6 +117,11 @@ class TestReddit(UnitTest):
             assert str(excinfo.value).startswith('Required configuration '
                                                  'setting \'{}\' missing.'
                                                  .format(setting))
+
+    def test_reddit__site_name_no_section(self):
+        with pytest.raises(configparser.NoSectionError) as excinfo:
+            Reddit('bad_site_name')
+        assert 'praw.readthedocs.io' in excinfo.value.message
 
     def test_submission(self):
         assert self.reddit.submission('2gmzqe').id == '2gmzqe'

--- a/tests/unit/test_reddit.py
+++ b/tests/unit/test_reddit.py
@@ -1,9 +1,9 @@
-import configparser
 import types
 
 import mock
 import pytest
 from praw import __version__, Reddit
+from praw.const import configparser
 from praw.exceptions import ClientException
 
 from . import UnitTest


### PR DESCRIPTION
Closes #744. When the user passes a non-None `site_name` causing `praw.Reddit(site_name)` to raise `configparser.NoSectionError`, the exception has some help text appended to it, and is reraised.

    configparser.NoSectionError: No section: 'test'
    You provided the name of a praw.ini configuration which does not exist.

    For help with creating a Reddit instance, visit
    https://praw.readthedocs.io/en/latest/code_overview/reddit_instance.html

    For help on configuring PRAW, visit
    https://praw.readthedocs.io/en/latest/getting_started/configuration.html

How's it look?

&nbsp;

Edit: Sorry, I'm still a noob at code coverage. I'm assuming Coveralls highlighted those lines because it wants me to write a unittest for catching that case?

Edit: All good.