### PR TITLE
Add Redditor.stream.comments() and Redditor.stream.submissions()

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -31,4 +31,5 @@ Source Contributors
 - Keith Diedrick <kediedrick@gmail.com> `@darthkedrik <https://github.com/darthkedrik>`_
 - elnuno `@elnuno <https://github.com/elnuno>`_
 - Robbie Gibson `@rkgibson2 <https://github.com/rkgibson2>`_
+- jarhill0 `@jarhill0 <https://github.com/jarhill0>`_
 - Add "Name <email (optional)> and github profile link" above this line.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,18 @@
 Change Log
 ==========
 
+Unreleased
+----------
+
+**Added**
+
+* :attr:`.Redditor.stream`, with methods :meth:`.RedditorStream.submissions()`
+  and :meth:`.RedditorStream.comments()` to stream a Redditor's
+  comments or submissions
+* :class:`.Redditor` has been added to facilitate
+  :attr:`.Redditor.stream`
+
+
 5.0.1 (2017/07/11)
 ------------------
 

--- a/docs/code_overview/other.rst
+++ b/docs/code_overview/other.rst
@@ -65,4 +65,5 @@ instances of them bound to an attribute of one of the PRAW models.
    other/redditorlist
    other/sublisting
    other/subredditmessage
+   other/redditorstream
    other/util

--- a/docs/code_overview/other/redditorstream.rst
+++ b/docs/code_overview/other/redditorstream.rst
@@ -1,0 +1,5 @@
+RedditorStream
+==============
+
+.. autoclass:: praw.models.reddit.redditor.RedditorStream
+   :inherited-members:


### PR DESCRIPTION
## Feature Summary and Justification

This feature provides a `Redditor.stream` attribute that can be used as `Redditor.stream.comments()` and `Redditor.stream.submissions()`. This is a feature that one would expect already exists in PRAW, because user contributions, just like subreddit posts and comments, can be sorted chronologically, and sometimes must be handled ASAP.

---

This is my first ever contribution to a real project. I did my best to follow [both](http://praw.readthedocs.io/en/latest/package_info/contributing.html) sets of [guidelines](https://github.com/praw-dev/praw/blob/master/.github/CONTRIBUTING.md) for contribution.

The code itself seemed simple enough, so I hope I did that all correctly.

Let me know if there are any issues with my PR so that we can fix them together. I hope this can be added to PRAW so that I can use it.