### PR TITLE
Replace deprecated Sphinx option "html_use_smartypants"

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,6 @@ html_theme = 'sphinx_rtd_theme'
 html_theme_options = {
     'collapse_navigation': True
 }
-html_use_smartypants = True
 htmlhelp_basename = 'PRAW'
 intersphinx_mapping = {'python': ('https://docs.python.org/3.6', None)}
 master_doc = 'index'

--- a/docs/docutils.conf
+++ b/docs/docutils.conf
@@ -1,0 +1,2 @@
+[parsers]
+smart_quotes: true


### PR DESCRIPTION
Sphinx has deprecated the `html_use_smartypants` option, resulting in [a bunch of noise](https://travis-ci.org/praw-dev/praw/jobs/244599349#L697) when running the pre-push scripts. This PR moves this option  to docutils config as described at rtfd/readthedocs.org#2940.