### PR TITLE
Depend on prawcore >= 0.11.0, <0.12.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(name=PACKAGE_NAME,
       description=('PRAW, an acronym for `Python Reddit API Wrapper`, is a '
                    'python package that allows for simple access to '
                    'reddit\'s API.'),
-      install_requires=['prawcore >=0.10.1, <0.11',
+      install_requires=['prawcore >=0.11.0, <0.12',
                         'update_checker >=0.16'],
       keywords='reddit api wrapper',
       license='Simplified BSD License',


### PR DESCRIPTION
This will enable prawdditions (and any other PRAW clients) to use the new `prawcore.exceptions.Conflict`.