### PR TITLE
re-add support for https_proxy as a praw.ini entry

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -30,4 +30,5 @@ Source Contributors
 - Levi Roth <levimroth@gmail.com> `@leviroth <https://github.com/leviroth>`_
 - Keith Diedrick <diedrickke@gmail.com> `@darthkedrik <https://github.com/darthkedrik>`_
 - elnuno `@elnuno <https://github.com/elnuno>`_
+- Robbie Gibson `@rkgibson2 <https://github.com/rkgibson2>`_
 - Add "Name <email (optional)> and github profile link" above this line.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Change Log
 Unreleased PRAW5
 ----------------
 
+**Added**
+
+* ``https_proxy`` can be set in ``praw.ini`` and is passed through
+  to the Requestor instance.
+
 **Changed**
 
 * ``cloudsearch`` is no longer the default syntax for

--- a/docs/getting_started/configuration.rst
+++ b/docs/getting_started/configuration.rst
@@ -21,6 +21,8 @@ Configuration options can be provided to PRAW in one of three ways:
 Environment variables have the highest priority, followed by keyword arguments
 to :class:`.Reddit`, and finally settings in ``praw.ini`` files.
 
+.. _https_proxy:
+
 Using an HTTP or HTTPS proxy with PRAW
 --------------------------------------
 
@@ -39,3 +41,6 @@ environment variable can be provided on the command line like so:
 .. code-block:: bash
 
    HTTPS_PROXY=https://localhost:3128 ./prawbot.py
+
+It is also possible to add an HTTPS proxy to your ``praw.ini`` file,
+using the ``https_proxy`` key.

--- a/docs/getting_started/configuration/options.rst
+++ b/docs/getting_started/configuration/options.rst
@@ -28,6 +28,9 @@ Basic Configuration Options
              ``<platform>:<app ID>:<version string> (by /u/<reddit
              username>)``.
 
+:https_proxy: An HTTPS proxy for all requests made by PRAW. See :ref:`https_proxy` for
+              more details.
+
 .. _oauth_options:
 
 OAuth Configuration Options

--- a/praw/config.py
+++ b/praw/config.py
@@ -68,6 +68,7 @@ class Config(object):
         self.client_id = self.client_secret = self.oauth_url = None
         self.reddit_url = self.refresh_token = self.redirect_uri = None
         self.password = self.user_agent = self.username = None
+        self.https_proxy = None
 
         self._initialize_attributes()
 
@@ -100,9 +101,9 @@ class Config(object):
                       ['comment', 'message', 'redditor', 'submission',
                        'subreddit']}
 
-        for attribute in ('client_id', 'client_secret', 'http_proxy',
-                          'https_proxy', 'redirect_uri', 'refresh_token',
-                          'password', 'user_agent', 'username'):
+        for attribute in ('client_id', 'client_secret', 'https_proxy',
+                          'redirect_uri', 'refresh_token', 'password',
+                          'user_agent', 'username'):
             setattr(self, attribute, self._fetch_or_not_set(attribute))
 
         for required_attribute in ('oauth_url', 'reddit_url'):

--- a/praw/reddit.py
+++ b/praw/reddit.py
@@ -303,10 +303,14 @@ class Reddit(object):
         requestor_class = requestor_class or Requestor
         requestor_kwargs = requestor_kwargs or {}
 
+        proxies = {}
+        if self.config.https_proxy:
+            proxies['https'] = self.config.https_proxy
+
         requestor = requestor_class(
             USER_AGENT_FORMAT.format(self.config.user_agent),
             self.config.oauth_url, self.config.reddit_url,
-            **requestor_kwargs)
+            proxies=proxies, **requestor_kwargs)
 
         if self.config.client_secret:
             self._prepare_trusted_prawcore(requestor)


### PR DESCRIPTION
It looks like this function was added in #317, but has been removed somewhere along the way. As `https_proxy` is still a supported attribute, I figured this functionality was still desired. praw-dev/prawcore#58 has the changes necessary in `prawcore`.