### PR TITLE
Support link_flair endpoint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Unreleased PRAW5
   :meth:`.Submission.disable_inbox_replies`, and
   :meth:`.Submission.enable_inbox_replies` to toggle inbox replies on comments
   and submissions.
+* :attr:`.SubredditFlair.link_templates` to manage link flair templates.
 
 **Changed**
 
@@ -43,6 +44,9 @@ Unreleased PRAW5
   :meth:`.select`, and :meth:`.unfriend` are removed as they do not provide
   any useful information.
 * ``praw.ini`` no longer reads in ``http_proxy`` and ``https_proxy`` settings.
+* ``is_link`` parameter of :meth:`.SubredditRedditorFlairTemplates.add` and
+  :meth:`.SubredditRedditorFlairTemplates.clear`. Use
+  :class:`.SubredditLinkFlairTemplates` instead.
 
 4.5.1 (2017/05/07)
 ------------------

--- a/docs/code_overview/other.rst
+++ b/docs/code_overview/other.rst
@@ -12,6 +12,8 @@ instances of them bound to an attribute of one of the PRAW models.
    other/submissionflair
    other/subredditflair
    other/subredditflairtemplates
+   other/subredditlinkflairtemplates
+   other/subredditredditorflairtemplates
 
 .. toctree::
    :maxdepth: 2

--- a/docs/code_overview/other/subredditlinkflairtemplates.rst
+++ b/docs/code_overview/other/subredditlinkflairtemplates.rst
@@ -1,0 +1,5 @@
+SubredditLinkFlairTemplates
+===========================
+
+.. autoclass:: praw.models.reddit.subreddit.SubredditLinkFlairTemplates
+   :inherited-members:

--- a/docs/code_overview/other/subredditredditorflairtemplates.rst
+++ b/docs/code_overview/other/subredditredditorflairtemplates.rst
@@ -1,0 +1,5 @@
+SubredditRedditorFlairTemplates
+===============================
+
+.. autoclass:: praw.models.reddit.subreddit.SubredditRedditorFlairTemplates
+   :inherited-members:

--- a/praw/const.py
+++ b/praw/const.py
@@ -52,6 +52,7 @@ API_PATH = {
     'karma':                  'api/v1/me/karma',
     'leavecontributor':       'api/leavecontributor',
     'leavemoderator':         'api/leavemoderator',
+    'link_flair':             'r/{subreddit}/api/link_flair',
     'list_banned':            'r/{subreddit}/about/banned/',
     'list_contributor':       'r/{subreddit}/about/contributors/',
     'list_moderator':         'r/{subreddit}/about/moderators/',

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -602,8 +602,26 @@ class SubredditFlair(object):
     """Provide a set of functions to interact with a Subreddit's flair."""
 
     @property
+    def link_templates(self):
+        """Provide an instance of :class:`.SubredditLinkFlairTemplates`.
+
+        Use this attribute for interacting with a subreddit's link flair
+        templates. For example to list all the link flair templates for a
+        subreddit which you have the ``flair`` moderator permission on try:
+
+        .. code-block:: python
+
+           for template in reddit.subreddit('NAME').flair.link_templates:
+               print(template)
+
+        """
+        if self._link_templates is None:
+            self._link_templates = SubredditLinkFlairTemplates(self.subreddit)
+        return self._link_templates
+
+    @property
     def templates(self):
-        """Provide an instance of :class:`.SubredditFlairTemplates`.
+        """Provide an instance of :class:`.SubredditRedditorFlairTemplates`.
 
         Use this attribute for interacting with a subreddit's flair
         templates. For example to list all the flair templates for a subreddit
@@ -616,7 +634,7 @@ class SubredditFlair(object):
 
         """
         if self._templates is None:
-            self._templates = SubredditFlairTemplates(self.subreddit)
+            self._templates = SubredditRedditorFlairTemplates(self.subreddit)
         return self._templates
 
     def __call__(self, redditor=None, **generator_kwargs):
@@ -646,7 +664,7 @@ class SubredditFlair(object):
         :param subreddit: The subreddit whose flair to work with.
 
         """
-        self._templates = None
+        self._link_templates = self._templates = None
         self.subreddit = subreddit
 
     def configure(self, position='right', self_assign=False,
@@ -783,64 +801,19 @@ class SubredditFlairTemplates(object):
 
         .. note:: This class should not be initialized directly. Instead obtain
            an instance via:
-           ``reddit.subreddit('subreddit_name').flair.templates``
+           ``reddit.subreddit('subreddit_name').flair.templates`` or
+           ``reddit.subreddit('subreddit_name').flair.link_templates``.
 
         """
         self.subreddit = subreddit
 
-    def __iter__(self):
-        """Iterate through the user flair templates.
-
-        Example:
-
-        .. code-block:: python
-
-           for template in reddit.subreddit('NAME').flair.templates:
-               print(template)
-
-
-        """
-        url = API_PATH['flairselector'].format(subreddit=self.subreddit)
-        data = {'unique': self.subreddit._reddit._next_unique}
-        for template in self.subreddit._reddit.post(url, data=data)['choices']:
-            yield template
-
-    def add(self, text, css_class='', text_editable=False, is_link=False):
-        """Add a flair template to the associated subreddit.
-
-        :param text: The flair template's text (required).
-        :param css_class: The flair template's css_class (default: '').
-        :param text_editable: (boolean) Indicate if the flair text can be
-            modified for each Redditor that sets it (default: False).
-        :param is_link: (boolean) When True, add a link flair template rather
-            than a Redditor flair template (default: False).
-
-        For example, to add an editable link flair try:
-
-        .. code-block:: python
-
-           reddit.subreddit('NAME').flair.templates.add(
-               css_class='praw', text_editable=True, is_link=True)
-
-        """
+    def _add(self, text, css_class='', text_editable=False, is_link=None):
         url = API_PATH['flairtemplate'].format(subreddit=self.subreddit)
         data = {'css_class': css_class, 'flair_type': self.flair_type(is_link),
                 'text': text, 'text_editable': bool(text_editable)}
         self.subreddit._reddit.post(url, data=data)
 
-    def clear(self, is_link=False):
-        """Remove all flair templates from the subreddit.
-
-        :param is_link: (boolean) When True, clear all link flair templates
-            rather than a Redditor flair templates (default: False).
-
-        For example, to clear all Redditor flair templates, run:
-
-        .. code-block:: python
-
-           reddit.subreddit('NAME').flair.templates.clear()
-
-        """
+    def _clear(self, is_link=None):
         url = API_PATH['flairtemplateclear'].format(subreddit=self.subreddit)
         self.subreddit._reddit.post(
             url, data={'flair_type': self.flair_type(is_link)})
@@ -883,6 +856,109 @@ class SubredditFlairTemplates(object):
         data = {'css_class': css_class, 'flair_template_id': template_id,
                 'text': text, 'text_editable': bool(text_editable)}
         self.subreddit._reddit.post(url, data=data)
+
+
+class SubredditRedditorFlairTemplates(SubredditFlairTemplates):
+    """Provide functions to interact with Redditor flair templates."""
+
+    def __iter__(self):
+        """Iterate through the user flair templates.
+
+        Example:
+
+        .. code-block:: python
+
+           for template in reddit.subreddit('NAME').flair.templates:
+               print(template)
+
+
+        """
+        url = API_PATH['flairselector'].format(subreddit=self.subreddit)
+        data = {'unique': self.subreddit._reddit._next_unique}
+        for template in self.subreddit._reddit.post(url, data=data)['choices']:
+            yield template
+
+    def add(self, text, css_class='', text_editable=False):
+        """Add a Redditor flair template to the associated subreddit.
+
+        :param text: The flair template's text (required).
+        :param css_class: The flair template's css_class (default: '').
+        :param text_editable: (boolean) Indicate if the flair text can be
+            modified for each Redditor that sets it (default: False).
+
+        For example, to add an editable Redditor flair try:
+
+        .. code-block:: python
+
+           reddit.subreddit('NAME').flair.templates.add(
+               css_class='praw', text_editable=True)
+
+        """
+        self._add(text, css_class=css_class, text_editable=text_editable,
+                  is_link=False)
+
+    def clear(self):
+        """Remove all Redditor flair templates from the subreddit.
+
+        For example:
+
+        .. code-block:: python
+
+           reddit.subreddit('NAME').flair.templates.clear()
+
+        """
+        self._clear(is_link=False)
+
+
+class SubredditLinkFlairTemplates(SubredditFlairTemplates):
+    """Provide functions to interact with link flair templates."""
+
+    def __iter__(self):
+        """Iterate through the link flair templates.
+
+        Example:
+
+        .. code-block:: python
+
+           for template in reddit.subreddit('NAME').flair.link_templates:
+               print(template)
+
+
+        """
+        url = API_PATH['link_flair'].format(subreddit=self.subreddit)
+        for template in self.subreddit._reddit.get(url):
+            yield template
+
+    def add(self, text, css_class='', text_editable=False):
+        """Add a link flair template to the associated subreddit.
+
+        :param text: The flair template's text (required).
+        :param css_class: The flair template's css_class (default: '').
+        :param text_editable: (boolean) Indicate if the flair text can be
+            modified for each Redditor that sets it (default: False).
+
+        For example, to add an editable link flair try:
+
+        .. code-block:: python
+
+           reddit.subreddit('NAME').flair.link_templates.add(
+               css_class='praw', text_editable=True)
+
+        """
+        self._add(text, css_class=css_class, text_editable=text_editable,
+                  is_link=True)
+
+    def clear(self):
+        """Remove all link flair templates from the subreddit.
+
+        For example:
+
+        .. code-block:: python
+
+           reddit.subreddit('NAME').flair.link_templates.clear()
+
+        """
+        self._clear(is_link=True)
 
 
 class SubredditModeration(object):

--- a/tests/integration/cassettes/TestSubredditLinkFlairTemplates.test__iter.json
+++ b/tests/integration/cassettes/TestSubredditLinkFlairTemplates.test__iter.json
@@ -1,0 +1,112 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-06-17T23:03:34",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "57",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 17 Jun 2017 23:03:34 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1730-ORD",
+          "X-Timer": "S1497740614.320938,VS0,VE474",
+          "cache-control": "max-age=0, must-revalidate",
+          "set-cookie": "session_tracker=mKlZ5ldsPgcgQ2SRqo.0.1497740614336.Z0FBQUFBQlpSYlZHS090YnZ2VGdpTk5wUU5hbVh0bGtQdlplM0IzOTBvM0t2dEFsR2c1VmNNbXlld0ZLUFc5UzU2RGl2SzNkNVB0dWFLdTgtckVVZHN3NDlGcFFxVUt3S2FyMV9nci1UWUl2b1N4NUtIdnVTX2NDcTV2c0I2aHlSY0lDUVB0TXpkem0; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 18-Jun-2017 01:03:34 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2017-06-17T23:03:34",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=BQ2shQfcVs8Pfg8RKA; session_tracker=mKlZ5ldsPgcgQ2SRqo.0.1497740614336.Z0FBQUFBQlpSYlZHS090YnZ2VGdpTk5wUU5hbVh0bGtQdlplM0IzOTBvM0t2dEFsR2c1VmNNbXlld0ZLUFc5UzU2RGl2SzNkNVB0dWFLdTgtckVVZHN3NDlGcFFxVUt3S2FyMV9nci1UWUl2b1N4NUtIdnVTX2NDcTV2c0I2aHlSY0lDUVB0TXpkem0",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/link_flair?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"text\": \"Test flair\", \"text_editable\": true, \"id\": \"17bf09c4-520c-11e7-8073-0ef8adb5ef68\", \"css_class\": \"test-flair-class\"}]"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "126",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 17 Jun 2017 23:03:35 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1744-ORD",
+          "X-Timer": "S1497740615.129139,VS0,VE64",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSYlZIMVg0WjUzU1F0aHJJV2dwT290ZGx4bmdiNWs0MmVYc1dBZVlSSjlZZGNmSl9tcldnWFFsWlpWbENtN2VzUUpkNWpIcmc0NUFBSEpMR21XTVVXRzRJQmo2SlAzeGRPV0Z6Y1l2SFA4YVlKWVJZVE5ndGFlYm4ya2xBMmhJN1BxS2Q; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Mon, 17-Jun-2019 23:03:35 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "598.0",
+          "x-ratelimit-reset": "385",
+          "x-ratelimit-used": "2",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=l7SgqX4e1Hv3TXkSmT%2Fk%2BxoSZAW99Ve4fN0P1YOy9ojmde%2Fr9wi6gkwiV8sg6h0Bsglz2Bs974aKfzBwoua4XxtrchirBf0w",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/link_flair?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/tests/integration/cassettes/TestSubredditLinkFlairTemplates.test_add.json
+++ b/tests/integration/cassettes/TestSubredditLinkFlairTemplates.test_add.json
@@ -1,0 +1,5813 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-06-19T16:30:22",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "57",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:22 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1744-ORD",
+          "X-Timer": "S1497889822.457163,VS0,VE464",
+          "cache-control": "max-age=0, must-revalidate",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889822474.Z0FBQUFBQlpSX3dlQU9HNXBaRk9BRmdjVl9XRFNMemhBdElpeFpFM1BtbFRDUlVaVVZGX1NTUHVtRW1qb1B6V1AzLTRnOUJQaUItN05xbnBkbDBTZGpYb3JtUlg0cDRCODlGb1FjcFpLQk5PNndnVWFQbkVaVEtfdkFBcFBPTC14Q0ZzRk9PN3Z3a0s; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:22 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:22",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW0&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "77",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889822474.Z0FBQUFBQlpSX3dlQU9HNXBaRk9BRmdjVl9XRFNMemhBdElpeFpFM1BtbFRDUlVaVVZGX1NTUHVtRW1qb1B6V1AzLTRnOUJQaUItN05xbnBkbDBTZGpYb3JtUlg0cDRCODlGb1FjcFpLQk5PNndnVWFQbkVaVEtfdkFBcFBPTC14Q0ZzRk9PN3Z3a0s",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:23 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889823.126874,VS0,VE176",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Wed, 19-Jun-2019 16:30:23 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "599.0",
+          "x-ratelimit-reset": "577",
+          "x-ratelimit-used": "1",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:22",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW1&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "77",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889823143.Z0FBQUFBQlpSX3dmSnpUM2tSWXFIOFVULVl3QUwzeExhYUlhOEp0djItSXlRM0I2eFI5MjNRN3NGMnZHTFQ4eG5HNkRDd1hwSDZ6THZpVjRFVE9RYkpQNlNJY3Z4Z0ppYXNIRnBOX2FaQUVqN193YVR3VGZtOGt4WU9DaTJaS0pOMzNUeE1JVUkxY1M",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:23 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889823.350094,VS0,VE66",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889823367.Z0FBQUFBQlpSX3dmR2l6VWpXTjlXZDdVckJ2S1ZxUjQ2VUxsalR5ODI4akVsbG5IbEliSy1TSkJkWVhaUlZsU0FkRklWMDM2OWs5UHR5LWpxa2JqQmQwWVMxUmNYRTA0bE1kWnF4UDNoSG52UV92UXBhLVlIWXFCUXFaM29hdGhVNUJQQkR4T1NWLWw; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:23 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "598.0",
+          "x-ratelimit-reset": "577",
+          "x-ratelimit-used": "2",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW2&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "77",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889823367.Z0FBQUFBQlpSX3dmR2l6VWpXTjlXZDdVckJ2S1ZxUjQ2VUxsalR5ODI4akVsbG5IbEliSy1TSkJkWVhaUlZsU0FkRklWMDM2OWs5UHR5LWpxa2JqQmQwWVMxUmNYRTA0bE1kWnF4UDNoSG52UV92UXBhLVlIWXFCUXFaM29hdGhVNUJQQkR4T1NWLWw",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:23 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889823.489304,VS0,VE74",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889823512.Z0FBQUFBQlpSX3dmeXBzOURzd3BwbktnWXlBc1ZaX2JIeDZSMHdPWFlhWlk0U2lLUFlKQ2RfR041SjJYYUlYUlJxTExjZ3BKMEhPd3dWempjX0x5MjhPdzF4Y1cwTG9iODFmYlVWS09wdXh6MXNDeG1GLV9vUGdITXpKUEgzWndNQzJVUUFsNWpodGU; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:23 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "597.0",
+          "x-ratelimit-reset": "577",
+          "x-ratelimit-used": "3",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW3&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "77",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889823512.Z0FBQUFBQlpSX3dmeXBzOURzd3BwbktnWXlBc1ZaX2JIeDZSMHdPWFlhWlk0U2lLUFlKQ2RfR041SjJYYUlYUlJxTExjZ3BKMEhPd3dWempjX0x5MjhPdzF4Y1cwTG9iODFmYlVWS09wdXh6MXNDeG1GLV9vUGdITXpKUEgzWndNQzJVUUFsNWpodGU",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:23 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889824.626357,VS0,VE88",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889823647.Z0FBQUFBQlpSX3dmRFlRbnFRYldfdy1mY0JDYTI4OVRvVEFhbk9pSHJuQmQ1V180QURmcFVCMWNYUUJsREhINzNnMWRNSlFfRmQ3dE0wUG50Y0tHeFhfMW4tbG43V3VMSnhGU05zRGFka1lEcm8yS1pSWGZvOWJpc3BvR2VXbjFlSVZLOWRrb0xZWkQ; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:23 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "596.0",
+          "x-ratelimit-reset": "577",
+          "x-ratelimit-used": "4",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW4&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "77",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889823647.Z0FBQUFBQlpSX3dmRFlRbnFRYldfdy1mY0JDYTI4OVRvVEFhbk9pSHJuQmQ1V180QURmcFVCMWNYUUJsREhINzNnMWRNSlFfRmQ3dE0wUG50Y0tHeFhfMW4tbG43V3VMSnhGU05zRGFka1lEcm8yS1pSWGZvOWJpc3BvR2VXbjFlSVZLOWRrb0xZWkQ",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:23 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889824.756211,VS0,VE81",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889823776.Z0FBQUFBQlpSX3dmUnI4RWpIY2d6OEpEVjB3dnBBLXZLb2RUUWtITm5HOWt5X1JoY3RyWkw3Q3cxTERoVmNjYnRqQ2hJT01IRE9nR0xDZF94U0M1VkdoRzE0dzFzLUxLSE5jV2JpbG9OUFZlMkx4bzM5bVc1WUxKN3M3R3Y1a1N1SEZ1UnIyVnQ2dGY; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:23 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "595.0",
+          "x-ratelimit-reset": "577",
+          "x-ratelimit-used": "5",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW5&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "77",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889823776.Z0FBQUFBQlpSX3dmUnI4RWpIY2d6OEpEVjB3dnBBLXZLb2RUUWtITm5HOWt5X1JoY3RyWkw3Q3cxTERoVmNjYnRqQ2hJT01IRE9nR0xDZF94U0M1VkdoRzE0dzFzLUxLSE5jV2JpbG9OUFZlMkx4bzM5bVc1WUxKN3M3R3Y1a1N1SEZ1UnIyVnQ2dGY",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:24 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889824.928149,VS0,VE286",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889823982.Z0FBQUFBQlpSX3dneE9zcTFla1YtM0RvU3huTTVXLWtpS2h1dC0zNWxidk5oaEJKUmRKSTJ3aS1kUFZLbDMyQ01sUGNoUzNRbEFKcFExMnFzaFFoclRPeXNvSjJlMU5JLWRmaDdBdVA1YU14cVZlYWJwUVBLS3lCSmtSUE03T1dZZlNnT2hUanFmSV8; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:24 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "594.0",
+          "x-ratelimit-reset": "577",
+          "x-ratelimit-used": "6",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW6&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "77",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889823982.Z0FBQUFBQlpSX3dneE9zcTFla1YtM0RvU3huTTVXLWtpS2h1dC0zNWxidk5oaEJKUmRKSTJ3aS1kUFZLbDMyQ01sUGNoUzNRbEFKcFExMnFzaFFoclRPeXNvSjJlMU5JLWRmaDdBdVA1YU14cVZlYWJwUVBLS3lCSmtSUE03T1dZZlNnT2hUanFmSV8",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:24 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889824.263052,VS0,VE73",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889824280.Z0FBQUFBQlpSX3dnSXp0NXhZazJIN0Z3d1VSdEdvNE5IekUyV1dMbUl4bnZUZ2NoejZjREFtTWd3dHZxYjA4OHF1Ym4zSndpbHJtOWlMODBVQTRNeFBXVHhaancwUzBLNTloMXRpa1ptbkZ5ZkJ5VTZWakVSSmF0b3dLY1hQdVBCWDh0RHFja2xjYWo; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:24 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "593.0",
+          "x-ratelimit-reset": "576",
+          "x-ratelimit-used": "7",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW7&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "77",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889824280.Z0FBQUFBQlpSX3dnSXp0NXhZazJIN0Z3d1VSdEdvNE5IekUyV1dMbUl4bnZUZ2NoejZjREFtTWd3dHZxYjA4OHF1Ym4zSndpbHJtOWlMODBVQTRNeFBXVHhaancwUzBLNTloMXRpa1ptbkZ5ZkJ5VTZWakVSSmF0b3dLY1hQdVBCWDh0RHFja2xjYWo",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:24 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889824.387564,VS0,VE64",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889824429.Z0FBQUFBQlpSX3dnRnNxMzJnckdSbTJHX1NHRXV3b2loSV9NVC1SRzQwSXh5SmpmaHI2eVg4WTdZeXYweTlsSl9rNzhjVFlHTW9wdUdVVXRqcFdwSzBHQ2owN1pocGo4OWJENFBVWlJ3dkh3UjlwRkVsdF9ISzFZLTNGV2NPWHZjOTdjaGVKZnRINTI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:24 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "592.0",
+          "x-ratelimit-reset": "576",
+          "x-ratelimit-used": "8",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:24",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW8&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "77",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889824429.Z0FBQUFBQlpSX3dnRnNxMzJnckdSbTJHX1NHRXV3b2loSV9NVC1SRzQwSXh5SmpmaHI2eVg4WTdZeXYweTlsSl9rNzhjVFlHTW9wdUdVVXRqcFdwSzBHQ2owN1pocGo4OWJENFBVWlJ3dkh3UjlwRkVsdF9ISzFZLTNGV2NPWHZjOTdjaGVKZnRINTI",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:24 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889824.495732,VS0,VE71",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889824488.Z0FBQUFBQlpSX3dnS2kxVktxdkxfMEJfanNJTTJBRVlxUXpiZnBkcmdnbWNmVjhRMVRyanNrbmNlTS05WkpkSjRXdS14aEVBRUlvblFhMDFQbE4tYngtRlNJRWJLaFJTQlRfcHBHQ2JLRlpRZXpWak8wSWlERGxTOFhSRGpNZDRNXzdlcks1cS1PaXI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:24 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "591.0",
+          "x-ratelimit-reset": "576",
+          "x-ratelimit-used": "9",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:24",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW9&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "77",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889824488.Z0FBQUFBQlpSX3dnS2kxVktxdkxfMEJfanNJTTJBRVlxUXpiZnBkcmdnbWNmVjhRMVRyanNrbmNlTS05WkpkSjRXdS14aEVBRUlvblFhMDFQbE4tYngtRlNJRWJLaFJTQlRfcHBHQ2JLRlpRZXpWak8wSWlERGxTOFhSRGpNZDRNXzdlcks1cS1PaXI",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:24 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889825.609613,VS0,VE79",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889824630.Z0FBQUFBQlpSX3dnaTlyRVc0YmVHR05ua0J3eXF0QUw0akpwaG81NzhuZ0FfS1hkU1RZTzVpSXV3bk1xOGFDdlU4d29ock9nVFBEWVV1VkVYMzB3ZUIwRXlGblAyNWF2eVV0ZjlwU0RRV3FUSy1acGtiYU8xZ05DbUo5VksycnNQclhaNFNKR1FkeVk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:24 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "590.0",
+          "x-ratelimit-reset": "576",
+          "x-ratelimit-used": "10",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:24",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW10&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889824630.Z0FBQUFBQlpSX3dnaTlyRVc0YmVHR05ua0J3eXF0QUw0akpwaG81NzhuZ0FfS1hkU1RZTzVpSXV3bk1xOGFDdlU4d29ock9nVFBEWVV1VkVYMzB3ZUIwRXlGblAyNWF2eVV0ZjlwU0RRV3FUSy1acGtiYU8xZ05DbUo5VksycnNQclhaNFNKR1FkeVk",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:24 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889825.737361,VS0,VE102",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889824764.Z0FBQUFBQlpSX3dnNXpLdnBZWkpueHNYSE5rQzdHREowMDVSYTJnbTJaalZFREtEcmpxUmY1eEhjaWM4MDlCcmxtdEpmNkVDdjByaG83ak1JcGowN09Nbmt0by1wbmxXRjVEN2l3Qnd2YXNiUVBuelpIdlhXdDZleHZFenJrSkdya0hmRFRzSkNfWUY; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:24 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "589.0",
+          "x-ratelimit-reset": "576",
+          "x-ratelimit-used": "11",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:24",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW11&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889824764.Z0FBQUFBQlpSX3dnNXpLdnBZWkpueHNYSE5rQzdHREowMDVSYTJnbTJaalZFREtEcmpxUmY1eEhjaWM4MDlCcmxtdEpmNkVDdjByaG83ak1JcGowN09Nbmt0by1wbmxXRjVEN2l3Qnd2YXNiUVBuelpIdlhXdDZleHZFenJrSkdya0hmRFRzSkNfWUY",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:25 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889825.930555,VS0,VE71",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889825091.Z0FBQUFBQlpSX3doSi1HMWFfR3hVY0pCRkhia21SQkM0X014T1VtSVNmNU5PMk9qVmJvSkNWWXhvd0lpTnZqVDRYbUZQMjQ4b1JNZ0c0UkVyMmx4N3hkd3h2NGVTQ2VBdnhCZUFIWXFzX01pemFFMXlHRFFIWkJXX3Mxd1NWLXNHM0N5X2dfWVA3MFk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:25 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "588.0",
+          "x-ratelimit-reset": "575",
+          "x-ratelimit-used": "12",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:24",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW12&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889825091.Z0FBQUFBQlpSX3doSi1HMWFfR3hVY0pCRkhia21SQkM0X014T1VtSVNmNU5PMk9qVmJvSkNWWXhvd0lpTnZqVDRYbUZQMjQ4b1JNZ0c0UkVyMmx4N3hkd3h2NGVTQ2VBdnhCZUFIWXFzX01pemFFMXlHRFFIWkJXX3Mxd1NWLXNHM0N5X2dfWVA3MFk",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:25 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889825.049036,VS0,VE73",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889825066.Z0FBQUFBQlpSX3doWUE5dm94NVhVa3hHZnBvM2xwS3ROb3RXa0tGRDhyTGd0TXFpbVRyeE5WUjByaFp0cHRoQWNCRUZVWmFoMHNvWkVHY05HQzJYc0g2WjRUYmdodG9mT3EteF9ZSDBkNkZrVmJBWVlCUWF0RmpUbmcxanNmSHN3Q2Uwa0xGdU9sRGk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:25 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "587.0",
+          "x-ratelimit-reset": "575",
+          "x-ratelimit-used": "13",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:24",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW13&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889825066.Z0FBQUFBQlpSX3doWUE5dm94NVhVa3hHZnBvM2xwS3ROb3RXa0tGRDhyTGd0TXFpbVRyeE5WUjByaFp0cHRoQWNCRUZVWmFoMHNvWkVHY05HQzJYc0g2WjRUYmdodG9mT3EteF9ZSDBkNkZrVmJBWVlCUWF0RmpUbmcxanNmSHN3Q2Uwa0xGdU9sRGk",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:25 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889825.168847,VS0,VE79",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889825191.Z0FBQUFBQlpSX3doblVNcDNWbW1sMFFWNnNHdE9FckZla05LNmJLM2lCVDkxZ3RHNXpSZmFCWFh2WkJXcWtuUU02QWh4MHY3LTRUcnkwOFBqdnNzcXR5bU1wR0EtbGlVaDBqMW9xWUU0WUlkZElzLUQtclpvRllYZTBKem55ZHluaGx0d0JDbmtoWFI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:25 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "586.0",
+          "x-ratelimit-reset": "575",
+          "x-ratelimit-used": "14",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:24",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW14&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889825191.Z0FBQUFBQlpSX3doblVNcDNWbW1sMFFWNnNHdE9FckZla05LNmJLM2lCVDkxZ3RHNXpSZmFCWFh2WkJXcWtuUU02QWh4MHY3LTRUcnkwOFBqdnNzcXR5bU1wR0EtbGlVaDBqMW9xWUU0WUlkZElzLUQtclpvRllYZTBKem55ZHluaGx0d0JDbmtoWFI",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:25 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889825.306531,VS0,VE71",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889825334.Z0FBQUFBQlpSX3doRUVzVmgtR0NFT2xvNFUyS2dNbTE3ZGMxaXF0MENXNVJDV05JTHk0NnBIcko1akcybnd3UEphN3MzVV9CU2tkWXJxLVE2YlJHWlhnUnJPWmhYWjdxS2pCRXRTTUhnM2pleV9GZUFsZm1PUGJfWXJmc2RvZ0xYTmJCVFRuaVI3S0g; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:25 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "585.0",
+          "x-ratelimit-reset": "575",
+          "x-ratelimit-used": "15",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:25",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW15&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889825334.Z0FBQUFBQlpSX3doRUVzVmgtR0NFT2xvNFUyS2dNbTE3ZGMxaXF0MENXNVJDV05JTHk0NnBIcko1akcybnd3UEphN3MzVV9CU2tkWXJxLVE2YlJHWlhnUnJPWmhYWjdxS2pCRXRTTUhnM2pleV9GZUFsZm1PUGJfWXJmc2RvZ0xYTmJCVFRuaVI3S0g",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:25 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889825.437992,VS0,VE212",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889825449.Z0FBQUFBQlpSX3doRkFnMldyMHF1cXNOUm5xNEVXLXk2QnQyZVZFR0tEbHlRQmpCZzd0TzJfckRNaDZWMldCcERHV25wRHR0blhFNXFaQ1JRdUZEbWw4SGp1bUprTXFub0M5MDl3ZzJEdF9QNEltRjg2LVRMc243dWhYUVQ0dFBOd2pBMVV6djM3ajA; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:25 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "584.0",
+          "x-ratelimit-reset": "575",
+          "x-ratelimit-used": "16",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:25",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW16&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889825449.Z0FBQUFBQlpSX3doRkFnMldyMHF1cXNOUm5xNEVXLXk2QnQyZVZFR0tEbHlRQmpCZzd0TzJfckRNaDZWMldCcERHV25wRHR0blhFNXFaQ1JRdUZEbWw4SGp1bUprTXFub0M5MDl3ZzJEdF9QNEltRjg2LVRMc243dWhYUVQ0dFBOd2pBMVV6djM3ajA",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:25 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889826.691854,VS0,VE73",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889825726.Z0FBQUFBQlpSX3dobC1vS1RYZWJCWHVOcGxSb2RORVhUZWRhNHV1WEJnWkFuZjRsbFF2c2R6RUd2R2VCay0tZGpKbXNnTHVwWkZvNEFoeTZZNWNrbW9ldjBlWFcyMERhdnZYM2JWNnVqUWEyZHFFX0xwWmRvRXZERzFlZ0NHb21jNUZOWWFoZzVRc1U; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:25 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "583.0",
+          "x-ratelimit-reset": "575",
+          "x-ratelimit-used": "17",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:25",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW17&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889825726.Z0FBQUFBQlpSX3dobC1vS1RYZWJCWHVOcGxSb2RORVhUZWRhNHV1WEJnWkFuZjRsbFF2c2R6RUd2R2VCay0tZGpKbXNnTHVwWkZvNEFoeTZZNWNrbW9ldjBlWFcyMERhdnZYM2JWNnVqUWEyZHFFX0xwWmRvRXZERzFlZ0NHb21jNUZOWWFoZzVRc1U",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:26 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889826.806608,VS0,VE633",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889825826.Z0FBQUFBQlpSX3dpclJZOVRnTFo4RjlGMjRkelVuTTVLaV9JRHRNT2pSdTVuRTZjSWU0MTZHNGQzNmRwT1diZGpxYzI4OFhSeVZZQnFIUGdNUTlOQ3pWX3B6NDhfTHVobnBfYnNaWDdVNnhCY1RxREM5Y0pWWENHd0doNTBwVEwyQ3dtdUFEckJkaWs; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:26 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "582.0",
+          "x-ratelimit-reset": "575",
+          "x-ratelimit-used": "18",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:26",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW18&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889825826.Z0FBQUFBQlpSX3dpclJZOVRnTFo4RjlGMjRkelVuTTVLaV9JRHRNT2pSdTVuRTZjSWU0MTZHNGQzNmRwT1diZGpxYzI4OFhSeVZZQnFIUGdNUTlOQ3pWX3B6NDhfTHVobnBfYnNaWDdVNnhCY1RxREM5Y0pWWENHd0doNTBwVEwyQ3dtdUFEckJkaWs",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:26 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889826.481990,VS0,VE72",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889826497.Z0FBQUFBQlpSX3dpLWdWR3Z0ZHMwQlp1WlVNWFlvdFlNejZ4cXVxYU1vVkhPZGo1NTd3ZTBlMEFzWDZ2Tms0VWZmSVkwbkIwQUZLcWtmVTliQ1VUeGwtZU11cFU2QlRLVXFDaHI0WUFRMmRrRDM0aW1CR012SzlaT2FMTDhtYkNOa0J6S1NLS2dPUlA; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:26 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "581.0",
+          "x-ratelimit-reset": "574",
+          "x-ratelimit-used": "19",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:26",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW19&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889826497.Z0FBQUFBQlpSX3dpLWdWR3Z0ZHMwQlp1WlVNWFlvdFlNejZ4cXVxYU1vVkhPZGo1NTd3ZTBlMEFzWDZ2Tms0VWZmSVkwbkIwQUZLcWtmVTliQ1VUeGwtZU11cFU2QlRLVXFDaHI0WUFRMmRrRDM0aW1CR012SzlaT2FMTDhtYkNOa0J6S1NLS2dPUlA",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:26 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889827.597891,VS0,VE98",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889826605.Z0FBQUFBQlpSX3dpeUdPampxcDhCTWJmTURoMkk2Zzdiakp5Q3JMdEhDS2ZBS3F3Q1Qwa2YzdG14TnJCSG5uY19aSHFFNUJyQm9hM0lSM24xQWR6U01mcGx3ZnlMS2haVWVKVmlTSTg5NnNMOV94aFlOZzRNUW9fVnRHYTVmWGEwWXlTM3B0NGZFQlg; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:26 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "580.0",
+          "x-ratelimit-reset": "574",
+          "x-ratelimit-used": "20",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:26",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW20&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889826605.Z0FBQUFBQlpSX3dpeUdPampxcDhCTWJmTURoMkk2Zzdiakp5Q3JMdEhDS2ZBS3F3Q1Qwa2YzdG14TnJCSG5uY19aSHFFNUJyQm9hM0lSM24xQWR6U01mcGx3ZnlMS2haVWVKVmlTSTg5NnNMOV94aFlOZzRNUW9fVnRHYTVmWGEwWXlTM3B0NGZFQlg",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:26 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889827.755126,VS0,VE87",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889826772.Z0FBQUFBQlpSX3dpY2dwRTdrQm03VHBpYU9LRTdOWm5fS1QtVTFLQ1pqVFR3S1FwaGYyaFQ0T2RtRU1UTVJfMEl3d0VlazEtMkFzck9fLXUxZjl2MWZCeEhzUEhXRzNaT1pLYTVJOHVhUVJ2N0ZVZldMb24tV1ZUVXg5UXN1dGoteXJkbzYwZ2hhZDY; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:26 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "579.0",
+          "x-ratelimit-reset": "574",
+          "x-ratelimit-used": "21",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:26",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW21&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889826772.Z0FBQUFBQlpSX3dpY2dwRTdrQm03VHBpYU9LRTdOWm5fS1QtVTFLQ1pqVFR3S1FwaGYyaFQ0T2RtRU1UTVJfMEl3d0VlazEtMkFzck9fLXUxZjl2MWZCeEhzUEhXRzNaT1pLYTVJOHVhUVJ2N0ZVZldMb24tV1ZUVXg5UXN1dGoteXJkbzYwZ2hhZDY",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:26 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889827.891715,VS0,VE85",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889826917.Z0FBQUFBQlpSX3dpVV9TYjJ3YnZwVlhlNzJfNm1PeGpSNzJTMVFlNmJjN3ROVHlwRGNjbWhEMmlUOV9fYXlWRG1QdmN5R2lXSDFiTEJvVEIyVUcwUkhWZDh2NkE2N2p4d2ZndEd4ZzYwc2Q0czVpT0tqQU42X2lXNmctREIzTUhjT3hVVExRWjM3TEo; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:26 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "578.0",
+          "x-ratelimit-reset": "574",
+          "x-ratelimit-used": "22",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:26",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW22&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889826917.Z0FBQUFBQlpSX3dpVV9TYjJ3YnZwVlhlNzJfNm1PeGpSNzJTMVFlNmJjN3ROVHlwRGNjbWhEMmlUOV9fYXlWRG1QdmN5R2lXSDFiTEJvVEIyVUcwUkhWZDh2NkE2N2p4d2ZndEd4ZzYwc2Q0czVpT0tqQU42X2lXNmctREIzTUhjT3hVVExRWjM3TEo",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:27 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889827.051364,VS0,VE83",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889827142.Z0FBQUFBQlpSX3dqOXlHTFZlLXptTGxTcmdqazRnU0ppeEg4U094eTQ1VTdUWXBJZHgteHItRlcycjI0NW1GeUh5V0lzeFB1allRdnhBdFhMd0NmUHhXY1MxMmZhYkw5VVoyQmdaUlAtRURpek9CeXVzQk5oVFlWeGk2Y0dyaC1hZ1UwZ3k1LXhoRGY; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:27 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "577.0",
+          "x-ratelimit-reset": "573",
+          "x-ratelimit-used": "23",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:26",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW23&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889827142.Z0FBQUFBQlpSX3dqOXlHTFZlLXptTGxTcmdqazRnU0ppeEg4U094eTQ1VTdUWXBJZHgteHItRlcycjI0NW1GeUh5V0lzeFB1allRdnhBdFhMd0NmUHhXY1MxMmZhYkw5VVoyQmdaUlAtRURpek9CeXVzQk5oVFlWeGk2Y0dyaC1hZ1UwZ3k1LXhoRGY",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:27 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889827.194391,VS0,VE70",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889827249.Z0FBQUFBQlpSX3dqU0tST0lxdlJOUmc0b1VOX0J4OGYtdkpUWlJvY1lZVElYLTM0TE9HakpRaURNS3F2Tmhfd3VmQ01yQ3NKdUxNWHRqTE11YndVZXFWOUFqc1pQbFM1ZTN0akpWX1cxZm9fYlZKdTRyVFQwSnFROVcwOU9ibVcyNTJxOGV0LUxHd0M; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:27 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "576.0",
+          "x-ratelimit-reset": "573",
+          "x-ratelimit-used": "24",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:26",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW24&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889827249.Z0FBQUFBQlpSX3dqU0tST0lxdlJOUmc0b1VOX0J4OGYtdkpUWlJvY1lZVElYLTM0TE9HakpRaURNS3F2Tmhfd3VmQ01yQ3NKdUxNWHRqTE11YndVZXFWOUFqc1pQbFM1ZTN0akpWX1cxZm9fYlZKdTRyVFQwSnFROVcwOU9ibVcyNTJxOGV0LUxHd0M",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:27 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889827.323213,VS0,VE78",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889827344.Z0FBQUFBQlpSX3dqMU1XSGtQTTJreWtFV1g2U0VGR3B3aXNJeDF4eExUNW1PYlQ4Q0VHWExudkxXM1YtWndFOTdYN3h0RGo2Tk90Sk5KYjRBZEplai1JQVdnaW1IbHRzNkNXZEJ2RXdtdmVCb05qQ01kVGJBZXlJYmJsWXJJQzI0QmJfMTdjUktETVk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:27 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "575.0",
+          "x-ratelimit-reset": "573",
+          "x-ratelimit-used": "25",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:27",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW25&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889827344.Z0FBQUFBQlpSX3dqMU1XSGtQTTJreWtFV1g2U0VGR3B3aXNJeDF4eExUNW1PYlQ4Q0VHWExudkxXM1YtWndFOTdYN3h0RGo2Tk90Sk5KYjRBZEplai1JQVdnaW1IbHRzNkNXZEJ2RXdtdmVCb05qQ01kVGJBZXlJYmJsWXJJQzI0QmJfMTdjUktETVk",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:27 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889827.471399,VS0,VE74",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889827489.Z0FBQUFBQlpSX3dqWFZYN2pjUEdfb2tHOG0yeU1kVFpYMW5xWFJsU2F1YVl5Xy1fTXVFRWxSYzk0UlhMN3d1YVBkTlZCbXhrZkQwcDNzWGttVTlzanRubVA1NG1raVBMSmp3eVJSOXg5dlpTR2NyeWxqcjBWbW5IXzRlb09WYWlhNWduaVNPSG5Kak4; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:27 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "574.0",
+          "x-ratelimit-reset": "573",
+          "x-ratelimit-used": "26",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:27",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW26&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889827489.Z0FBQUFBQlpSX3dqWFZYN2pjUEdfb2tHOG0yeU1kVFpYMW5xWFJsU2F1YVl5Xy1fTXVFRWxSYzk0UlhMN3d1YVBkTlZCbXhrZkQwcDNzWGttVTlzanRubVA1NG1raVBMSmp3eVJSOXg5dlpTR2NyeWxqcjBWbW5IXzRlb09WYWlhNWduaVNPSG5Kak4",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:27 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889828.603009,VS0,VE93",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889827650.Z0FBQUFBQlpSX3dqOG40QzJkSGh0TEp4dE5LbC1xUEtQMUEzVHVkMmdKdVM1N05veGc4MlpWcXF1eTg5YmlMNE5yWlZtVXdMcS00dzV4OENTcUpuTmtQSGw2bUY3LUJkdUlHUVlKbGc3cHBEQjN6aVFqamtGZjBibGhFazJpanZBZENMUHViT0V4SjI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:27 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "573.0",
+          "x-ratelimit-reset": "573",
+          "x-ratelimit-used": "27",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:27",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW27&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889827650.Z0FBQUFBQlpSX3dqOG40QzJkSGh0TEp4dE5LbC1xUEtQMUEzVHVkMmdKdVM1N05veGc4MlpWcXF1eTg5YmlMNE5yWlZtVXdMcS00dzV4OENTcUpuTmtQSGw2bUY3LUJkdUlHUVlKbGc3cHBEQjN6aVFqamtGZjBibGhFazJpanZBZENMUHViT0V4SjI",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:28 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889828.739203,VS0,VE298",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889827755.Z0FBQUFBQlpSX3drODVOU2xQeW5mS1dLRXdCNlVaeGkydGRMeWJ2eDVTZUt1cTlYbDd3QkQ1ODdJbzdfN2NoOXlXTGQ4RXpoNlZIejhNVVY1MEhobXYzY0hXSjRPOEVPcXNkcTBYSFRGeTVfY0lIN2hJZmZJVk5fRG9nZ0cyR1NlN09Hb2txU1NUbm8; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:28 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "572.0",
+          "x-ratelimit-reset": "573",
+          "x-ratelimit-used": "28",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:27",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW28&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889827755.Z0FBQUFBQlpSX3drODVOU2xQeW5mS1dLRXdCNlVaeGkydGRMeWJ2eDVTZUt1cTlYbDd3QkQ1ODdJbzdfN2NoOXlXTGQ4RXpoNlZIejhNVVY1MEhobXYzY0hXSjRPOEVPcXNkcTBYSFRGeTVfY0lIN2hJZmZJVk5fRG9nZ0cyR1NlN09Hb2txU1NUbm8",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:28 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889828.079363,VS0,VE94",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889828130.Z0FBQUFBQlpSX3drS05TNVRuOEJUazhRU210dEdCY2E4bkEtNnQwbzlmbmliLUgzMk83TmNXNjgwUW1YZEp4NzdqcWQydzBCdkFCLXkyMGdhaWZGMEZuUE01djllMWxWRVBPYTI1UTJFSjRUUFNRTkZhT05mRHM1bU81bGxyTjd6emRpQU5wWUx3WVo; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:28 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "571.0",
+          "x-ratelimit-reset": "572",
+          "x-ratelimit-used": "29",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:28",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW29&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889828130.Z0FBQUFBQlpSX3drS05TNVRuOEJUazhRU210dEdCY2E4bkEtNnQwbzlmbmliLUgzMk83TmNXNjgwUW1YZEp4NzdqcWQydzBCdkFCLXkyMGdhaWZGMEZuUE01djllMWxWRVBPYTI1UTJFSjRUUFNRTkZhT05mRHM1bU81bGxyTjd6emRpQU5wWUx3WVo",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:28 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889828.218616,VS0,VE653",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889828240.Z0FBQUFBQlpSX3draFZDcFV2NmV3MVUzNy0yaW9FZm9McXJmNm1XLTBuakJXZnlobXNsRzlKVXBSX1lRNU5DMDRMc2Fwd1pjWV8tN0tnVF9tbmNaTFJxd2JTUzlLTlRHSVFzSlNsNV85eWJIVkRaYzZEWmNhYTB5XzhCSUpsRHp1YzB3a09LZW5uUy0; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:28 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "570.0",
+          "x-ratelimit-reset": "572",
+          "x-ratelimit-used": "30",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:28",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW30&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889828240.Z0FBQUFBQlpSX3draFZDcFV2NmV3MVUzNy0yaW9FZm9McXJmNm1XLTBuakJXZnlobXNsRzlKVXBSX1lRNU5DMDRMc2Fwd1pjWV8tN0tnVF9tbmNaTFJxd2JTUzlLTlRHSVFzSlNsNV85eWJIVkRaYzZEWmNhYTB5XzhCSUpsRHp1YzB3a09LZW5uUy0",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:28 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889829.910165,VS0,VE72",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889828931.Z0FBQUFBQlpSX3drWEtVNXprM2d5eVNHREJjbTNPVzVMdjlWU1YzbWFpa2JHQ0tlQ3ktMDA5b0pNa2VTNnd4dUtoLVV1MlFVdHkxQ0hYT0JTY1VscHkxR0lXbGUzSWFRS0lOVzFMaGtjRTVQSUk5S1JYMTJyOEZlajBac0oydDItVDNDMUNZTjRqVnQ; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:28 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "569.0",
+          "x-ratelimit-reset": "572",
+          "x-ratelimit-used": "31",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:28",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW31&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889828931.Z0FBQUFBQlpSX3drWEtVNXprM2d5eVNHREJjbTNPVzVMdjlWU1YzbWFpa2JHQ0tlQ3ktMDA5b0pNa2VTNnd4dUtoLVV1MlFVdHkxQ0hYT0JTY1VscHkxR0lXbGUzSWFRS0lOVzFMaGtjRTVQSUk5S1JYMTJyOEZlajBac0oydDItVDNDMUNZTjRqVnQ",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:29 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889829.026398,VS0,VE72",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889829045.Z0FBQUFBQlpSX3dsLWIzS2pvX2pZUWtkWnVOWkFzSmdYTjFxUGxheHIwdkN1N1Bod2J2Y2dnYXZ0bnBIcWRmR2pYVFhCalc3UnhmQlpLZ2V2WHlVeDdaOFkyT203bkJFcjdWTG4xYjBLT2xyVDBpWXMxNXBDVUw3b1JNOW9rbzhxR1JIVnJBc2tmbVg; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:29 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "568.0",
+          "x-ratelimit-reset": "571",
+          "x-ratelimit-used": "32",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:28",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW32&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889829045.Z0FBQUFBQlpSX3dsLWIzS2pvX2pZUWtkWnVOWkFzSmdYTjFxUGxheHIwdkN1N1Bod2J2Y2dnYXZ0bnBIcWRmR2pYVFhCalc3UnhmQlpLZ2V2WHlVeDdaOFkyT203bkJFcjdWTG4xYjBLT2xyVDBpWXMxNXBDVUw3b1JNOW9rbzhxR1JIVnJBc2tmbVg",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:29 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889829.139206,VS0,VE73",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889829156.Z0FBQUFBQlpSX3dsU0pFY2lLUHQ3MXlEQWgwcmFoc0hyYUM5dzY3aGtwUzJ4TGw2NmpnN0tiQVVoMmJmaDFjZXNadW9RNHNfZmhLbUJVWVNoMGEtT25NTjZLVjBueHBkTHJXeU91Tk1JZW5zU2lIdG1oT214TXdoT3Y1ZlA5aUJ3V0pRVWtMVzdmQlo; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:29 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "567.0",
+          "x-ratelimit-reset": "571",
+          "x-ratelimit-used": "33",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:28",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW33&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889829156.Z0FBQUFBQlpSX3dsU0pFY2lLUHQ3MXlEQWgwcmFoc0hyYUM5dzY3aGtwUzJ4TGw2NmpnN0tiQVVoMmJmaDFjZXNadW9RNHNfZmhLbUJVWVNoMGEtT25NTjZLVjBueHBkTHJXeU91Tk1JZW5zU2lIdG1oT214TXdoT3Y1ZlA5aUJ3V0pRVWtMVzdmQlo",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:29 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889829.293086,VS0,VE68",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889829307.Z0FBQUFBQlpSX3dsS3BWYVdyRTB3bnZMdHBqY1p6eUFfcEFFX3N5dC1PSk1Nbzh4emNwajc3Vy1iYWVGZWlZUjJ1Z0MyUzNUUUxDVFZPZmZ5bjlfX19reGQxb3l3MWFOT1pZdWhXbGhjNzlsVFZuME44a2lVRmRVYUdWY1p2S3Z5cjZpUzZkNHVqUmY; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:29 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "566.0",
+          "x-ratelimit-reset": "571",
+          "x-ratelimit-used": "34",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:29",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW34&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889829307.Z0FBQUFBQlpSX3dsS3BWYVdyRTB3bnZMdHBqY1p6eUFfcEFFX3N5dC1PSk1Nbzh4emNwajc3Vy1iYWVGZWlZUjJ1Z0MyUzNUUUxDVFZPZmZ5bjlfX19reGQxb3l3MWFOT1pZdWhXbGhjNzlsVFZuME44a2lVRmRVYUdWY1p2S3Z5cjZpUzZkNHVqUmY",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:29 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889829.446152,VS0,VE100",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889829462.Z0FBQUFBQlpSX3dsMmxXZWcxcmdMODE5bEo0NFc3QWtVQ1gxLVhMNHV2dkd0N2p2cVFqY25MVUR1SHhLdmtpUVJuNnJEMzVNbk02al90a3JUV0JVU2ZOSEFYajhHdzVPdHlpc05CYzZwTjdnSnpPMDNHX3gxQmxsQWhiNlJaWlptbloyQnIwZzMtdUQ; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:29 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "565.0",
+          "x-ratelimit-reset": "571",
+          "x-ratelimit-used": "35",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:29",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW35&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889829462.Z0FBQUFBQlpSX3dsMmxXZWcxcmdMODE5bEo0NFc3QWtVQ1gxLVhMNHV2dkd0N2p2cVFqY25MVUR1SHhLdmtpUVJuNnJEMzVNbk02al90a3JUV0JVU2ZOSEFYajhHdzVPdHlpc05CYzZwTjdnSnpPMDNHX3gxQmxsQWhiNlJaWlptbloyQnIwZzMtdUQ",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:29 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889830.595134,VS0,VE65",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889829612.Z0FBQUFBQlpSX3dsVW13MGdoZEpHMm1rM25VN3kzQ3JJZjZ4Q3FXdktSbjBCZlFmcVk3LWRZZV91WEpNT0xKaGxKaThPbVJ6a0JIeDhyVmduX3FrTWlJa3NLRHNXRHlacGtrbjNPM0NaeG5xM3lLQXVTUGdSd2VlQjhiT0UxRXZ1bVJCaERCbU12VWk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:29 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "564.0",
+          "x-ratelimit-reset": "571",
+          "x-ratelimit-used": "36",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:29",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW36&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889829612.Z0FBQUFBQlpSX3dsVW13MGdoZEpHMm1rM25VN3kzQ3JJZjZ4Q3FXdktSbjBCZlFmcVk3LWRZZV91WEpNT0xKaGxKaThPbVJ6a0JIeDhyVmduX3FrTWlJa3NLRHNXRHlacGtrbjNPM0NaeG5xM3lLQXVTUGdSd2VlQjhiT0UxRXZ1bVJCaERCbU12VWk",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:29 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889830.720373,VS0,VE156",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889829735.Z0FBQUFBQlpSX3dsQ0NEQ0NlTWJWY3Yxd0VGR0ZMYk44blprM0t1WDlKRmVRTFhGekN0dHZqdEZka0JadTZVclBFMGwxTDUwckhfU21CckNwU2RhWnV1QkNFVGFLaGJuZXZJMnk4aWtpMl9yMFpQcktaWWV0U0dQTW45V1VEZmNLYm9FV1BuOGJYeHM; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:29 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "563.0",
+          "x-ratelimit-reset": "571",
+          "x-ratelimit-used": "37",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:29",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW37&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889829735.Z0FBQUFBQlpSX3dsQ0NEQ0NlTWJWY3Yxd0VGR0ZMYk44blprM0t1WDlKRmVRTFhGekN0dHZqdEZka0JadTZVclBFMGwxTDUwckhfU21CckNwU2RhWnV1QkNFVGFLaGJuZXZJMnk4aWtpMl9yMFpQcktaWWV0U0dQTW45V1VEZmNLYm9FV1BuOGJYeHM",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:29 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889830.921039,VS0,VE75",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889829955.Z0FBQUFBQlpSX3dsQWVmMnhYSzFhb0tCUWx4RUVLNzZJY0FtV281em51bFEwQ2FLM3JTMkhYNUxGdjBKY21EekNXUk9iSzk4UGZIMzVnZmI1aVdNNUtZa1A1NlNBcG9OVDNIYVY0eXVRU2ktTkp4bU9QaG9MYW85REhUMnB2M1hqcEY3M0JmcGtEdVc; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:29 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "562.0",
+          "x-ratelimit-reset": "571",
+          "x-ratelimit-used": "38",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:29",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW38&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889829955.Z0FBQUFBQlpSX3dsQWVmMnhYSzFhb0tCUWx4RUVLNzZJY0FtV281em51bFEwQ2FLM3JTMkhYNUxGdjBKY21EekNXUk9iSzk4UGZIMzVnZmI1aVdNNUtZa1A1NlNBcG9OVDNIYVY0eXVRU2ktTkp4bU9QaG9MYW85REhUMnB2M1hqcEY3M0JmcGtEdVc",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:30 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889830.052268,VS0,VE69",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889830080.Z0FBQUFBQlpSX3dtMDdBem9mXy1reHByaHNyS05EYzRYR2c4Q2F3S0xQelZMQUQ1U3ZYdF82SUFjR2ktQlBtTTN5VTlwNndUOUd0YVZnek1QYWhzakdPbDgzTG5jYXNMdVRoWUV6QzlodGw2eXYybHFoUzJWZ29BRHdESldVOTVFMzNHcVJ4TE9fenE; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:30 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "561.0",
+          "x-ratelimit-reset": "570",
+          "x-ratelimit-used": "39",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:29",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW39&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889830080.Z0FBQUFBQlpSX3dtMDdBem9mXy1reHByaHNyS05EYzRYR2c4Q2F3S0xQelZMQUQ1U3ZYdF82SUFjR2ktQlBtTTN5VTlwNndUOUd0YVZnek1QYWhzakdPbDgzTG5jYXNMdVRoWUV6QzlodGw2eXYybHFoUzJWZ29BRHdESldVOTVFMzNHcVJ4TE9fenE",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:30 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889830.167881,VS0,VE77",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889830211.Z0FBQUFBQlpSX3dtbEJZOVlNdzAyRmZvbThXWDJDbjlObVZlYmxCZ1o2WUw4bzI3enV4Y1R3NldxalJ3enR0NkxzMldpMnlkenBZVHkzdmxoVUJsdUlGenpIVW96dDVSMXMyVDMyeDR0azdPQUhYbU8tdzZMeFh0bVV0SjJCeXliNzZHOVRlNTZaZF8; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:30 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "560.0",
+          "x-ratelimit-reset": "570",
+          "x-ratelimit-used": "40",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:29",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW40&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889830211.Z0FBQUFBQlpSX3dtbEJZOVlNdzAyRmZvbThXWDJDbjlObVZlYmxCZ1o2WUw4bzI3enV4Y1R3NldxalJ3enR0NkxzMldpMnlkenBZVHkzdmxoVUJsdUlGenpIVW96dDVSMXMyVDMyeDR0azdPQUhYbU8tdzZMeFh0bVV0SjJCeXliNzZHOVRlNTZaZF8",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:30 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889830.289400,VS0,VE78",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889830284.Z0FBQUFBQlpSX3dtdWhtN21uVjg5STVkenZHQkhHc2lqb1k4NWF4Tk9JamJlejZQRER6eGFtbnlsaGg3dE1ZVGFKQjNVMjRITjc0MzcwclFSeVBmdWdmYVpQS0FER3dtVXpMZ1M5eDJWLXRfVUN5cmVmaS04ZWoxdEJfRnhFVl9mOFpZTER3S2RVVTc; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:30 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "559.0",
+          "x-ratelimit-reset": "570",
+          "x-ratelimit-used": "41",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:29",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW41&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889830284.Z0FBQUFBQlpSX3dtdWhtN21uVjg5STVkenZHQkhHc2lqb1k4NWF4Tk9JamJlejZQRER6eGFtbnlsaGg3dE1ZVGFKQjNVMjRITjc0MzcwclFSeVBmdWdmYVpQS0FER3dtVXpMZ1M5eDJWLXRfVUN5cmVmaS04ZWoxdEJfRnhFVl9mOFpZTER3S2RVVTc",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:30 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889830.407623,VS0,VE79",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889830429.Z0FBQUFBQlpSX3dtQzhmalFUcVNHRERtYTVxVmtyUlEzS2Y0WEtHR1V6U2hzUm9UQjllSW1NaS12WVNQU25EN2VCMHhiaDZDUVcxbkZnM2RTT3dnR1otNEhwSUFodXhHWUYwMVVGYjQxOFMtNkFtOW9yWV9GR3NKRWl0S0p3SnBUcjhHeVNxWGdGU24; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:30 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "558.0",
+          "x-ratelimit-reset": "570",
+          "x-ratelimit-used": "42",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:30",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW42&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889830429.Z0FBQUFBQlpSX3dtQzhmalFUcVNHRERtYTVxVmtyUlEzS2Y0WEtHR1V6U2hzUm9UQjllSW1NaS12WVNQU25EN2VCMHhiaDZDUVcxbkZnM2RTT3dnR1otNEhwSUFodXhHWUYwMVVGYjQxOFMtNkFtOW9yWV9GR3NKRWl0S0p3SnBUcjhHeVNxWGdGU24",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:30 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889831.579554,VS0,VE173",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889830599.Z0FBQUFBQlpSX3dtOHN0N2hvTk92QjY5WE5DUkI5dkNURlRFaWc4SkNUekxnNUhuOTdZeHdkNWRCTUZFZjUtYUVncHZhRjZyODZPVjFvTHVsVnlnWm81RFJmb0otU3VWWUlianFZOTBYZ0k3Z1hWQlBiX1lrZGJLQWppTU42SlBHQUE0VWNmWXFNYTI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:30 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "557.0",
+          "x-ratelimit-reset": "570",
+          "x-ratelimit-used": "43",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:30",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW43&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889830599.Z0FBQUFBQlpSX3dtOHN0N2hvTk92QjY5WE5DUkI5dkNURlRFaWc4SkNUekxnNUhuOTdZeHdkNWRCTUZFZjUtYUVncHZhRjZyODZPVjFvTHVsVnlnWm81RFJmb0otU3VWWUlianFZOTBYZ0k3Z1hWQlBiX1lrZGJLQWppTU42SlBHQUE0VWNmWXFNYTI",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:30 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889831.789835,VS0,VE77",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889830810.Z0FBQUFBQlpSX3dtTDN3aXUtVFJUcE1VQWV1b3V3YUt5YjhraTJCOGpqUk11eWFBMGVpQzl2elJCNkpKSjcwQXpBZXlCTVpxUzNYMTIxTkJ4dVA1Z3AwYndMVk5LNTdVUGY2NnhVa2F0SVJyaVI5RHZoUnBNdW1ETG5BZ1N6MXFyTzlKS25IUG1hdVU; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:30 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "556.0",
+          "x-ratelimit-reset": "570",
+          "x-ratelimit-used": "44",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:30",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW44&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889830810.Z0FBQUFBQlpSX3dtTDN3aXUtVFJUcE1VQWV1b3V3YUt5YjhraTJCOGpqUk11eWFBMGVpQzl2elJCNkpKSjcwQXpBZXlCTVpxUzNYMTIxTkJ4dVA1Z3AwYndMVk5LNTdVUGY2NnhVa2F0SVJyaVI5RHZoUnBNdW1ETG5BZ1N6MXFyTzlKS25IUG1hdVU",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:31 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889831.912574,VS0,VE444",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889831053.Z0FBQUFBQlpSX3duOFFmd2hfZTZaNzRVMk5OUXhHM0dOV2otQ1puazJVMEthMjZMWFNFQ21aLWE0OGluSURZTWN5Yzl2dzNEZ0lZR1RzbWJrbkY5YVg5Qm5LOUphTWNJN0FLelc2QlhNa0ZOUVV4cFZOOHBQYzVIc3NZYzhjR285NnNyd0RnMGVPNi0; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:31 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "555.0",
+          "x-ratelimit-reset": "569",
+          "x-ratelimit-used": "45",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:30",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW45&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889831053.Z0FBQUFBQlpSX3duOFFmd2hfZTZaNzRVMk5OUXhHM0dOV2otQ1puazJVMEthMjZMWFNFQ21aLWE0OGluSURZTWN5Yzl2dzNEZ0lZR1RzbWJrbkY5YVg5Qm5LOUphTWNJN0FLelc2QlhNa0ZOUVV4cFZOOHBQYzVIc3NZYzhjR285NnNyd0RnMGVPNi0",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:31 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889831.399076,VS0,VE90",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889831419.Z0FBQUFBQlpSX3dubUU0blhncjB1Wkk3ZjJUbXo3NE9NSjc1ZVZETWhDZXVlQlA5aEN0UDVuZzRiX1Q4eHJPUUUyeGxxc2hvZUt3NFU5bGtVa3kzRkYtSmRBV3lYSU05WHNleEh6VVp2WVQweTl2RGZRYlk1cF95Zl9MRkpubTJWZ2R6Nk1aWWR3M3g; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:31 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "554.0",
+          "x-ratelimit-reset": "569",
+          "x-ratelimit-used": "46",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW46&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889831419.Z0FBQUFBQlpSX3dubUU0blhncjB1Wkk3ZjJUbXo3NE9NSjc1ZVZETWhDZXVlQlA5aEN0UDVuZzRiX1Q4eHJPUUUyeGxxc2hvZUt3NFU5bGtVa3kzRkYtSmRBV3lYSU05WHNleEh6VVp2WVQweTl2RGZRYlk1cF95Zl9MRkpubTJWZ2R6Nk1aWWR3M3g",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:31 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889832.530943,VS0,VE70",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889831545.Z0FBQUFBQlpSX3duTVJLNWppMXhDYzFWQVhYSlFKNnNvZ2NJRloxMF9FVWdBWllRWk9RVi1ZTTlVa1BDTy1nbjBDRGZ0azU3cDNzU1QyeGtJUWtkb2ZMd0k1Q0dfSkRsazFOUlR4ZXBScnM3bFBZYlBjVmpycXFGMGtISVdXdW5fWXBsWjBQRTlVVDE; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:31 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "553.0",
+          "x-ratelimit-reset": "569",
+          "x-ratelimit-used": "47",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW47&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889831545.Z0FBQUFBQlpSX3duTVJLNWppMXhDYzFWQVhYSlFKNnNvZ2NJRloxMF9FVWdBWllRWk9RVi1ZTTlVa1BDTy1nbjBDRGZ0azU3cDNzU1QyeGtJUWtkb2ZMd0k1Q0dfSkRsazFOUlR4ZXBScnM3bFBZYlBjVmpycXFGMGtISVdXdW5fWXBsWjBQRTlVVDE",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:32 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889832.671162,VS0,VE358",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889831688.Z0FBQUFBQlpSX3dvSEVIUzhTZ2FXQnVsa01NQUUta2k3S2RqekZUcjJoQ2VBb1ZVLXY0U3lKZGFjZzgtWDNNenhxdFlMS1kzbUdpNjk0dGxSNG8wRlRoRTZ5Ulo3OTZCbTc2eWdHalNOMW5lSXNzUkdJOURFdDBja3EybE9pb3NDN0hGeTg5cldzeDI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:32 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "552.0",
+          "x-ratelimit-reset": "569",
+          "x-ratelimit-used": "48",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW48&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889831688.Z0FBQUFBQlpSX3dvSEVIUzhTZ2FXQnVsa01NQUUta2k3S2RqekZUcjJoQ2VBb1ZVLXY0U3lKZGFjZzgtWDNNenhxdFlMS1kzbUdpNjk0dGxSNG8wRlRoRTZ5Ulo3OTZCbTc2eWdHalNOMW5lSXNzUkdJOURFdDBja3EybE9pb3NDN0hGeTg5cldzeDI",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:32 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889832.087888,VS0,VE75",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889832106.Z0FBQUFBQlpSX3dvUGNXeUFCNzFKUXlmMXg1Q1FvSFJOdmNpeWFrZUFSdWxqbFZjY001Q2piTkJycHAzR3c2X0xnQ25zS29CUkxhUGNCQUJsMndrMWsyM2NCZ2FweUtnVW0yVTcxRm1Ock8ycktEeV9hMk0xdGtxdGJmdUFzRkZlMXV1X2ZZOWtfNEs; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:32 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "551.0",
+          "x-ratelimit-reset": "568",
+          "x-ratelimit-used": "49",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW49&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889832106.Z0FBQUFBQlpSX3dvUGNXeUFCNzFKUXlmMXg1Q1FvSFJOdmNpeWFrZUFSdWxqbFZjY001Q2piTkJycHAzR3c2X0xnQ25zS29CUkxhUGNCQUJsMndrMWsyM2NCZ2FweUtnVW0yVTcxRm1Ock8ycktEeV9hMk0xdGtxdGJmdUFzRkZlMXV1X2ZZOWtfNEs",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:32 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889832.205972,VS0,VE104",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889832213.Z0FBQUFBQlpSX3dvWE5kczNVbXVmNnVCTHlUUGl0WkN1TTdIcTJ4aTRGSHdpcUxXZkhVaDgtTEMwMmhhNklxUnRtQWQ4WHIxaDh5d1ZZRlZDNXFSUnlkM2ItTDdYazRxbkhDT2s1alVISWJoMXlWbXZsQUk3eHF3dWkwUEpuVkJ4U3Zqd3JTSTk3aXc; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:32 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "550.0",
+          "x-ratelimit-reset": "568",
+          "x-ratelimit-used": "50",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW50&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889832213.Z0FBQUFBQlpSX3dvWE5kczNVbXVmNnVCTHlUUGl0WkN1TTdIcTJ4aTRGSHdpcUxXZkhVaDgtTEMwMmhhNklxUnRtQWQ4WHIxaDh5d1ZZRlZDNXFSUnlkM2ItTDdYazRxbkhDT2s1alVISWJoMXlWbXZsQUk3eHF3dWkwUEpuVkJ4U3Zqd3JTSTk3aXc",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:32 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889832.357145,VS0,VE77",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889832373.Z0FBQUFBQlpSX3dvS3hmREtzbExyeXBBN3JBZUJHWVpRaVpOcWs2UkxUbWc4NURZM21pX3BtcDZ0ejZvSDhIc3lBaDN4SzNVcWhiYkhBTGxnbTNhNmNINjkzdFhMVVBYZnY0T28zSDNGcXlXeU1QV0tLQ1hRWC1fZkhPM0VJQWhpalZKeWRqZWVHeU4; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:32 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "549.0",
+          "x-ratelimit-reset": "568",
+          "x-ratelimit-used": "51",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:32",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW51&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889832373.Z0FBQUFBQlpSX3dvS3hmREtzbExyeXBBN3JBZUJHWVpRaVpOcWs2UkxUbWc4NURZM21pX3BtcDZ0ejZvSDhIc3lBaDN4SzNVcWhiYkhBTGxnbTNhNmNINjkzdFhMVVBYZnY0T28zSDNGcXlXeU1QV0tLQ1hRWC1fZkhPM0VJQWhpalZKeWRqZWVHeU4",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:32 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889832.483180,VS0,VE63",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889832503.Z0FBQUFBQlpSX3dvc3RjZThaRXZCM29DS3RsMElpeXpxRVN4MlVIWWc3aW5ha0ZTS0hYLVZLcjhtbG5DMmhHOFNPTUpRaUNuZDRjMG5YWmdaYUszQ2pSYkdGbzZRQVp3anBaUUNCYVBSdHotRUd2RUNJbGNnYnBOVzhBcUhsdWg4bThBVDRrdzM2dS0; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:32 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "548.0",
+          "x-ratelimit-reset": "568",
+          "x-ratelimit-used": "52",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:32",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW52&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889832503.Z0FBQUFBQlpSX3dvc3RjZThaRXZCM29DS3RsMElpeXpxRVN4MlVIWWc3aW5ha0ZTS0hYLVZLcjhtbG5DMmhHOFNPTUpRaUNuZDRjMG5YWmdaYUszQ2pSYkdGbzZRQVp3anBaUUNCYVBSdHotRUd2RUNJbGNnYnBOVzhBcUhsdWg4bThBVDRrdzM2dS0",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:32 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889833.592958,VS0,VE67",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889832608.Z0FBQUFBQlpSX3dvSlQzaXc4MDN5QVozdHRCMGU4alRlOWZobEZyeDhMaHdfNXA2bXZPdFJzT0g5b0Rsc1JwT09DaW95RW1oX2g2cEc0WjlKUFZ0NmI0WTVLcXR5MUpYX2dNaldLTnlGQjJxTjVzVHoyUTZNeko0WTRhT25ldlF2UzkwWVFLbjdYQUg; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:32 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "547.0",
+          "x-ratelimit-reset": "568",
+          "x-ratelimit-used": "53",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:32",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW53&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889832608.Z0FBQUFBQlpSX3dvSlQzaXc4MDN5QVozdHRCMGU4alRlOWZobEZyeDhMaHdfNXA2bXZPdFJzT0g5b0Rsc1JwT09DaW95RW1oX2g2cEc0WjlKUFZ0NmI0WTVLcXR5MUpYX2dNaldLTnlGQjJxTjVzVHoyUTZNeko0WTRhT25ldlF2UzkwWVFLbjdYQUg",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:32 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889833.704104,VS0,VE64",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889832735.Z0FBQUFBQlpSX3dvV2lnXzRKNWVrNTdRRHViaVBFMTZnLXBRRTRKVnZYUDZGLXZPN0o4WW5yRnVGamtRb2NQZzJLXy14REowY01Tc0NoVzhfV1g2RzZlZk5rZWZxaVhYeWhoY2N6Mk1kZDZ6elc1UEdWU2VqWkhDMi16ZUo3aUlja2E4cXZJQXV1Zmo; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:32 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "546.0",
+          "x-ratelimit-reset": "568",
+          "x-ratelimit-used": "54",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:32",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW54&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889832735.Z0FBQUFBQlpSX3dvV2lnXzRKNWVrNTdRRHViaVBFMTZnLXBRRTRKVnZYUDZGLXZPN0o4WW5yRnVGamtRb2NQZzJLXy14REowY01Tc0NoVzhfV1g2RzZlZk5rZWZxaVhYeWhoY2N6Mk1kZDZ6elc1UEdWU2VqWkhDMi16ZUo3aUlja2E4cXZJQXV1Zmo",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:32 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889833.813219,VS0,VE68",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889832827.Z0FBQUFBQlpSX3dveGlDQ0hDLTFjdkxVLVFKUm5fdE44eWxNUWUzOE01N19UVE04aUJVZVkyWXJ6RWRaWkI1REpoWDdPR1FuOEtzdDZKYUQ5QzNHVEt0RW83MFB3a3drU0QzMHQxZzNVQW9JTmJlRWdDT1Ffa0pQWHZhWGstSWhTWDEzNkJkUEdENlM; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:32 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "545.0",
+          "x-ratelimit-reset": "568",
+          "x-ratelimit-used": "55",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:32",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW55&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889832827.Z0FBQUFBQlpSX3dveGlDQ0hDLTFjdkxVLVFKUm5fdE44eWxNUWUzOE01N19UVE04aUJVZVkyWXJ6RWRaWkI1REpoWDdPR1FuOEtzdDZKYUQ5QzNHVEt0RW83MFB3a3drU0QzMHQxZzNVQW9JTmJlRWdDT1Ffa0pQWHZhWGstSWhTWDEzNkJkUEdENlM",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:33 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889833.928667,VS0,VE74",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889832944.Z0FBQUFBQlpSX3dvRTZRUW5DSU5ma0NlbVg3SUpWc21LNDUycnAwam9WcllFTEJuUHJrODlBNmJxaXNFZmpWbXVCaHJsb1ZsRnVTbXZRMzBrOWZyTEp5Z0hnWUpCX0ZNMVNwRmR4NUtFX0VEZUFIVzBpZkhnOEFWNDhFV3BBaWRhS3VObUJ4YXZ5Vks; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:32 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "544.0",
+          "x-ratelimit-reset": "568",
+          "x-ratelimit-used": "56",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:32",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW56&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889832944.Z0FBQUFBQlpSX3dvRTZRUW5DSU5ma0NlbVg3SUpWc21LNDUycnAwam9WcllFTEJuUHJrODlBNmJxaXNFZmpWbXVCaHJsb1ZsRnVTbXZRMzBrOWZyTEp5Z0hnWUpCX0ZNMVNwRmR4NUtFX0VEZUFIVzBpZkhnOEFWNDhFV3BBaWRhS3VObUJ4YXZ5Vks",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:33 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889833.059975,VS0,VE74",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889833071.Z0FBQUFBQlpSX3dwX24zNm5lVWV4a2RXSW9fNDJTckNtQ3d3V3FBVVlYWG9IMWFEMEQ3MmF2RTMtS0d1dldvdkdaRGZ6b0tmdlRDa3FDTWViN0hTTkoxaWp2QVhkalNfMzJqb3FiWm1aVkNLQ3ZBdXo0cDdRanp0VmNUZHZqMjR6ZVd2Q0h1VVN4VVk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:33 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "543.0",
+          "x-ratelimit-reset": "567",
+          "x-ratelimit-used": "57",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:32",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW57&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889833071.Z0FBQUFBQlpSX3dwX24zNm5lVWV4a2RXSW9fNDJTckNtQ3d3V3FBVVlYWG9IMWFEMEQ3MmF2RTMtS0d1dldvdkdaRGZ6b0tmdlRDa3FDTWViN0hTTkoxaWp2QVhkalNfMzJqb3FiWm1aVkNLQ3ZBdXo0cDdRanp0VmNUZHZqMjR6ZVd2Q0h1VVN4VVk",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:33 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889833.186872,VS0,VE78",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889833203.Z0FBQUFBQlpSX3dwVFZsMm1JWWxEU2JkZTV1V19kWml3NXA4NlN5Y3hxX2ZoSmlkNGlHM2tNbVhkX2Zub3JwdkpzZDlXdUdLcmpRdXdQR1hSNWNoN0c2SkdkaHpGOFR5WWdOWU1HaGFXT1NzemtyYW1XOFlvNk9id3IyeFo4OXd2S3hia2lpRTV2ZUk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:33 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "542.0",
+          "x-ratelimit-reset": "567",
+          "x-ratelimit-used": "58",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:32",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW58&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889833203.Z0FBQUFBQlpSX3dwVFZsMm1JWWxEU2JkZTV1V19kWml3NXA4NlN5Y3hxX2ZoSmlkNGlHM2tNbVhkX2Zub3JwdkpzZDlXdUdLcmpRdXdQR1hSNWNoN0c2SkdkaHpGOFR5WWdOWU1HaGFXT1NzemtyYW1XOFlvNk9id3IyeFo4OXd2S3hia2lpRTV2ZUk",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:33 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889833.307137,VS0,VE69",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889833324.Z0FBQUFBQlpSX3dwblBGbHRZUkxVdF9EeXAxTXpKZWNoQ3FZclpFMUFoSmZqNTFYQW0wbzJYbUtSYjRMRlBCTHNVeFYyamsxZzBtVXR5djNZcGhJMWtXaDhqcHA5aVZvQklUOHJhWGp0cE1UeWhERHQtdU5iRUZ3TmZPMmxiN3VGU2lfZ2owOGVBYUo; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:33 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "541.0",
+          "x-ratelimit-reset": "567",
+          "x-ratelimit-used": "59",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:33",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW59&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889833324.Z0FBQUFBQlpSX3dwblBGbHRZUkxVdF9EeXAxTXpKZWNoQ3FZclpFMUFoSmZqNTFYQW0wbzJYbUtSYjRMRlBCTHNVeFYyamsxZzBtVXR5djNZcGhJMWtXaDhqcHA5aVZvQklUOHJhWGp0cE1UeWhERHQtdU5iRUZ3TmZPMmxiN3VGU2lfZ2owOGVBYUo",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:34 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889833.419217,VS0,VE622",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889833435.Z0FBQUFBQlpSX3dxOWhTZW5kQzFXUWpuT1l6bkRTZTBQa0M2SU1yMVRhMTlXb1BDaWgtRDJZa2FBY3ZHb3p6THJ4VnBET3dSNDFPX1VkbHlOVXpTSktXU3BrSHZxUGdKSTVBTlVQWVNSa0I3SVR0NXdwSm1aaXBreVNWYXU0NktJamtCeGc1aUVlWE4; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:34 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "540.0",
+          "x-ratelimit-reset": "567",
+          "x-ratelimit-used": "60",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:33",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW60&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889833435.Z0FBQUFBQlpSX3dxOWhTZW5kQzFXUWpuT1l6bkRTZTBQa0M2SU1yMVRhMTlXb1BDaWgtRDJZa2FBY3ZHb3p6THJ4VnBET3dSNDFPX1VkbHlOVXpTSktXU3BrSHZxUGdKSTVBTlVQWVNSa0I3SVR0NXdwSm1aaXBreVNWYXU0NktJamtCeGc1aUVlWE4",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:34 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889834.101974,VS0,VE77",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889834124.Z0FBQUFBQlpSX3dxOE0zVlh5dk44Y0VaSDZnelE4eE1mMVhPbjdLNlpnaDZOdUZDR2V0dE8yRlkzVGVaQmdjbXhhak84RGp5dUx1YjM4M25Qd2h6bVpLRkwwSzQ1bWZlUjNEd1J3Yk5DSS02dHNzeXF0Z2RaOUcxNUprbGlPajlscVI3d21BZmtvX0Y; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:34 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "539.0",
+          "x-ratelimit-reset": "566",
+          "x-ratelimit-used": "61",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:33",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW61&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889834124.Z0FBQUFBQlpSX3dxOE0zVlh5dk44Y0VaSDZnelE4eE1mMVhPbjdLNlpnaDZOdUZDR2V0dE8yRlkzVGVaQmdjbXhhak84RGp5dUx1YjM4M25Qd2h6bVpLRkwwSzQ1bWZlUjNEd1J3Yk5DSS02dHNzeXF0Z2RaOUcxNUprbGlPajlscVI3d21BZmtvX0Y",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:34 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889834.246730,VS0,VE68",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889834276.Z0FBQUFBQlpSX3dxZmxFSVlqWngtUzY2WDBxZHNqeTAyQlRxbzBOSGJDQ0dOSVN0bURYUFR3aGZrcVppaFJtUUhLVDMzUnd0ZmR2SmNTdXpVUk9RRTBZTnpRNk8wSUdaOE5SbnhGOVZKZTJGWFFMLXlnUXFaRktSX0x5ZDJMRXN3U3RZZHFLT2xvTFM; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:34 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "538.0",
+          "x-ratelimit-reset": "566",
+          "x-ratelimit-used": "62",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:33",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW62&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889834276.Z0FBQUFBQlpSX3dxZmxFSVlqWngtUzY2WDBxZHNqeTAyQlRxbzBOSGJDQ0dOSVN0bURYUFR3aGZrcVppaFJtUUhLVDMzUnd0ZmR2SmNTdXpVUk9RRTBZTnpRNk8wSUdaOE5SbnhGOVZKZTJGWFFMLXlnUXFaRktSX0x5ZDJMRXN3U3RZZHFLT2xvTFM",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:34 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889834.359275,VS0,VE74",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889834387.Z0FBQUFBQlpSX3dxbm9yNXY3LXhVTUhfQzU1ZVNVUzlUY3BPR21HeGVJb0g5R1FaVjAwOUNBN0k0S1RlSVk3ZnlTMGpqTW9PeFlsdDVzTHRBci00MkRNQUVWR2NyQmk2VzhOQXNVUnV1SGJIOC1BSEN1VW8zbUZWNWRwY0s3MGl1RXlQZm5hN2M5dW8; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:34 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "537.0",
+          "x-ratelimit-reset": "566",
+          "x-ratelimit-used": "63",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:34",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW63&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889834387.Z0FBQUFBQlpSX3dxbm9yNXY3LXhVTUhfQzU1ZVNVUzlUY3BPR21HeGVJb0g5R1FaVjAwOUNBN0k0S1RlSVk3ZnlTMGpqTW9PeFlsdDVzTHRBci00MkRNQUVWR2NyQmk2VzhOQXNVUnV1SGJIOC1BSEN1VW8zbUZWNWRwY0s3MGl1RXlQZm5hN2M5dW8",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:34 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889834.475990,VS0,VE70",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889834516.Z0FBQUFBQlpSX3dxcl9nY3YyOXMzTHN1SzVPSnNDTHhkMHRSMlJMejF0QWhacERuUFpYUnhlYjN1R3VpV0lsT2pwV2V0Z1RxRG9WZEVTdjFLQ2ZkR0dGQjJHRFV2RDB3aGk4SXlrZjdwNGloWFNWRGs1Yl83MG9TanFNZTBMVDE2WDZZUzdxMzczM1o; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:34 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "536.0",
+          "x-ratelimit-reset": "566",
+          "x-ratelimit-used": "64",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:34",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW64&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889834516.Z0FBQUFBQlpSX3dxcl9nY3YyOXMzTHN1SzVPSnNDTHhkMHRSMlJMejF0QWhacERuUFpYUnhlYjN1R3VpV0lsT2pwV2V0Z1RxRG9WZEVTdjFLQ2ZkR0dGQjJHRFV2RDB3aGk4SXlrZjdwNGloWFNWRGs1Yl83MG9TanFNZTBMVDE2WDZZUzdxMzczM1o",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:34 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889835.596417,VS0,VE68",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889834616.Z0FBQUFBQlpSX3dxc3BPX19VQnE4cURSN3ZFOFVXVmpSelVpWEdiYW5jRVRGOGpiUTVwZDJ2UEpGeTFUZGFKQW1VNDNZUUc1d0c0NEJTYUxuMVdaRloxdTN1MTR1SXNoWUhrWmxnVmllTUFQM29ZQzNqN3lraWpNaGNIdElUZjU2ZHRhbmNKcVo0c2U; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:34 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "535.0",
+          "x-ratelimit-reset": "566",
+          "x-ratelimit-used": "65",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:34",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW65&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889834616.Z0FBQUFBQlpSX3dxc3BPX19VQnE4cURSN3ZFOFVXVmpSelVpWEdiYW5jRVRGOGpiUTVwZDJ2UEpGeTFUZGFKQW1VNDNZUUc1d0c0NEJTYUxuMVdaRloxdTN1MTR1SXNoWUhrWmxnVmllTUFQM29ZQzNqN3lraWpNaGNIdElUZjU2ZHRhbmNKcVo0c2U",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:34 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889835.712356,VS0,VE143",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889834727.Z0FBQUFBQlpSX3dxRURWWHU0VG9Kdy00STdJVFVHcnFoYWhiNmI0RVFtV096aWdIaXdxWHBOZ2J2SWwxRVg1ZGhCZXNzblBpbjRFQTltRjdGNWVtckdxV0l2Y3Ria2ItaHVuT1Z2UVNjcDZ0aE1TUDJOQlhkRTBaNkY4Ul9kT3JRNFR5REMydFpyb3g; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:34 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "534.0",
+          "x-ratelimit-reset": "566",
+          "x-ratelimit-used": "66",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:34",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW66&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889834727.Z0FBQUFBQlpSX3dxRURWWHU0VG9Kdy00STdJVFVHcnFoYWhiNmI0RVFtV096aWdIaXdxWHBOZ2J2SWwxRVg1ZGhCZXNzblBpbjRFQTltRjdGNWVtckdxV0l2Y3Ria2ItaHVuT1Z2UVNjcDZ0aE1TUDJOQlhkRTBaNkY4Ul9kT3JRNFR5REMydFpyb3g",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:34 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889835.891466,VS0,VE66",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889834932.Z0FBQUFBQlpSX3dxQjJhYzN1RDdyOWE2RzBCNnBzS2RDdzEySUdkZkpiQzZSd3I3aGpyWjlyaUlMRDhncXdfZlNieTBmNDRUWU5UMi1QaVBaWG90TnY3WUx3OVlmSXBUTzMyRWpXdWpoV1NwenAwVXMzY1JRaU8yZG52LU5pUnczb2RmdHlZMXRLSWk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:34 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "533.0",
+          "x-ratelimit-reset": "566",
+          "x-ratelimit-used": "67",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:34",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW67&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889834932.Z0FBQUFBQlpSX3dxQjJhYzN1RDdyOWE2RzBCNnBzS2RDdzEySUdkZkpiQzZSd3I3aGpyWjlyaUlMRDhncXdfZlNieTBmNDRUWU5UMi1QaVBaWG90TnY3WUx3OVlmSXBUTzMyRWpXdWpoV1NwenAwVXMzY1JRaU8yZG52LU5pUnczb2RmdHlZMXRLSWk",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:35 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889835.998393,VS0,VE77",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889835017.Z0FBQUFBQlpSX3dyZ08teWxtSmw3TUt1NktJa3l6SzNHWFMyMUFlQnNOUjFpdXRXZHREMlN5V3M4M2c2NHU2Z003OXVCa2xMTjF6dTNuSWwwYnBUTUswamFfX0I4RGtlMFNpNGx3RTJWdEVtbE9yUWxtLXQtcXU0Um1MUFNGODNxd0drUHNCMTBwS3o; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:35 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "532.0",
+          "x-ratelimit-reset": "565",
+          "x-ratelimit-used": "68",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:35",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW68&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889835017.Z0FBQUFBQlpSX3dyZ08teWxtSmw3TUt1NktJa3l6SzNHWFMyMUFlQnNOUjFpdXRXZHREMlN5V3M4M2c2NHU2Z003OXVCa2xMTjF6dTNuSWwwYnBUTUswamFfX0I4RGtlMFNpNGx3RTJWdEVtbE9yUWxtLXQtcXU0Um1MUFNGODNxd0drUHNCMTBwS3o",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:35 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889835.122021,VS0,VE486",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889835189.Z0FBQUFBQlpSX3dyZG84emoyWXIyQl9rMTVqZnBxZ2dnb2xtaEhqWmc2SGlzS01nQ05hQThhRkd2WGRLNHFoRUtnLXdNX1BsYy1ONkdBRWdwcFFOMUNVU3lCZFdSSkVnTGpRQllYRDFoNV9HRVp1dEUwNTF3VG5TZXdsem9KTFRWSzgwZW1wOHRnR00; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:35 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "531.0",
+          "x-ratelimit-reset": "565",
+          "x-ratelimit-used": "69",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:35",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW69&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889835189.Z0FBQUFBQlpSX3dyZG84emoyWXIyQl9rMTVqZnBxZ2dnb2xtaEhqWmc2SGlzS01nQ05hQThhRkd2WGRLNHFoRUtnLXdNX1BsYy1ONkdBRWdwcFFOMUNVU3lCZFdSSkVnTGpRQllYRDFoNV9HRVp1dEUwNTF3VG5TZXdsem9KTFRWSzgwZW1wOHRnR00",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:35 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889836.654756,VS0,VE70",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889835664.Z0FBQUFBQlpSX3dyeVJWM2VfZ09LZVBaRDVDS0RnaGVjYlNvNDNkYlRhN3dtZmNIaDR3Wk93bHR1RE5saWtmcXp4MHpfemhKcEFLRzJ6RUFHcmdDR1B5TTZmb3VDb2lkeDcwT2MzZmhzT3NjM1A0aEVvcl90SjI0bDNaZHZBR1hMa1lGUGo3amZKWHE; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:35 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "530.0",
+          "x-ratelimit-reset": "565",
+          "x-ratelimit-used": "70",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:35",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW70&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889835664.Z0FBQUFBQlpSX3dyeVJWM2VfZ09LZVBaRDVDS0RnaGVjYlNvNDNkYlRhN3dtZmNIaDR3Wk93bHR1RE5saWtmcXp4MHpfemhKcEFLRzJ6RUFHcmdDR1B5TTZmb3VDb2lkeDcwT2MzZmhzT3NjM1A0aEVvcl90SjI0bDNaZHZBR1hMa1lGUGo3amZKWHE",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:35 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889836.775066,VS0,VE66",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889835800.Z0FBQUFBQlpSX3dyNHVabzg1TzJUWTVHNTk2SWY3QXlWZFVnaFEtUnd6bDhYZ2VydWV5cXNEbHF3UlE4UFBHdWF0MDluYVFBaUxvd3JFdkVyVzhZclN6c2dmNmVkTzJyaHZVMllxZHI4cUpVcUhRLXhPRzAyWjQybUpHa3hBU0ZhbFdVQmsyZlVKQVU; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:35 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "529.0",
+          "x-ratelimit-reset": "565",
+          "x-ratelimit-used": "71",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:35",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW71&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889835800.Z0FBQUFBQlpSX3dyNHVabzg1TzJUWTVHNTk2SWY3QXlWZFVnaFEtUnd6bDhYZ2VydWV5cXNEbHF3UlE4UFBHdWF0MDluYVFBaUxvd3JFdkVyVzhZclN6c2dmNmVkTzJyaHZVMllxZHI4cUpVcUhRLXhPRzAyWjQybUpHa3hBU0ZhbFdVQmsyZlVKQVU",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:35 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889836.886671,VS0,VE79",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889835904.Z0FBQUFBQlpSX3dyWGh0WVJ0ZDhZQ0tjRFExbUJjUkRqTHhTTXZJQmJ4R3BSMlBLbi1ZREVRZGt6Y3E3YTVVQ0Zsbm9BNHpLc2RhUzUyV3U5NmdqcEM3TEk5TGtSLUk3MTBFQUtpTjZpMC0yTlFyRHJGQS1GblRoVE9fWGExeDlMVXIyajJKMVUzV3M; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:35 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "528.0",
+          "x-ratelimit-reset": "565",
+          "x-ratelimit-used": "72",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:35",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW72&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889835904.Z0FBQUFBQlpSX3dyWGh0WVJ0ZDhZQ0tjRFExbUJjUkRqTHhTTXZJQmJ4R3BSMlBLbi1ZREVRZGt6Y3E3YTVVQ0Zsbm9BNHpLc2RhUzUyV3U5NmdqcEM3TEk5TGtSLUk3MTBFQUtpTjZpMC0yTlFyRHJGQS1GblRoVE9fWGExeDlMVXIyajJKMVUzV3M",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:36 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889836.009359,VS0,VE438",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889836063.Z0FBQUFBQlpSX3dzVUVnX2pSMHJwT0tRVTQ2aGh4cXRrc2Q3TVZlNlNxajhkYUJwM3AybzlBWkcwSkVFLXVsanZHZEdSMGNrQ1JvNGU1QXZXLU0wVzVYazg3RkJleFhlTGpFQ3Fjc2NPV1lHWk5keERaSl92MnhzY1Z1Q0J2YXBwQVJiRjYzY0tFSms; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:36 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "527.0",
+          "x-ratelimit-reset": "564",
+          "x-ratelimit-used": "73",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:36",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW73&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889836063.Z0FBQUFBQlpSX3dzVUVnX2pSMHJwT0tRVTQ2aGh4cXRrc2Q3TVZlNlNxajhkYUJwM3AybzlBWkcwSkVFLXVsanZHZEdSMGNrQ1JvNGU1QXZXLU0wVzVYazg3RkJleFhlTGpFQ3Fjc2NPV1lHWk5keERaSl92MnhzY1Z1Q0J2YXBwQVJiRjYzY0tFSms",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:36 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889836.490715,VS0,VE64",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889836503.Z0FBQUFBQlpSX3dzY1dQYUZnTEM1TlZUWnpTSnZvUXhmaGh2bDBkZEplb21BeFF3RnpXSkUyMVltZW1TWkpCTldvcDFNQ2d3MnhzQzdQWHRyM3ZCaklWcC1Pd2ZTQkwxWUxmclVuN3FNRjBIa1ZJN1lpVV9pYzlJMUZMQmxIbktnNmR4dFhSajFGR2I; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:36 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "526.0",
+          "x-ratelimit-reset": "564",
+          "x-ratelimit-used": "74",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:36",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW74&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889836503.Z0FBQUFBQlpSX3dzY1dQYUZnTEM1TlZUWnpTSnZvUXhmaGh2bDBkZEplb21BeFF3RnpXSkUyMVltZW1TWkpCTldvcDFNQ2d3MnhzQzdQWHRyM3ZCaklWcC1Pd2ZTQkwxWUxmclVuN3FNRjBIa1ZJN1lpVV9pYzlJMUZMQmxIbktnNmR4dFhSajFGR2I",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:36 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889837.601916,VS0,VE67",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889836619.Z0FBQUFBQlpSX3dzVlhSLVEtRTBUaE5HY3BRZ1pJeHVYVWNJTnJGR1ZUcU1LNXdKM0tmNWNZVGE2UjgyQmlVY1JqRTdyZ1piaF8xcENpUkNESGRXWW10YXlVTHYteHdudVdmWkU4X2p5S0JUUm02YnhONjNZLTNWdk1nOUw2QWw0ekdkajh4Z3ozMFU; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:36 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "525.0",
+          "x-ratelimit-reset": "564",
+          "x-ratelimit-used": "75",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:36",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW75&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889836619.Z0FBQUFBQlpSX3dzVlhSLVEtRTBUaE5HY3BRZ1pJeHVYVWNJTnJGR1ZUcU1LNXdKM0tmNWNZVGE2UjgyQmlVY1JqRTdyZ1piaF8xcENpUkNESGRXWW10YXlVTHYteHdudVdmWkU4X2p5S0JUUm02YnhONjNZLTNWdk1nOUw2QWw0ekdkajh4Z3ozMFU",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:36 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889837.716465,VS0,VE66",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889836729.Z0FBQUFBQlpSX3dzc3J6dlprclRLcTA5UXpFV0pXSW5wZ0VlTjhRVTFIX01EcEx0Sm9WVWM5NmlVSnJ2b25SNWluaTNiTk1WdHVSZEwyc2tJVEItREhXU3lselV1RjdhMllGSUFvMXNKZDBRUHcweks5emhBdTA4R051RTk4eW5GT0RlMnMySFBYOUs; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:36 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "524.0",
+          "x-ratelimit-reset": "564",
+          "x-ratelimit-used": "76",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:36",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW76&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889836729.Z0FBQUFBQlpSX3dzc3J6dlprclRLcTA5UXpFV0pXSW5wZ0VlTjhRVTFIX01EcEx0Sm9WVWM5NmlVSnJ2b25SNWluaTNiTk1WdHVSZEwyc2tJVEItREhXU3lselV1RjdhMllGSUFvMXNKZDBRUHcweks5emhBdTA4R051RTk4eW5GT0RlMnMySFBYOUs",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:36 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889837.824614,VS0,VE72",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889836842.Z0FBQUFBQlpSX3dzWkh4Uzg0V0dMOHF2aUFTZWNvOE12TjFpRFB6bjFPNTZJNnZBZldzeVFIaC1rQ0p2UW56ZjVFUjJBQ2FjNW1LYmc3T0g5dzhuX0h5M1JhT19xWkx0MzhXSHpsVFpObDEtbjlySWswODZydy1OeVVlelU5SGxlWllyZHlWTzYyZG4; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:36 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "523.0",
+          "x-ratelimit-reset": "564",
+          "x-ratelimit-used": "77",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:36",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW77&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889836842.Z0FBQUFBQlpSX3dzWkh4Uzg0V0dMOHF2aUFTZWNvOE12TjFpRFB6bjFPNTZJNnZBZldzeVFIaC1rQ0p2UW56ZjVFUjJBQ2FjNW1LYmc3T0g5dzhuX0h5M1JhT19xWkx0MzhXSHpsVFpObDEtbjlySWswODZydy1OeVVlelU5SGxlWllyZHlWTzYyZG4",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:37 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889837.944104,VS0,VE76",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889836961.Z0FBQUFBQlpSX3d0dzNfRjRidVI1SXBicy1xbmJhMmtid292TS1pcUpWS0Q0XzQwMkpCaGk3Z3VfTExpQzlUaFI2MEdHNUQ5TDQtZ2NYWmc3bEc0ZzZkNEhXMUVXOVR6bjBHTU9BM1AtQTRlVHRTb2hhSElFek5rTmxfLXN2UEtvQnRYUDRaLTVDdzc; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:37 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "522.0",
+          "x-ratelimit-reset": "564",
+          "x-ratelimit-used": "78",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:36",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW78&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889836961.Z0FBQUFBQlpSX3d0dzNfRjRidVI1SXBicy1xbmJhMmtid292TS1pcUpWS0Q0XzQwMkpCaGk3Z3VfTExpQzlUaFI2MEdHNUQ5TDQtZ2NYWmc3bEc0ZzZkNEhXMUVXOVR6bjBHTU9BM1AtQTRlVHRTb2hhSElFek5rTmxfLXN2UEtvQnRYUDRaLTVDdzc",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:37 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889837.068257,VS0,VE77",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889837097.Z0FBQUFBQlpSX3d0a244UnlLaGxPc0lRT2Rtdng3a0tkNkhvVmE2SGRzRkE3Z3RKaDZlNVBwbzh3QXJlYkQxUk1DR1FkTEZ2alRXNWExNzkyMzdaalRkbUdTUnFtMVM1Sjgwek9QOUFJSVpyTnlKRGx0LWdrNFJHZ2s3aXBlRWpjVEpoRkQ4UHdKTjg; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:37 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "521.0",
+          "x-ratelimit-reset": "563",
+          "x-ratelimit-used": "79",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:36",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW79&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889837097.Z0FBQUFBQlpSX3d0a244UnlLaGxPc0lRT2Rtdng3a0tkNkhvVmE2SGRzRkE3Z3RKaDZlNVBwbzh3QXJlYkQxUk1DR1FkTEZ2alRXNWExNzkyMzdaalRkbUdTUnFtMVM1Sjgwek9QOUFJSVpyTnlKRGx0LWdrNFJHZ2s3aXBlRWpjVEpoRkQ4UHdKTjg",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:37 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889837.196092,VS0,VE69",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889837216.Z0FBQUFBQlpSX3d0Y2w4QjFaNy11RmdzcEVXdWlfZGc0bkZmNmdHZjdzWXhoODAtX25GaGxtQlV3VU4wSHZ1Tl8wRlRyS2lRMDRuUEdtUnptNXB4azhiY1VMZWpKN1A3RW9RS2U3YWx4enZrRjBZQmdON09RX0h6ZFZxVWFNdXlJVGZYdXZuZXJVbFM; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:37 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "520.0",
+          "x-ratelimit-reset": "563",
+          "x-ratelimit-used": "80",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:36",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW80&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889837216.Z0FBQUFBQlpSX3d0Y2w4QjFaNy11RmdzcEVXdWlfZGc0bkZmNmdHZjdzWXhoODAtX25GaGxtQlV3VU4wSHZ1Tl8wRlRyS2lRMDRuUEdtUnptNXB4azhiY1VMZWpKN1A3RW9RS2U3YWx4enZrRjBZQmdON09RX0h6ZFZxVWFNdXlJVGZYdXZuZXJVbFM",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:37 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889837.312145,VS0,VE67",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889837329.Z0FBQUFBQlpSX3d0UmlqRWhRRktKQ29BSlpxcEdkcTJOVTFQT0R3QjlGZ2dOOUZJRnA5aUdSWHU1WUtmQWJmTzY1aXYyMFVQeUQ2X1B1NEtUcnlKWTk3WVRVOE5jMURyenUxX1Vva1RmbC1tMXpJT1h6SkM4T2gzR184Q250MHlQOGZEX0J6Q3psMmU; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:37 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "519.0",
+          "x-ratelimit-reset": "563",
+          "x-ratelimit-used": "81",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:36",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW81&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889837329.Z0FBQUFBQlpSX3d0UmlqRWhRRktKQ29BSlpxcEdkcTJOVTFQT0R3QjlGZ2dOOUZJRnA5aUdSWHU1WUtmQWJmTzY1aXYyMFVQeUQ2X1B1NEtUcnlKWTk3WVRVOE5jMURyenUxX1Vva1RmbC1tMXpJT1h6SkM4T2gzR184Q250MHlQOGZEX0J6Q3psMmU",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:37 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889837.425146,VS0,VE84",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889837456.Z0FBQUFBQlpSX3d0NHRZVFhCNWFzUWZLZEFrTnVOOTlBVVcwT2t2Zl96X3VhclJXeEpjNy1MT2ZPMlctbTkxNzEwMTB0Y29qQV9TNklqZzBUY0ItMXpxNGgxanBsTFFZYndySHJPUXY0cWJSaVJObXBXTlUtei0xdmtWQ3VwSXZNUlBKZVdTUnRZSWk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:37 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "518.0",
+          "x-ratelimit-reset": "563",
+          "x-ratelimit-used": "82",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:37",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW82&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889837456.Z0FBQUFBQlpSX3d0NHRZVFhCNWFzUWZLZEFrTnVOOTlBVVcwT2t2Zl96X3VhclJXeEpjNy1MT2ZPMlctbTkxNzEwMTB0Y29qQV9TNklqZzBUY0ItMXpxNGgxanBsTFFZYndySHJPUXY0cWJSaVJObXBXTlUtei0xdmtWQ3VwSXZNUlBKZVdTUnRZSWk",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:37 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889838.565142,VS0,VE107",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889837584.Z0FBQUFBQlpSX3d0b0VUTVZadG53SnIwaVB5RWZvSGs5elJLRnhhZHBZSHJaNW02TVNBRDBvSzg3MXVNV1JIV3FmQXo0R0UyTHZ1Tk9hUzk3bC04OHF1dWg4R0Z3RlNEQXZVR0NfQU9qbUFlU0NfUUdhYVVrN0JtTV9RZ0t5RDdLVC1mSTRLeGYxeDg; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:37 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "517.0",
+          "x-ratelimit-reset": "563",
+          "x-ratelimit-used": "83",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:37",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW83&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889837584.Z0FBQUFBQlpSX3d0b0VUTVZadG53SnIwaVB5RWZvSGs5elJLRnhhZHBZSHJaNW02TVNBRDBvSzg3MXVNV1JIV3FmQXo0R0UyTHZ1Tk9hUzk3bC04OHF1dWg4R0Z3RlNEQXZVR0NfQU9qbUFlU0NfUUdhYVVrN0JtTV9RZ0t5RDdLVC1mSTRLeGYxeDg",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:37 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889838.731148,VS0,VE67",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889837746.Z0FBQUFBQlpSX3d0eUxSTGZLQk1MbmJaX1ZHUWNLVHprQ0ZZTkktbVRHajUySXVycmJrdjZRbXRKbDdwdlQzbGhOZVpKUTkxUGFtNEx4d3lXQ21Ub1pqNlYzLTNFLUdqMlJ3S3lGQkNDYWJUMHRGUTRGbEdZWDE2RTRSemtlTG1SeWctX0lKc3l6RDM; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:37 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "516.0",
+          "x-ratelimit-reset": "563",
+          "x-ratelimit-used": "84",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:37",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW84&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889837746.Z0FBQUFBQlpSX3d0eUxSTGZLQk1MbmJaX1ZHUWNLVHprQ0ZZTkktbVRHajUySXVycmJrdjZRbXRKbDdwdlQzbGhOZVpKUTkxUGFtNEx4d3lXQ21Ub1pqNlYzLTNFLUdqMlJ3S3lGQkNDYWJUMHRGUTRGbEdZWDE2RTRSemtlTG1SeWctX0lKc3l6RDM",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:37 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889838.841647,VS0,VE76",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889837872.Z0FBQUFBQlpSX3d0VEQ1Zy0wWWFWZldwWE1iX1pSUVRxNzFwWWVyWlViV2ZHYVV5QlR2NkNrTmRnSmZnMzlkVl9SeWtKWlY0OUdlZW5TUUpyUHdYeV9XNGhBMlRjb1JpU05jU1lfNDV4eUc1dkx1Vk1ta1BXYUdlUTdDbUlIQi0zZHlOWl96UHVKMS0; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:37 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "515.0",
+          "x-ratelimit-reset": "563",
+          "x-ratelimit-used": "85",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:37",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW85&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889837872.Z0FBQUFBQlpSX3d0VEQ1Zy0wWWFWZldwWE1iX1pSUVRxNzFwWWVyWlViV2ZHYVV5QlR2NkNrTmRnSmZnMzlkVl9SeWtKWlY0OUdlZW5TUUpyUHdYeV9XNGhBMlRjb1JpU05jU1lfNDV4eUc1dkx1Vk1ta1BXYUdlUTdDbUlIQi0zZHlOWl96UHVKMS0",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:38 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889838.963831,VS0,VE63",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889837979.Z0FBQUFBQlpSX3d1eXNaWDZZNEJvY3ZINkJ6QU1hazFoQzNPQUJLa1EtT0FDdURIRUlSNjUyVlVyWTJjMkhmNXVKZWZvaDJLaGdBRkNBR3R5Z3ctbUp2ZE9UOHdwTldWbC0weE81ZmRNc09iamx2SUFJcjV2eVY0RlEzdC0yNUJ5dU5tRmVDNVk3Z3c; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:38 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "514.0",
+          "x-ratelimit-reset": "563",
+          "x-ratelimit-used": "86",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:37",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW86&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889837979.Z0FBQUFBQlpSX3d1eXNaWDZZNEJvY3ZINkJ6QU1hazFoQzNPQUJLa1EtT0FDdURIRUlSNjUyVlVyWTJjMkhmNXVKZWZvaDJLaGdBRkNBR3R5Z3ctbUp2ZE9UOHdwTldWbC0weE81ZmRNc09iamx2SUFJcjV2eVY0RlEzdC0yNUJ5dU5tRmVDNVk3Z3c",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:38 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889838.069730,VS0,VE62",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889838226.Z0FBQUFBQlpSX3d1S1Z5UnMwWkdkSnMzbXJYT05acjJJSXNGTkhXYmlTazZkRHZBalhndG1fVlZtYzFuaWc4Y01KR3lHdW8yck80V0JmRTRaaXBZcDJSMl9SZG1oTm9MRHF2eHRiNk1TcWE1aEItTDgxcUExSG1rckFUYXF0X2lKcHNoMHVVQ0Z1Si0; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:38 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "513.0",
+          "x-ratelimit-reset": "562",
+          "x-ratelimit-used": "87",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:37",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW87&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889838226.Z0FBQUFBQlpSX3d1S1Z5UnMwWkdkSnMzbXJYT05acjJJSXNGTkhXYmlTazZkRHZBalhndG1fVlZtYzFuaWc4Y01KR3lHdW8yck80V0JmRTRaaXBZcDJSMl9SZG1oTm9MRHF2eHRiNk1TcWE1aEItTDgxcUExSG1rckFUYXF0X2lKcHNoMHVVQ0Z1Si0",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:38 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889838.178259,VS0,VE70",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889838193.Z0FBQUFBQlpSX3d1ZHZjMUZKazlyTzlPc1E5OWdPWVlSMkgzZndDc3huazh2OWk1anloTEZGSWxXWUJ4QkktS1VtbHIzR05RMlU1WmVDTlh0ZWlnT05GNWJwenR5N2Y4SWh3U1A5ZnZLSW03ZGc4QlpzYXFzVWhMTWc0NDZEbnY4b1U2S1lDYXRMSHA; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:38 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "512.0",
+          "x-ratelimit-reset": "562",
+          "x-ratelimit-used": "88",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:37",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW88&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889838193.Z0FBQUFBQlpSX3d1ZHZjMUZKazlyTzlPc1E5OWdPWVlSMkgzZndDc3huazh2OWk1anloTEZGSWxXWUJ4QkktS1VtbHIzR05RMlU1WmVDTlh0ZWlnT05GNWJwenR5N2Y4SWh3U1A5ZnZLSW03ZGc4QlpzYXFzVWhMTWc0NDZEbnY4b1U2S1lDYXRMSHA",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:38 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889838.292963,VS0,VE66",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889838308.Z0FBQUFBQlpSX3d1WHRTNUlWWWtnbEFkZGxpZ1VUTlZzUDFmSkY0d0dSY3FVaU1FMkxEVzdaaU1KbFhxUU42SU9fV0tjVUJuTzFpM3U4dGR1R3dfaVdROGRvM19ycGw0aXd1OEdVd1dYNHpTcm41aUNja0hZNWtuWG01QnVQd2dnRy1iejAtdUxuUFI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:38 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "511.0",
+          "x-ratelimit-reset": "562",
+          "x-ratelimit-used": "89",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:37",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW89&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889838308.Z0FBQUFBQlpSX3d1WHRTNUlWWWtnbEFkZGxpZ1VUTlZzUDFmSkY0d0dSY3FVaU1FMkxEVzdaaU1KbFhxUU42SU9fV0tjVUJuTzFpM3U4dGR1R3dfaVdROGRvM19ycGw0aXd1OEdVd1dYNHpTcm41aUNja0hZNWtuWG01QnVQd2dnRy1iejAtdUxuUFI",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:38 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889838.417411,VS0,VE64",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889838436.Z0FBQUFBQlpSX3d1NVk3WG84b3VSQ3VnOVppQjFZSTEyNDhpeTB0d09rX25ZQWg3ZlJ2dTliaW53eTRDdEtXYktRbGJXMnV6Q0ZuY0FaLVNadkFfYUJ2dTZab0MxMERnZlAzZ2toQk1ObEszejBnOC1zaFhZS2VhWmdHdnJxQnNzQ3Fxekt0Q2tnUW0; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:38 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "510.0",
+          "x-ratelimit-reset": "562",
+          "x-ratelimit-used": "90",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:38",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW90&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889838436.Z0FBQUFBQlpSX3d1NVk3WG84b3VSQ3VnOVppQjFZSTEyNDhpeTB0d09rX25ZQWg3ZlJ2dTliaW53eTRDdEtXYktRbGJXMnV6Q0ZuY0FaLVNadkFfYUJ2dTZab0MxMERnZlAzZ2toQk1ObEszejBnOC1zaFhZS2VhWmdHdnJxQnNzQ3Fxekt0Q2tnUW0",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:38 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889839.525010,VS0,VE97",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889838545.Z0FBQUFBQlpSX3d1NEFJbmh0VWZ1VnV1QjA0Tmc0RHlxZ1FNQ1dnQXQ2OEYwN2E5c19XeUU3TDNUVmQwVEJhcFUxd2o3VGJpTHlGVGRZdVFhZzdDZkpWcFFrUDl6dTJzWFpzY2t2U2VoVmVmaUhsU2dnbUlReEk1RFp6eDg3RHFqV1NNV0NwbzVZcm0; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:38 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "509.0",
+          "x-ratelimit-reset": "562",
+          "x-ratelimit-used": "91",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:38",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW91&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889838545.Z0FBQUFBQlpSX3d1NEFJbmh0VWZ1VnV1QjA0Tmc0RHlxZ1FNQ1dnQXQ2OEYwN2E5c19XeUU3TDNUVmQwVEJhcFUxd2o3VGJpTHlGVGRZdVFhZzdDZkpWcFFrUDl6dTJzWFpzY2t2U2VoVmVmaUhsU2dnbUlReEk1RFp6eDg3RHFqV1NNV0NwbzVZcm0",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:38 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889839.664592,VS0,VE135",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889838683.Z0FBQUFBQlpSX3d1bS1VWnBzT1FjdWlBUFRZWU5NUzFIWkhqWmJpQkFQbXVESEpHU2dBWk1CVEh2d3ZzSGZuQVNtSy1wRWhKQ2xxX21sUEJ1SjYxWDZKcF9ZSk9pNVJHai1YNGZqd3Ezc2dxRVY5RktXdnZzT1JzaVlHemk0UE1JQndXWXJvZS0wWmU; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:38 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "508.0",
+          "x-ratelimit-reset": "562",
+          "x-ratelimit-used": "92",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:38",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW92&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889838683.Z0FBQUFBQlpSX3d1bS1VWnBzT1FjdWlBUFRZWU5NUzFIWkhqWmJpQkFQbXVESEpHU2dBWk1CVEh2d3ZzSGZuQVNtSy1wRWhKQ2xxX21sUEJ1SjYxWDZKcF9ZSk9pNVJHai1YNGZqd3Ezc2dxRVY5RktXdnZzT1JzaVlHemk0UE1JQndXWXJvZS0wWmU",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:38 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889839.846534,VS0,VE69",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889838863.Z0FBQUFBQlpSX3d1bnIyZTFKMFRrblA0bHQxaS0zTzNRdHdrMjh5TmdwRzNidTB3NkRydkpCa0lHNm9CUEU3SWgycGJWMUFJMjk2ZG5rcEFTRFgxQmFkak1CZUFxdVZSbXJvWFBPOUFVU2ZueWdDcHpnNVJkbE9NZERRRmZUOVZVcmotMTNRLXV2dWI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:38 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "507.0",
+          "x-ratelimit-reset": "562",
+          "x-ratelimit-used": "93",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:38",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW93&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889838863.Z0FBQUFBQlpSX3d1bnIyZTFKMFRrblA0bHQxaS0zTzNRdHdrMjh5TmdwRzNidTB3NkRydkpCa0lHNm9CUEU3SWgycGJWMUFJMjk2ZG5rcEFTRFgxQmFkak1CZUFxdVZSbXJvWFBPOUFVU2ZueWdDcHpnNVJkbE9NZERRRmZUOVZVcmotMTNRLXV2dWI",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:39 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889839.957990,VS0,VE71",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889838973.Z0FBQUFBQlpSX3d2TGxkOHpXRTl3dWRfb004ekExZS1fRHZkZ3FkaVNGNHVheElScDdfQ2ZNZEFBUW01NXFGSmQ0TUZpS0lORWIxdjlIb21rcnQ1Wk9nN3BPYzdDbzdYeXpaM2VlbDRRUFpMNm5BWU1iR2plZ3ZWRkU0SUg1VW9SdjBYX0dEbFBCREY; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:39 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "506.0",
+          "x-ratelimit-reset": "562",
+          "x-ratelimit-used": "94",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:38",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW94&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889838973.Z0FBQUFBQlpSX3d2TGxkOHpXRTl3dWRfb004ekExZS1fRHZkZ3FkaVNGNHVheElScDdfQ2ZNZEFBUW01NXFGSmQ0TUZpS0lORWIxdjlIb21rcnQ1Wk9nN3BPYzdDbzdYeXpaM2VlbDRRUFpMNm5BWU1iR2plZ3ZWRkU0SUg1VW9SdjBYX0dEbFBCREY",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:39 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889839.138654,VS0,VE70",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889839296.Z0FBQUFBQlpSX3d2YXlnWklzdmJqNU8zTE54ZDBMSEJ4eFNacGhydDQwUXhQOUZxczBBcTFOd2dHdUpKbWgzdDBGM05qcVBYRnBod3d4OXlqWTFzTnlmTzV1ZklDcE1LZ1M4LWl6UG9Fc1FBOTR0aW9SbnV0QXdaVl9FNk5oTEhYb1VSZTVUNGQ0OUQ; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:39 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "505.0",
+          "x-ratelimit-reset": "561",
+          "x-ratelimit-used": "95",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:38",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW95&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889839296.Z0FBQUFBQlpSX3d2YXlnWklzdmJqNU8zTE54ZDBMSEJ4eFNacGhydDQwUXhQOUZxczBBcTFOd2dHdUpKbWgzdDBGM05qcVBYRnBod3d4OXlqWTFzTnlmTzV1ZklDcE1LZ1M4LWl6UG9Fc1FBOTR0aW9SbnV0QXdaVl9FNk5oTEhYb1VSZTVUNGQ0OUQ",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:39 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889839.246846,VS0,VE81",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889839264.Z0FBQUFBQlpSX3d2QUZDdGdHTk9uYWJVSlMwVkdJODROM2ozRVMyOXJneXd4N1BKRVZGbUotSG5PaGVFRjJVVTFPazRmSEliSmIyVi1KWnRmcVk1NnBMMWotMzEwSGk3d2I0X0F6d0tZT0p3RC1SWTZIdzk5LUdQRUhyMXgxZ001MHVaZndGYjhhd1k; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:39 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "504.0",
+          "x-ratelimit-reset": "561",
+          "x-ratelimit-used": "96",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:38",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW96&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889839264.Z0FBQUFBQlpSX3d2QUZDdGdHTk9uYWJVSlMwVkdJODROM2ozRVMyOXJneXd4N1BKRVZGbUotSG5PaGVFRjJVVTFPazRmSEliSmIyVi1KWnRmcVk1NnBMMWotMzEwSGk3d2I0X0F6d0tZT0p3RC1SWTZIdzk5LUdQRUhyMXgxZ001MHVaZndGYjhhd1k",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:39 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889839.371961,VS0,VE77",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889839438.Z0FBQUFBQlpSX3d2N2Ffa0w4TENfYkV0NkJ5M2dKeDNNSm16eTNVbU5DcWo0QnktelBTWGZrTEtaaTQwd3JVeGM5ckp3ZWUxYXZKTzhfRVFJeWFhNDF6UFcyLV9hU0tzNVk0ODNwQS1RXzR4TVBKQjNSWERyMWxMNzdBeUI0cmttRV9KaHk2WkxVVFY; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:39 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "503.0",
+          "x-ratelimit-reset": "561",
+          "x-ratelimit-used": "97",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:39",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW97&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889839438.Z0FBQUFBQlpSX3d2N2Ffa0w4TENfYkV0NkJ5M2dKeDNNSm16eTNVbU5DcWo0QnktelBTWGZrTEtaaTQwd3JVeGM5ckp3ZWUxYXZKTzhfRVFJeWFhNDF6UFcyLV9hU0tzNVk0ODNwQS1RXzR4TVBKQjNSWERyMWxMNzdBeUI0cmttRV9KaHk2WkxVVFY",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:39 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889839.498828,VS0,VE76",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889839518.Z0FBQUFBQlpSX3d2YmJxTWFsOVI2N0dJbGZHX1d3cXBRNnBjbk53U2NhSFhlTlEtT3JrcDZTRDNxZTVUQVRnbUs3TWVEdkUtd0NfaEU4d3oxVG82Vl9LUmxMN0ZtNW8yNTZndU11YlpZWm10T1otdXhxY24xUTZHQ1JERTBORjhuYTJjUkxac0dSQTU; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:39 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "502.0",
+          "x-ratelimit-reset": "561",
+          "x-ratelimit-used": "98",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:39",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW98&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889839518.Z0FBQUFBQlpSX3d2YmJxTWFsOVI2N0dJbGZHX1d3cXBRNnBjbk53U2NhSFhlTlEtT3JrcDZTRDNxZTVUQVRnbUs3TWVEdkUtd0NfaEU4d3oxVG82Vl9LUmxMN0ZtNW8yNTZndU11YlpZWm10T1otdXhxY24xUTZHQ1JERTBORjhuYTJjUkxac0dSQTU",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:39 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889840.631691,VS0,VE76",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889839648.Z0FBQUFBQlpSX3d2M3pZTnV3UzNOTHNmekVpSU1KMUFrNElQandGTTVWR0xqV0JZd3hna2gyU2dzaTZQSFFqOHRnQ1VTQnptaEVUcEp0TTBqOGVXTW1Yc09XZV9fS0t2MVdzV0QyekRlUnQ4d1pybVZyWkFDa2R1WmxzelUycDRreUxzSXlna3UzYkQ; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:39 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "501.0",
+          "x-ratelimit-reset": "561",
+          "x-ratelimit-used": "99",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:39",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW99&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "78",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889839648.Z0FBQUFBQlpSX3d2M3pZTnV3UzNOTHNmekVpSU1KMUFrNElQandGTTVWR0xqV0JZd3hna2gyU2dzaTZQSFFqOHRnQ1VTQnptaEVUcEp0TTBqOGVXTW1Yc09XZV9fS0t2MVdzV0QyekRlUnQ4d1pybVZyWkFDa2R1WmxzelUycDRreUxzSXlna3UzYkQ",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:39 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889840.772913,VS0,VE67",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889839788.Z0FBQUFBQlpSX3d2aWQ2Z1hna3JxWnJScUZTeDVNOGhiRFR0QVBlUUt1UVdsNWhGYVJHdHdESlRpeDVkQmFuNWNxbEs2X3hjN0N6OFNuS1JyLXFvME8yV2MwYWg1MUlYeVBORkhxREpjMkRJd1VBRVdsT3hNRjFBa0RENG5JbzRwWWhUbzlmb0lZUFc; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:39 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "500.0",
+          "x-ratelimit-reset": "561",
+          "x-ratelimit-used": "100",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:30:39",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&css_class=&flair_type=LINK_FLAIR&text=PRAW100&text_editable=False"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "79",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=WXOYjbssbnunf6g7sn; loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3dmNDVYZGhNTDdUYVd3cTRXV0dmRVYwdWNrYWt5WFZHRW9fUjBXWm9ld1kyUDlOcGNTUkw0Rl92b0VWV3Y0RGJlYWt3b1dnbDZkNTBnM2tuS0ZuUGdUNmxsay1Nc1pnWjJfTFZFeHBIdFlMT1dnY2ZSZFJHc3hTTDJ3SlBMYTFaQUk; session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889839788.Z0FBQUFBQlpSX3d2aWQ2Z1hna3JxWnJScUZTeDVNOGhiRFR0QVBlUUt1UVdsNWhGYVJHdHdESlRpeDVkQmFuNWNxbEs2X3hjN0N6OFNuS1JyLXFvME8yV2MwYWg1MUlYeVBORkhxREpjMkRJd1VBRVdsT3hNRjFBa0RENG5JbzRwWWhUbzlmb0lZUFc",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:30:40 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1721-ORD",
+          "X-Timer": "S1497889840.884196,VS0,VE125",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=jYEJnHPdznGPY0Nq2O.0.1497889839919.Z0FBQUFBQlpSX3d3XzlCN1UxWGoyLUhpVHAwcjZubkJjTE44MEg2SE5teWJUTkM3THp0enZzcXllZ1J0NnRhM0k5YXY0ZkZCSlg5dk5KZGdZQkV5UTVQY0czRnBjVmROeDQ1ekNhQWwyWGlBenl2ZlN5dnhwanpYcWR1SmZfNXNRQWx3ZDhBamxTd3I; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:30:40 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "499.0",
+          "x-ratelimit-reset": "561",
+          "x-ratelimit-used": "101",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairtemplate/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/tests/integration/cassettes/TestSubredditLinkFlairTemplates.test_clear.json
+++ b/tests/integration/cassettes/TestSubredditLinkFlairTemplates.test_clear.json
@@ -1,0 +1,113 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-06-19T16:32:54",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "57",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:32:54 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1730-ORD",
+          "X-Timer": "S1497889974.338302,VS0,VE320",
+          "cache-control": "max-age=0, must-revalidate",
+          "set-cookie": "session_tracker=2DgHJkIDuimJIx3xmB.0.1497889974352.Z0FBQUFBQlpSX3kySmRoNUQ2MVI4bXRHYVpONmE3aXZ2aFFJeWgybzJzMFV5WWstNnh3Z2tpX29EVGlGeXVHMUE5Tkx3anhkMEZNRUU1S1A3SWdiSEdhMnc5a01aSGFHcEdINjhyNmFWRWpBWHBlUnBncC13c2p0S3p0YWtnM0VYQ3ZhRVgzeFZubTg; Domain=reddit.com; Max-Age=7199; Path=/; expires=Mon, 19-Jun-2017 18:32:54 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2017-06-19T16:32:54",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&flair_type=LINK_FLAIR"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "35",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=oJ5vunWCV1R8WqKdz3; session_tracker=2DgHJkIDuimJIx3xmB.0.1497889974352.Z0FBQUFBQlpSX3kySmRoNUQ2MVI4bXRHYVpONmE3aXZ2aFFJeWgybzJzMFV5WWstNnh3Z2tpX29EVGlGeXVHMUE5Tkx3anhkMEZNRUU1S1A3SWdiSEdhMnc5a01aSGFHcEdINjhyNmFWRWpBWHBlUnBncC13c2p0S3p0YWtnM0VYQ3ZhRVgzeFZubTg",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.0.dev0 prawcore/0.10.1"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/clearflairtemplates/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": []}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "24",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Mon, 19 Jun 2017 16:32:54 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-ord1742-ORD",
+          "X-Timer": "S1497889975.914112,VS0,VE65",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "loid=0000000000000xw27h.2.1463097178233.Z0FBQUFBQlpSX3kyM0NGT2V4QmhLYkl3cmx6eGVES3dDVTFCMFVaZVF3Ni1DaHl3OElSbElxLWo1TEU1Z2RFaVBaQUdMNmVUaGpqNU03R2NLVFFZbkNSY1F6T2FYSzhmTlJaNDE4cHFoX1R2MUJ2ZHZJZl9PM2JWWVJES19DWHA2WmRXZGNSd043THU; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Wed, 19-Jun-2019 16:32:54 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "498.0",
+          "x-ratelimit-reset": "426",
+          "x-ratelimit-used": "102",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/clearflairtemplates/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/tests/integration/models/reddit/test_subreddit.py
+++ b/tests/integration/models/reddit/test_subreddit.py
@@ -411,6 +411,33 @@ class TestSubredditFlairTemplates(IntegrationTest):
                 template['flair_template_id'], 'PRAW updated')
 
 
+class TestSubredditLinkFlairTemplates(IntegrationTest):
+    @property
+    def subreddit(self):
+        return self.reddit.subreddit(pytest.placeholders.test_subreddit)
+
+    def test__iter(self):
+        self.reddit.read_only = False
+        with self.recorder.use_cassette(
+                'TestSubredditLinkFlairTemplates.test__iter'):
+            templates = list(self.subreddit.flair.link_templates)
+        assert len(templates) == 1
+
+    @mock.patch('time.sleep', return_value=None)
+    def test_add(self, _):
+        self.reddit.read_only = False
+        with self.recorder.use_cassette(
+                'TestSubredditLinkFlairTemplates.test_add'):
+            for i in range(101):
+                self.subreddit.flair.link_templates.add('PRAW{}'.format(i))
+
+    def test_clear(self):
+        self.reddit.read_only = False
+        with self.recorder.use_cassette(
+                'TestSubredditLinkFlairTemplates.test_clear'):
+            self.subreddit.flair.link_templates.clear()
+
+
 class TestSubredditListings(IntegrationTest):
     def test_comments(self):
         with self.recorder.use_cassette(


### PR DESCRIPTION
Fixes #812.

I tried a couple different approaches to getting rid of the `is_link` parameters. I wanted to keep it around since existing code might do something like:

    subreddit.flair.templates.clear(is_link=True)

The latest commit removes a lot of code duplication, and it seemed to me like the best approach.