### PR TITLE
Add warning about unreliability of reddit's search

### DIFF
--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -412,7 +412,7 @@ class Subreddit(RedditBase, MessageableMixin, SubredditListingMixin):
                print(submission.title)
 
         As of this writing there are 809 results.
-        
+
         .. note:: The results are only as reliable as reddit's search,
            submissions may be missing from the results.
 

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -412,6 +412,9 @@ class Subreddit(RedditBase, MessageableMixin, SubredditListingMixin):
                print(submission.title)
 
         As of this writing there are 809 results.
+        
+        .. note:: The results are only as reliable as reddit's search,
+           submissions may be missing from the results.
 
         """
         utc_offset = 28800


### PR DESCRIPTION
## Feature Summary and Justification

Since `Subreddit.submission` uses reddit's search, its results are only as reliable as reddit's search. Submissions are sometimes missing from the results. (see the reference for an example and some investigation)

## References

* #813