### PR TITLE
Fix some typos.

### DIFF
--- a/docs/examples/obtain_refresh_token.py
+++ b/docs/examples/obtain_refresh_token.py
@@ -49,7 +49,7 @@ def main():
                       'Personal use script at the top: ')
     client_secret = input('Enter the client secret, it\'s the line next '
                           'to secret: ')
-    commaScopes = input('Now enter a comma seperated list of scopes, or '
+    commaScopes = input('Now enter a comma separated list of scopes, or '
                         'all for all tokens: ')
 
     if commaScopes.lower() == 'all':

--- a/docs/getting_started/configuration/options.rst
+++ b/docs/getting_started/configuration/options.rst
@@ -19,7 +19,7 @@ Basic Configuration Options
 ---------------------------
 
 :check_for_updates: When ``true``, check for new versions of PRAW. When a
-                    newever version of PRAW is available a message is reported
+                    newer version of PRAW is available a message is reported
                     via standard out (default: ``true``).
 
 :user_agent: (Required) A unique description of your application. The following
@@ -108,7 +108,7 @@ Your application can utilize PRAW's configuration system in order to provide
 its own custom settings.
 
 For instance you might want to add an ``app_debugging: true`` option to your
-application's ``praw.ini`` file. To retreive the value of this custom option
+application's ``praw.ini`` file. To retrieve the value of this custom option
 from an instance of :class:`.Reddit` you can execute:
 
 .. code-block:: python

--- a/docs/getting_started/configuration/prawini.rst
+++ b/docs/getting_started/configuration/prawini.rst
@@ -14,7 +14,7 @@ user defined ``praw.ini`` files in a few other locations:
    detected in order as one of the following:
 
    1. In the directory specified by the ``XDG_CONFIG_HOME`` environment
-      varaible on operating systems that define such an environment variable
+      variable on operating systems that define such an environment variable
       (some modern Linux distributions).
 
    2. In the directory specified by ``$HOME/.config`` if the ``HOME``

--- a/docs/getting_started/quick_start.rst
+++ b/docs/getting_started/quick_start.rst
@@ -26,7 +26,7 @@ Prerequisites
                             a client ID and client secret, follow Reddit's
                             `First Steps Guide`_ to create them.
 
-:User Agent: A user agent is a unique indentifer that helps Reddit determine
+:User Agent: A user agent is a unique identifier that helps Reddit determine
              the source of network requests. To use Reddit's API, you need a
              unique and descriptive user agent. The recommended format is
              ``<platform>:<app ID>:<version string> (by /u/<Reddit
@@ -45,7 +45,7 @@ Prerequisites
 .. _`First Steps Guide`:
    https://github.com/reddit/reddit/wiki/OAuth2-Quick-Start-Example#first-steps
 
-With these prerequisites satisifed, you are ready to learn how to do some of
+With these prerequisites satisfied, you are ready to learn how to do some of
 the most common tasks with Reddit's API.
 
 Common Tasks

--- a/docs/package_info/contributing.rst
+++ b/docs/package_info/contributing.rst
@@ -13,7 +13,7 @@ checks. The following are PRAW-specific guidelines in addition to those PEP's.
 Code
 ----
 
-* Within a single file classes are sorted alphabetically where inheritence
+* Within a single file classes are sorted alphabetically where inheritance
   permits.
 * Within a class, methods are sorted alphabetically within their respective
   groups with the following as the grouping order:

--- a/praw/models/inbox.py
+++ b/praw/models/inbox.py
@@ -161,7 +161,7 @@ class Inbox(PRAWBase):
         Additional keyword arguments are passed in the initialization of
         :class:`.ListingGenerator`.
 
-        For example, to output the receipient of the mot recent 15 messages
+        For example, to output the recipient of the mot recent 15 messages
         try:
 
         .. code:: python

--- a/praw/models/listing/mixins/subreddit.py
+++ b/praw/models/listing/mixins/subreddit.py
@@ -8,7 +8,7 @@ from .rising import RisingListingMixin
 
 class SubredditListingMixin(BaseListingMixin, GildedListingMixin,
                             RisingListingMixin):
-    """Adds additional methods pertianing to Subreddit-like instances."""
+    """Adds additional methods pertaining to Subreddit-like instances."""
 
     @property
     def comments(self):

--- a/praw/models/reddit/base.py
+++ b/praw/models/reddit/base.py
@@ -26,7 +26,7 @@ class RedditBase(PRAWBase):
                 str(self).lower() == str(other).lower())
 
     def __getattr__(self, attribute):
-        """Return the value of `attrribute`."""
+        """Return the value of `attribute`."""
         if not attribute.startswith('_') and not self._fetched:
             self._fetch()
             return getattr(self, attribute)

--- a/praw/models/reddit/mixins/__init__.py
+++ b/praw/models/reddit/mixins/__init__.py
@@ -30,7 +30,7 @@ class ThingModerationMixin(object):
 
         :param how: One of 'yes', 'no', 'admin', 'special'. 'yes' adds a
             moderator level distinguish. 'no' removes any distinction. 'admin'
-            and 'special' require special user priviliges to use.
+            and 'special' require special user privileges to use.
         :param sticky: Comment is stickied if True, placing it at the top of
             the comment page regardless of score. If thing is not a top-level
             comment, this parameter is silently ignored.

--- a/praw/models/reddit/modmail.py
+++ b/praw/models/reddit/modmail.py
@@ -169,13 +169,13 @@ class ModmailConversation(RedditBase):
         .. code:: python
 
            conversation = reddit.subreddit('redditdev').modmail('2gmz')
-           converation.reply('Message body', author_hidden=True)
+           conversation.reply('Message body', author_hidden=True)
 
         To create a private moderator note on the conversation:
 
         .. code:: python
 
-           converation.reply('Message body', internal=True)
+           conversation.reply('Message body', internal=True)
 
         """
         data = {'body': body, 'isAuthorHidden': author_hidden,

--- a/praw/models/reddit/more.py
+++ b/praw/models/reddit/more.py
@@ -20,7 +20,7 @@ class MoreComments(PRAWBase):
             self.count == other.count and self.children == other.children
 
     def __lt__(self, other):
-        """Proide a sort order on the MoreComments object."""
+        """Provide a sort order on the MoreComments object."""
         # To work with heapq a "smaller" item is the one with the most comments
         # We are intentionally making the biggest element the smallest element
         # to turn the min-heap implementation in heapq into a max-heap.

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -480,7 +480,7 @@ class Subreddit(RedditBase, MessageableMixin, SubredditListingMixin):
             list of subreddits.
 
         """
-        data = {'action': 'sub', 'skip_initial_defaults': True,
+        data = {'action': 'sub', 'skip_inital_defaults': True,
                 'sr_name': self._subreddit_list(self, other_subreddits)}
         self._reddit.post(API_PATH['subscribe'], data=data)
 

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -342,7 +342,7 @@ class Subreddit(RedditBase, MessageableMixin, SubredditListingMixin):
             (default: all).
 
         .. warning:: (Deprecation) The default search syntax is changing to
-               ``lucene`` in PRAW 5. For forward compatibility please explicitly
+           ``lucene`` in PRAW 5. For forward compatibility please explicitly
            provide the search syntax.
 
         For more information on building a search query see:

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -342,7 +342,7 @@ class Subreddit(RedditBase, MessageableMixin, SubredditListingMixin):
             (default: all).
 
         .. warning:: (Deprecation) The default search syntax is changing to
-           ``lucene`` in PRAW 5. For forward compatability please explicitly
+               ``lucene`` in PRAW 5. For forward compatibility please explicitly
            provide the search syntax.
 
         For more information on building a search query see:
@@ -391,7 +391,7 @@ class Subreddit(RedditBase, MessageableMixin, SubredditListingMixin):
             submission yielded during the call. A value of ``None`` will
             consider all submissions newer than ``start`` (default: None).
         :param extra_query: A cloudsearch query that will be combined via
-            ``(and timestamp:start..end EXTRA_QUERY)`` to futher filter
+            ``(and timestamp:start..end EXTRA_QUERY)`` to further filter
             results (default: None).
 
         Submissions are yielded newest first.
@@ -480,7 +480,7 @@ class Subreddit(RedditBase, MessageableMixin, SubredditListingMixin):
             list of subreddits.
 
         """
-        data = {'action': 'sub', 'skip_inital_defaults': True,
+        data = {'action': 'sub', 'skip_initial_defaults': True,
                 'sr_name': self._subreddit_list(self, other_subreddits)}
         self._reddit.post(API_PATH['subscribe'], data=data)
 
@@ -510,7 +510,7 @@ class Subreddit(RedditBase, MessageableMixin, SubredditListingMixin):
 class SubredditFilters(object):
     """Provide functions to interact with the special Subreddit's filters.
 
-    Members of this class should be utilized via ``Subreddit.fiters``. For
+    Members of this class should be utilized via ``Subreddit.filters``. For
     example to add a filter run:
 
     .. code:: python
@@ -1170,7 +1170,7 @@ class SubredditModeration(object):
         Additional keyword arguments can be provided to handle new settings as
         Reddit introduces them.
 
-        Settings that are documented here and aren't explitly set by you in a
+        Settings that are documented here and aren't explicitly set by you in a
         call to :meth:`.SubredditModeration.update` should retain their current
         value. If they do not please file a bug.
 
@@ -1842,7 +1842,7 @@ class SubredditStylesheet(object):
 
         .. code:: python
 
-           reddit.subreddit('SUBREDDIT').stylesheet.delete_ombile_icon()
+           reddit.subreddit('SUBREDDIT').stylesheet.delete_mobile_icon()
 
         """
         url = API_PATH['delete_sr_icon'].format(subreddit=self.subreddit)
@@ -2011,7 +2011,8 @@ class SubredditWiki(object):
     def create(self, name, content, reason=None, **other_settings):
         """Create a new wiki page.
 
-        :param name: The name of the new WikiPage. This name will be normalied.
+        :param name: The name of the new WikiPage. This name will be
+            normalized.
         :param content: The content of the new WikiPage.
         :param reason: (Optional) The reason for the creation.
         :param other_settings: Additional keyword arguments to pass.

--- a/praw/reddit.py
+++ b/praw/reddit.py
@@ -100,7 +100,7 @@ class Reddit(object):
         * client_secret (for installed applications set this value to ``None``)
         * user_agent
 
-        The ``requestor_class`` and ``requerstor_kwargs`` allow for
+        The ``requestor_class`` and ``requestor_kwargs`` allow for
         customization of the requestor :class`.Reddit` will use. This allows,
         e.g., easily adding behavior to the requestor or wrapping its
         :class`Session` in a caching layer. Example usage:
@@ -151,7 +151,7 @@ class Reddit(object):
         if self.config.client_secret is self.config.CONFIG_NOT_SET:
             raise ClientException(required_message.format('client_secret') +
                                   '\nFor installed applications this value '
-                                  'must be set to None via a keyword arugment '
+                                  'must be set to None via a keyword argument '
                                   'to the `Reddit` class constructor.')
 
         self._check_for_update()
@@ -400,7 +400,7 @@ class Reddit(object):
         :param path: The path to fetch.
         :param data: Dictionary, bytes, or file-like object to send in the body
             of the request (default: None).
-        :param files: Dictionary, filename to file (like) object mappin
+        :param files: Dictionary, filename to file (like) object mapping
             (default: None).
         :param params: The query parameters to add to the request (default:
             None).
@@ -443,7 +443,7 @@ class Reddit(object):
             None).
         :param data: Dictionary, bytes, or file-like object to send in the body
             of the request (default: None).
-        :param files: Dictionary, filename to file (like) object mappin
+        :param files: Dictionary, filename to file (like) object mapping
             (default: None).
 
         """

--- a/tests/integration/models/test_comment_forest.py
+++ b/tests/integration/models/test_comment_forest.py
@@ -7,7 +7,7 @@ from .. import IntegrationTest
 class TestCommentForest(IntegrationTest):
     def setup(self):
         super(TestCommentForest, self).setup()
-        # Responses do not decode well on travis so manually renable gzip.
+        # Responses do not decode well on travis so manually re-enable gzip.
         self.reddit._core._requestor._http.headers['Accept-Encoding'] = 'gzip'
 
     def test_replace__all(self):

--- a/tests/unit/models/reddit/test_subreddit.py
+++ b/tests/unit/models/reddit/test_subreddit.py
@@ -6,7 +6,7 @@ from praw.models import Subreddit, WikiPage
 from ... import UnitTest
 
 
-class TestSubredit(UnitTest):
+class TestSubreddit(UnitTest):
     def test_equality(self):
         subreddit1 = Subreddit(self.reddit,
                                _data={'display_name': 'dummy1', 'n': 1})


### PR DESCRIPTION
Found I typo I added, tried to find others. The only real code change is [`Subreddit.subscribe`](https://github.com/praw-dev/praw/compare/master...elnuno:typos?expand=1#diff-a6c46ac5ed8df35e279b7cd7973765fcL483), but I'm assuming it's a fix too (inital -> initial):

```python
        data = {'action': 'sub', 'skip_inital_defaults': True,
                'sr_name': self._subreddit_list(self, other_subreddits)}
```