### PR TITLE
Re-add check for ModmailConversation.id existing in constructor

### DIFF
--- a/praw/models/reddit/modmail.py
+++ b/praw/models/reddit/modmail.py
@@ -70,7 +70,8 @@ class ModmailConversation(RedditBase):
         """Construct an instance of the ModmailConversation object."""
         super(ModmailConversation, self).__init__(reddit, _data)
 
-        self.id = id  # pylint: disable=invalid-name
+        if id is not None:
+            self.id = id  # pylint: disable=invalid-name
 
     def _info_path(self):
         return API_PATH['modmail_conversation'].format(id=self.id)

--- a/tests/unit/models/reddit/test_modmail.py
+++ b/tests/unit/models/reddit/test_modmail.py
@@ -1,0 +1,10 @@
+from praw.models import ModmailConversation
+
+from ... import UnitTest
+
+
+class TestModmailConversation(UnitTest):
+    def test_parse(self):
+        conversation = ModmailConversation(self.reddit,
+                                           _data={'id': 'ik72'})
+        assert str(conversation) == 'ik72'


### PR DESCRIPTION
This reverts commit 7040228388a7ddf5ca379a8382372698e343aa3e.

Turns out this check was doing something important: when it's missing, the call to `cls(reddit, _data=conversation` at the end of `ModmailConversation.parse` results in a `ModmailConversation` with the `id` attribute set to `None`. This ends up overriding the `id` attribute of the original object that called `_fetch`, and breaking, e.g., the `str` function.

I'm not sure this is the best way to handle the issue, but wanted to open the PR in any case.