### PR TITLE
Add support for fetching modmail conversation lists

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,8 @@ Unreleased
 
 **Added**
 
+* :meth:`~praw.models.reddit.subreddit.Modmail.conversations` to get new modmail
+  conversations.
 * :meth:`~praw.models.ModmailConversation.highlight` to highlight modmail
   conversations.
 * :meth:`~praw.models.ModmailConversation.unhighlight` to unhighlight modmail

--- a/praw/const.py
+++ b/praw/const.py
@@ -92,6 +92,7 @@ API_PATH = {
     'marknsfw':               'api/marknsfw/',
     'modmail_archive':        'api/mod/conversations/{id}/archive',
     'modmail_conversation':   'api/mod/conversations/{id}',
+    'modmail_conversations':  'api/mod/conversations/',
     'modmail_highlight':      'api/mod/conversations/{id}/highlight',
     'modmail_mute':           'api/mod/conversations/{id}/mute',
     'modmail_unarchive':      'api/mod/conversations/{id}/unarchive',

--- a/praw/models/reddit/modmail.py
+++ b/praw/models/reddit/modmail.py
@@ -42,24 +42,29 @@ class ModmailConversation(RedditBase):
                 key=lambda x: int(x.id, base=36), reverse=True)
 
     @classmethod
-    def parse(cls, data, reddit):
+    def parse(cls, data, reddit, convert_objects=True):
         """Return an instance of ModmailConversation from ``data``.
 
         :param data: The structured data.
         :param reddit: An instance of :class:`.Reddit`.
+        :param convert_objects: If True, convert message and mod action data
+            into objects (default: True).
 
         """
         conversation = data['conversation']
 
         conversation['authors'] = [reddit._objector.objectify(author)
                                    for author in conversation['authors']]
-        conversation['owner'] = reddit._objector.objectify(
-            conversation['owner'])
+        for entity in 'owner', 'participant':
+            conversation[entity] = reddit._objector.objectify(
+                conversation[entity])
 
-        if data['user']:
+        if data.get('user'):
             cls._convert_user_summary(data['user'], reddit)
             conversation['user'] = reddit._objector.objectify(data['user'])
-        conversation.update(cls._convert_conversation_objects(data, reddit))
+        if convert_objects:
+            conversation.update(cls._convert_conversation_objects(data,
+                                                                  reddit))
 
         conversation = reddit._objector._snake_case_keys(conversation)
 

--- a/tests/integration/cassettes/TestSubredditModmail.test_conversations.json
+++ b/tests/integration/cassettes/TestSubredditModmail.test_conversations.json
@@ -1,0 +1,110 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-04-01T23:12:48",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "57",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "<USER_AGENT> PRAW/4.4.1.dev0 prawcore/0.9.0"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 01 Apr 2017 23:12:48 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-jfk8150-JFK",
+          "X-Timer": "S1491088368.489300,VS0,VE320",
+          "cache-control": "max-age=0, must-revalidate",
+          "set-cookie": "loid=pXa99JKcDGwVf9vQeh.1.1491088368502.Z0FBQUFBQlk0RFB3eDc3RTJnQ09EZldrazRCVmpSTnpGcFBpR1NWa2Q0MDZiVWFQWEdEZmNnS0RVTDA0b05ZdWs5MkdqNDY5NWtoandGWllpaklFNk5BWGdsTGp4UE1qUHhGdDJGbjIxRmtiS1kyTGlRNFM1NkhHLUZ0djYwR1FIZTQwX1RoNXJEcDE; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Mon, 01-Apr-2019 23:12:48 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2017-04-01T23:12:48",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "loid=pXa99JKcDGwVf9vQeh.1.1491088368502.Z0FBQUFBQlk0RFB3eDc3RTJnQ09EZldrazRCVmpSTnpGcFBpR1NWa2Q0MDZiVWFQWEdEZmNnS0RVTDA0b05ZdWs5MkdqNDY5NWtoandGWllpaklFNk5BWGdsTGp4UE1qUHhGdDJGbjIxRmtiS1kyTGlRNFM1NkhHLUZ0djYwR1FIZTQwX1RoNXJEcDE; edgebucket=Kd6pxHfUbzXkLvIHWB",
+          "User-Agent": "<USER_AGENT> PRAW/4.4.1.dev0 prawcore/0.9.0"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/api/mod/conversations/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"conversations\": {\"ik72\": {\"isAuto\": false, \"objIds\": [{\"id\": \"13n0e\", \"key\": \"messages\"}], \"isRepliable\": true, \"lastUserUpdate\": \"2017-03-07T15:28:19.342937+00:00\", \"isInternal\": false, \"lastModUpdate\": \"2017-03-30T16:18:52.728653+00:00\", \"lastUpdated\": \"2017-03-30T16:18:52.728653+00:00\", \"authors\": [{\"isMod\": true, \"isAdmin\": false, \"name\": \"TheGrammarBolshevik\", \"isOp\": false, \"isParticipant\": false, \"isHidden\": false, \"id\": 5134815, \"isDeleted\": false}, {\"isMod\": true, \"isAdmin\": false, \"name\": \"TheGrammarBolshevik\", \"isOp\": false, \"isParticipant\": false, \"isHidden\": true, \"id\": 5134815, \"isDeleted\": false}, {\"isMod\": true, \"isAdmin\": false, \"name\": \"BJO_test_mod\", \"isOp\": false, \"isParticipant\": false, \"isHidden\": false, \"id\": 56923181, \"isDeleted\": false}, {\"isMod\": true, \"isAdmin\": false, \"name\": \"TheGrammarBolshevik\", \"isOp\": false, \"isParticipant\": false, \"isHidden\": false, \"id\": 5134815, \"isDeleted\": false}, {\"isMod\": true, \"isAdmin\": false, \"name\": \"BJO_test_mod\", \"isOp\": false, \"isParticipant\": false, \"isHidden\": false, \"id\": 56923181, \"isDeleted\": false}, {\"isMod\": true, \"isAdmin\": false, \"name\": \"BJO_test_mod\", \"isOp\": false, \"isParticipant\": false, \"isHidden\": false, \"id\": 56923181, \"isDeleted\": false}, {\"isMod\": true, \"isAdmin\": false, \"name\": \"TheGrammarBolshevik\", \"isOp\": false, \"isParticipant\": false, \"isHidden\": false, \"id\": 5134815, \"isDeleted\": false}, {\"isMod\": true, \"isAdmin\": false, \"name\": \"TheGrammarBolshevik\", \"isOp\": false, \"isParticipant\": false, \"isHidden\": false, \"id\": 5134815, \"isDeleted\": false}, {\"isMod\": true, \"isAdmin\": false, \"name\": \"BJO_test_mod\", \"isOp\": false, \"isParticipant\": false, \"isHidden\": false, \"id\": 56923181, \"isDeleted\": false}, {\"isMod\": false, \"isAdmin\": false, \"name\": \"BJO_test_user\", \"isOp\": true, \"isParticipant\": true, \"isHidden\": false, \"id\": 56922862, \"isDeleted\": false}], \"owner\": {\"displayName\": \"ThirdRealm\", \"type\": \"subreddit\", \"id\": \"t5_390u2\"}, \"id\": \"ik72\", \"isHighlighted\": false, \"subject\": \"This is an outrage!\", \"participant\": {\"isMod\": false, \"isAdmin\": false, \"name\": \"BJO_test_user\", \"isOp\": true, \"isParticipant\": true, \"isHidden\": false, \"id\": 56922862, \"isDeleted\": false}, \"state\": 1, \"lastUnread\": null, \"numMessages\": 10}}, \"messages\": {\"13n0e\": {\"body\": \"<!-- SC_OFF --><div class=\\\"md\\\"><p>Internal, not hidden</p>\\n</div><!-- SC_ON -->\", \"author\": {\"isMod\": true, \"isAdmin\": false, \"name\": \"TheGrammarBolshevik\", \"isOp\": false, \"isParticipant\": false, \"isHidden\": false, \"id\": 5134815, \"isDeleted\": false}, \"isInternal\": true, \"date\": \"2017-03-30T16:18:52.728653+00:00\", \"bodyMarkdown\": \"Internal, not hidden\", \"id\": \"13n0e\"}}, \"viewerId\": \"t2_xw27h\", \"conversationIds\": [\"ik72\"]}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "2696",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 01 Apr 2017 23:12:48 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-jfk8137-JFK",
+          "X-Timer": "S1491088368.912216,VS0,VE83",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "599.0",
+          "x-ratelimit-reset": "432",
+          "x-ratelimit-used": "1",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/mod/conversations/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/tests/integration/cassettes/TestSubredditModmail.test_conversations__other_subreddits.json
+++ b/tests/integration/cassettes/TestSubredditModmail.test_conversations__other_subreddits.json
@@ -1,0 +1,110 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-04-04T15:05:54",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "57",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "<USER_AGENT> PRAW/4.4.1.dev0 prawcore/0.9.0"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Tue, 04 Apr 2017 15:05:53 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-jfk8134-JFK",
+          "X-Timer": "S1491318353.266774,VS0,VE340",
+          "cache-control": "max-age=0, must-revalidate",
+          "set-cookie": "loid=FTVRbgGLw1qm5yiQGa.1.1491318353275.Z0FBQUFBQlk0N1pSbGxuR0hhNG1WX21RdkotNkFPQUpGcC1GWXVWaDQ1MDZqLUVER0VJV1hrQ3pWVEIzb0MtMWQ4eE9EdkpyYXFwSXJYQzBXYkJ4YS1BV3RTemJGTEw0ODF4ejVGX0g2eHE5dnF6Nzk3S0htYWdUUGNHSWxGMlZtR044dFM3TGhNVEc; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Thu, 04-Apr-2019 15:05:53 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2017-04-04T15:05:54",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "loid=FTVRbgGLw1qm5yiQGa.1.1491318353275.Z0FBQUFBQlk0N1pSbGxuR0hhNG1WX21RdkotNkFPQUpGcC1GWXVWaDQ1MDZqLUVER0VJV1hrQ3pWVEIzb0MtMWQ4eE9EdkpyYXFwSXJYQzBXYkJ4YS1BV3RTemJGTEw0ODF4ejVGX0g2eHE5dnF6Nzk3S0htYWdUUGNHSWxGMlZtR044dFM3TGhNVEc; edgebucket=z0oaVum1V8rwp0jGAp",
+          "User-Agent": "<USER_AGENT> PRAW/4.4.1.dev0 prawcore/0.9.0"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/api/mod/conversations/?raw_json=1&entity=modmailtestA%2CmodmailtestB"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"conversations\": {\"p8rr\": {\"isAuto\": false, \"objIds\": [{\"id\": \"15lqt\", \"key\": \"messages\"}], \"isRepliable\": true, \"lastUserUpdate\": \"2017-04-04T15:02:38.130283+00:00\", \"isInternal\": false, \"lastModUpdate\": null, \"lastUpdated\": \"2017-04-04T15:02:38.130283+00:00\", \"authors\": [{\"isMod\": false, \"isAdmin\": false, \"name\": \"BJO_test_user\", \"isOp\": true, \"isParticipant\": true, \"isHidden\": false, \"id\": 56922862, \"isDeleted\": false}], \"owner\": {\"displayName\": \"modmailtestB\", \"type\": \"subreddit\", \"id\": \"t5_3jv7w\"}, \"id\": \"p8rr\", \"isHighlighted\": false, \"subject\": \"This is a test message.\", \"participant\": {\"isMod\": false, \"isAdmin\": false, \"name\": \"BJO_test_user\", \"isOp\": true, \"isParticipant\": true, \"isHidden\": false, \"id\": 56922862, \"isDeleted\": false}, \"state\": 0, \"lastUnread\": \"2017-04-04T15:02:38.150322+00:00\", \"numMessages\": 1}, \"p8rp\": {\"isAuto\": false, \"objIds\": [{\"id\": \"15lqr\", \"key\": \"messages\"}], \"isRepliable\": true, \"lastUserUpdate\": \"2017-04-04T15:02:22.381135+00:00\", \"isInternal\": false, \"lastModUpdate\": null, \"lastUpdated\": \"2017-04-04T15:02:22.381135+00:00\", \"authors\": [{\"isMod\": false, \"isAdmin\": false, \"name\": \"BJO_test_user\", \"isOp\": true, \"isParticipant\": true, \"isHidden\": false, \"id\": 56922862, \"isDeleted\": false}], \"owner\": {\"displayName\": \"modmailtestA\", \"type\": \"subreddit\", \"id\": \"t5_3jv7v\"}, \"id\": \"p8rp\", \"isHighlighted\": false, \"subject\": \"This is a test message.\", \"participant\": {\"isMod\": false, \"isAdmin\": false, \"name\": \"BJO_test_user\", \"isOp\": true, \"isParticipant\": true, \"isHidden\": false, \"id\": 56922862, \"isDeleted\": false}, \"state\": 0, \"lastUnread\": \"2017-04-04T15:02:22.604378+00:00\", \"numMessages\": 1}, \"p8rh\": {\"isAuto\": true, \"objIds\": [{\"id\": \"15lqh\", \"key\": \"messages\"}], \"isRepliable\": true, \"lastUserUpdate\": \"2017-04-04T15:01:43.511678+00:00\", \"isInternal\": false, \"lastModUpdate\": null, \"lastUpdated\": \"2017-04-04T15:01:43.511678+00:00\", \"authors\": [{\"isMod\": false, \"isAdmin\": true, \"name\": \"reddit\", \"isOp\": true, \"isParticipant\": true, \"isHidden\": false, \"id\": 81524, \"isDeleted\": false}], \"owner\": {\"displayName\": \"modmailtestB\", \"type\": \"subreddit\", \"id\": \"t5_3jv7w\"}, \"id\": \"p8rh\", \"isHighlighted\": false, \"subject\": \"r/modmailtestB is now enrolled in the New Modmail\", \"participant\": {\"isMod\": false, \"isAdmin\": true, \"name\": \"reddit\", \"isOp\": true, \"isParticipant\": true, \"isHidden\": false, \"id\": 81524, \"isDeleted\": false}, \"state\": 0, \"lastUnread\": null, \"numMessages\": 1}, \"p8rd\": {\"isAuto\": true, \"objIds\": [{\"id\": \"15lqc\", \"key\": \"messages\"}], \"isRepliable\": true, \"lastUserUpdate\": \"2017-04-04T15:01:25.041803+00:00\", \"isInternal\": false, \"lastModUpdate\": null, \"lastUpdated\": \"2017-04-04T15:01:25.041803+00:00\", \"authors\": [{\"isMod\": false, \"isAdmin\": true, \"name\": \"reddit\", \"isOp\": true, \"isParticipant\": true, \"isHidden\": false, \"id\": 81524, \"isDeleted\": false}], \"owner\": {\"displayName\": \"modmailtestA\", \"type\": \"subreddit\", \"id\": \"t5_3jv7v\"}, \"id\": \"p8rd\", \"isHighlighted\": false, \"subject\": \"r/modmailtestA is now enrolled in the New Modmail\", \"participant\": {\"isMod\": false, \"isAdmin\": true, \"name\": \"reddit\", \"isOp\": true, \"isParticipant\": true, \"isHidden\": false, \"id\": 81524, \"isDeleted\": false}, \"state\": 0, \"lastUnread\": null, \"numMessages\": 1}}, \"messages\": {\"15lqt\": {\"body\": \"<!-- SC_OFF --><div class=\\\"md\\\"><p>This is its body.</p>\\n</div><!-- SC_ON -->\", \"author\": {\"isMod\": false, \"isAdmin\": false, \"name\": \"BJO_test_user\", \"isOp\": true, \"isParticipant\": true, \"isHidden\": false, \"id\": 56922862, \"isDeleted\": false}, \"isInternal\": false, \"date\": \"2017-04-04T15:02:38.130283+00:00\", \"bodyMarkdown\": \"This is its body.\", \"id\": \"15lqt\"}, \"15lqh\": {\"body\": \"<!-- SC_OFF --><div class=\\\"md\\\"><p>Please read the <a href=\\\"https://reddit.zendesk.com/hc/en-us/articles/210896606\\\">help document</a> to familiarize yourself with the new features.</p>\\n</div><!-- SC_ON -->\", \"author\": {\"isMod\": false, \"isAdmin\": true, \"name\": \"reddit\", \"isOp\": true, \"isParticipant\": true, \"isHidden\": false, \"id\": 81524, \"isDeleted\": false}, \"isInternal\": false, \"date\": \"2017-04-04T15:01:43.511678+00:00\", \"bodyMarkdown\": \"Please read the [help document](https://reddit.zendesk.com/hc/en-us/articles/210896606) to familiarize yourself with the new features.\", \"id\": \"15lqh\"}, \"15lqr\": {\"body\": \"<!-- SC_OFF --><div class=\\\"md\\\"><p>This is its body.</p>\\n</div><!-- SC_ON -->\", \"author\": {\"isMod\": false, \"isAdmin\": false, \"name\": \"BJO_test_user\", \"isOp\": true, \"isParticipant\": true, \"isHidden\": false, \"id\": 56922862, \"isDeleted\": false}, \"isInternal\": false, \"date\": \"2017-04-04T15:02:22.381135+00:00\", \"bodyMarkdown\": \"This is its body.\", \"id\": \"15lqr\"}, \"15lqc\": {\"body\": \"<!-- SC_OFF --><div class=\\\"md\\\"><p>Please read the <a href=\\\"https://reddit.zendesk.com/hc/en-us/articles/210896606\\\">help document</a> to familiarize yourself with the new features.</p>\\n</div><!-- SC_ON -->\", \"author\": {\"isMod\": false, \"isAdmin\": true, \"name\": \"reddit\", \"isOp\": true, \"isParticipant\": true, \"isHidden\": false, \"id\": 81524, \"isDeleted\": false}, \"isInternal\": false, \"date\": \"2017-04-04T15:01:25.041803+00:00\", \"bodyMarkdown\": \"Please read the [help document](https://reddit.zendesk.com/hc/en-us/articles/210896606) to familiarize yourself with the new features.\", \"id\": \"15lqc\"}}, \"viewerId\": \"t2_xw27h\", \"conversationIds\": [\"p8rr\", \"p8rp\", \"p8rh\", \"p8rd\"]}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "5320",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Tue, 04 Apr 2017 15:05:53 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-jfk8121-JFK",
+          "X-Timer": "S1491318354.816414,VS0,VE57",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "599.0",
+          "x-ratelimit-reset": "247",
+          "x-ratelimit-used": "1",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/mod/conversations/?raw_json=1&entity=modmailtestA%2CmodmailtestB"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/tests/integration/cassettes/TestSubredditModmail.test_conversations__params.json
+++ b/tests/integration/cassettes/TestSubredditModmail.test_conversations__params.json
@@ -1,0 +1,110 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-04-04T14:55:35",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "57",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "<USER_AGENT> PRAW/4.4.1.dev0 prawcore/0.9.0"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Tue, 04 Apr 2017 14:55:34 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-jfk8143-JFK",
+          "X-Timer": "S1491317734.560666,VS0,VE311",
+          "cache-control": "max-age=0, must-revalidate",
+          "set-cookie": "loid=TaKXMPbWKH2ALd9cu4.1.1491317734568.Z0FBQUFBQlk0N1BtcXVONm1lNVhnV1dWYndUWEttMENDY2lpSFpvVnE0VHVYdU4zRFVqYllWQzl6LW8wXzVISTBuTVFocDBhRlpLRFlqeWtobXVfbDNKUDVXeHFvSGo1S1JUZjJoM0xMcGIxWWhlUnh6aW9GY3pQUVZOemQ2cV9mZUpfdHNGUjNUWnQ; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Thu, 04-Apr-2019 14:55:34 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2017-04-04T14:55:36",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "loid=TaKXMPbWKH2ALd9cu4.1.1491317734568.Z0FBQUFBQlk0N1BtcXVONm1lNVhnV1dWYndUWEttMENDY2lpSFpvVnE0VHVYdU4zRFVqYllWQzl6LW8wXzVISTBuTVFocDBhRlpLRFlqeWtobXVfbDNKUDVXeHFvSGo1S1JUZjJoM0xMcGIxWWhlUnh6aW9GY3pQUVZOemQ2cV9mZUpfdHNGUjNUWnQ; edgebucket=YWoSxpMCUJ41xyAZuO",
+          "User-Agent": "<USER_AGENT> PRAW/4.4.1.dev0 prawcore/0.9.0"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/api/mod/conversations/?state=mod&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"conversations\": {\"p1ka\": {\"isAuto\": false, \"objIds\": [{\"id\": \"15a30\", \"key\": \"messages\"}], \"isRepliable\": true, \"lastUserUpdate\": null, \"isInternal\": true, \"lastModUpdate\": \"2017-04-03T19:03:01.570078+00:00\", \"lastUpdated\": \"2017-04-03T19:03:01.570078+00:00\", \"authors\": [{\"isMod\": true, \"isAdmin\": false, \"name\": \"TheGrammarBolshevik\", \"isOp\": true, \"isParticipant\": false, \"isHidden\": false, \"id\": 5134815, \"isDeleted\": false}], \"owner\": {\"displayName\": \"ThirdRealm\", \"type\": \"subreddit\", \"id\": \"t5_390u2\"}, \"id\": \"p1ka\", \"isHighlighted\": false, \"subject\": \"here's a test\", \"participant\": {}, \"state\": 0, \"lastUnread\": \"2017-04-03T19:03:01.591477+00:00\", \"numMessages\": 1}, \"p1pc\": {\"isAuto\": false, \"objIds\": [{\"id\": \"15aay\", \"key\": \"messages\"}], \"isRepliable\": true, \"lastUserUpdate\": null, \"isInternal\": true, \"lastModUpdate\": \"2017-04-03T19:24:08.264380+00:00\", \"lastUpdated\": \"2017-04-03T19:24:08.264380+00:00\", \"authors\": [{\"isMod\": true, \"isAdmin\": false, \"name\": \"BJO_test_mod\", \"isOp\": true, \"isParticipant\": false, \"isHidden\": false, \"id\": 56923181, \"isDeleted\": false}], \"owner\": {\"displayName\": \"ThirdRealm\", \"type\": \"subreddit\", \"id\": \"t5_390u2\"}, \"id\": \"p1pc\", \"isHighlighted\": false, \"subject\": \"Subject\", \"participant\": {}, \"state\": 0, \"lastUnread\": null, \"numMessages\": 1}, \"nbhy\": {\"isAuto\": false, \"objIds\": [{\"id\": \"12i4g\", \"key\": \"messages\"}], \"isRepliable\": true, \"lastUserUpdate\": null, \"isInternal\": true, \"lastModUpdate\": \"2017-03-27T16:48:24.529369+00:00\", \"lastUpdated\": \"2017-03-27T16:48:24.529369+00:00\", \"authors\": [{\"isMod\": true, \"isAdmin\": false, \"name\": \"BJO_test_mod\", \"isOp\": false, \"isParticipant\": false, \"isHidden\": false, \"id\": 56923181, \"isDeleted\": false}, {\"isMod\": true, \"isAdmin\": false, \"name\": \"TheGrammarBolshevik\", \"isOp\": true, \"isParticipant\": false, \"isHidden\": false, \"id\": 5134815, \"isDeleted\": false}], \"owner\": {\"displayName\": \"ThirdRealm\", \"type\": \"subreddit\", \"id\": \"t5_390u2\"}, \"id\": \"nbhy\", \"isHighlighted\": false, \"subject\": \"Internal moderator discussion\", \"participant\": {}, \"state\": 0, \"lastUnread\": null, \"numMessages\": 2}}, \"messages\": {\"12i4g\": {\"body\": \"<!-- SC_OFF --><div class=\\\"md\\\"><p>This is a reply within the conversation.</p>\\n</div><!-- SC_ON -->\", \"author\": {\"isMod\": true, \"isAdmin\": false, \"name\": \"BJO_test_mod\", \"isOp\": false, \"isParticipant\": false, \"isHidden\": false, \"id\": 56923181, \"isDeleted\": false}, \"isInternal\": true, \"date\": \"2017-03-27T16:48:24.529369+00:00\", \"bodyMarkdown\": \"This is a reply within the conversation.\", \"id\": \"12i4g\"}, \"15a30\": {\"body\": \"<!-- SC_OFF --><div class=\\\"md\\\"><p>Can we message a mod through this?</p>\\n</div><!-- SC_ON -->\", \"author\": {\"isMod\": true, \"isAdmin\": false, \"name\": \"TheGrammarBolshevik\", \"isOp\": true, \"isParticipant\": false, \"isHidden\": false, \"id\": 5134815, \"isDeleted\": false}, \"isInternal\": true, \"date\": \"2017-04-03T19:03:01.570078+00:00\", \"bodyMarkdown\": \"Can we message a mod through this?\", \"id\": \"15a30\"}, \"15aay\": {\"body\": \"<!-- SC_OFF --><div class=\\\"md\\\"><p>Body</p>\\n</div><!-- SC_ON -->\", \"author\": {\"isMod\": true, \"isAdmin\": false, \"name\": \"BJO_test_mod\", \"isOp\": true, \"isParticipant\": false, \"isHidden\": false, \"id\": 56923181, \"isDeleted\": false}, \"isInternal\": true, \"date\": \"2017-04-03T19:24:08.264380+00:00\", \"bodyMarkdown\": \"Body\", \"id\": \"15aay\"}}, \"viewerId\": \"t2_xw27h\", \"conversationIds\": [\"p1pc\", \"p1ka\", \"nbhy\"]}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "3377",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Tue, 04 Apr 2017 14:55:35 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-jfk8151-JFK",
+          "X-Timer": "S1491317735.072379,VS0,VE249",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "599.0",
+          "x-ratelimit-reset": "265",
+          "x-ratelimit-used": "1",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/mod/conversations/?state=mod&raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}


### PR DESCRIPTION
Partially implements #703 

Some notes:

Working on this feature has me wondering if `ModmailConversation.__call__` has the right name. Compare with `SubredditRelationship`, where `__call__` is a listing and individual relationships are handled through named methods.

There is a `limit` parameter. However, I wasn't able to find any maximum: in manual testing, I got as far as 1998 before I ran out of conversations to request. For this reason, I didn't make use of the existing `ListingGenerator` framework.

The second commit returns a list of `ModmailConversation` objects with just the `id` and no other data. The last commit adds some parsing: the idea is to just use the conversation metadata, while leaving messages and mod actions to be fetched on the individual conversation. This required a couple tweaks to `ModmailConversation.parse`. Apart from feedback on the code itself, I'm wondering what you think of this design.
