### PR TITLE
Documents replace_more and comment_sort order

### DIFF
--- a/docs/getting_started/quick_start.rst
+++ b/docs/getting_started/quick_start.rst
@@ -265,7 +265,8 @@ method on a :class:`.CommentForest` instance. For example:
 As you may be aware there will periodically be :class:`.MoreComments` instances
 scattered throughout the forest. Replace those :class:`.MoreComments` instances
 at any time by calling :meth:`.replace_more` on a :class:`.CommentForest`
-instance. See :ref:`extracting_comments` for an example.
+instance. Calling :meth:`.replace_more` access ``comments``, and so must be done
+after ``comment_sort`` is updated. See :ref:`extracting_comments` for an example.
 
 Determine Available Attributes of an Object
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -54,7 +54,8 @@ class Submission(RedditBase, SubmissionListingMixin, UserContentMixin):
            comments = submission.comments.list()
 
         Sort order and comment limit can be set with the ``comment_sort`` and
-        ``comment_limit`` attributes before comments are fetched:
+        ``comment_limit`` attributes before comments are fetched, including
+        any call to :meth:`.replace_more`:
 
         .. code:: python
 


### PR DESCRIPTION
Fixes

Documentation was unclear that `replace_more()` called comments and thus it is necessary to make any changes to `comment_sort` beforehand.  

## Feature Summary and Justification

A sentence for clarification was added in two places: quickstart and submission.py
