### PR TITLE
[WIP] Add crosspost support

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -33,4 +33,5 @@ Source Contributors
 - Robbie Gibson `@rkgibson2 <https://github.com/rkgibson2>`_
 - jarhill0 `@jarhill0 <https://github.com/jarhill0>`_
 - Mike Wohlrab `@D0cR3d <https://github.com/D0cR3d>`_
+- Matthew Lee `@kwwxis <https://github.com/kwwxis>`_
 - Add "Name <email (optional)> and github profile link" above this line.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,7 @@ Unreleased
   :attr:`.Redditor.stream`
 * :meth:`.Inbox.collapse` to mark messages as collapsed.
 * :meth:`.Inbox.uncollapse` to mark messages as uncollapsed.
+* :meth:`.Subreddit.crosspost` to crosspost to a subreddit.
 
 **Fixed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,7 +13,7 @@ Unreleased
   :attr:`.Redditor.stream`
 * :meth:`.Inbox.collapse` to mark messages as collapsed.
 * :meth:`.Inbox.uncollapse` to mark messages as uncollapsed.
-* :meth:`.Subreddit.crosspost` to crosspost to a subreddit.
+* :meth:`.Submission.crosspost` to crosspost to a subreddit.
 
 **Fixed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ Unreleased
   :attr:`.Redditor.stream`
 * :meth:`.Inbox.collapse` to mark messages as collapsed.
 * :meth:`.Inbox.uncollapse` to mark messages as uncollapsed.
+* Raise :class:`.ClientException` when calling :meth:`.refresh` when the
+  comment does not appear in the resulting comment tree.
 * :meth:`.Submission.crosspost` to crosspost to a subreddit.
 
 **Fixed**

--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -191,6 +191,30 @@ class Submission(RedditBase, SubmissionListingMixin, UserContentMixin):
         for submissions in self._chunk(other_submissions, 50):
             self._reddit.post(API_PATH['unhide'], data={'id': submissions})
 
+    def crosspost(self, subreddit, title=None, send_replies=True):
+        """Crosspost the submission to a subreddit.
+
+        :param subreddit: Name of the subreddit or :class:`~.Subreddit`
+            object to crosspost into.
+        :param title: Title of the submission. Will use this submission's
+            title if `None`. (default: None).
+        :param send_replies: When True, messages will be sent to the
+            submission author when comments are made to the submission
+            (default: True).
+        :returns: A :class:`~.Submission` object for the newly created
+            submission
+        """
+        if not isinstance(subreddit, Subreddit):
+            subreddit = self._reddit.subreddit(subreddit)
+
+        if title is None:
+            title = self.title
+
+        if not self.is_crosspostable:
+            raise ValueError('This Submission is not crosspostable.')
+
+        return subreddit._crosspost(self.fullname, title, send_replies)
+
 
 class SubmissionFlair(object):
     """Provide a set of functions pertaining to Submission flair."""

--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -197,23 +197,22 @@ class Submission(RedditBase, SubmissionListingMixin, UserContentMixin):
         :param subreddit: Name of the subreddit or :class:`~.Subreddit`
             object to crosspost into.
         :param title: Title of the submission. Will use this submission's
-            title if `None`. (default: None).
+            title if `None` (default: None).
         :param send_replies: When True, messages will be sent to the
             submission author when comments are made to the submission
             (default: True).
         :returns: A :class:`~.Submission` object for the newly created
-            submission
+            submission.
         """
-        if not isinstance(subreddit, Subreddit):
-            subreddit = self._reddit.subreddit(subreddit)
-
         if title is None:
             title = self.title
 
-        if not self.is_crosspostable:
-            raise ValueError('This Submission is not crosspostable.')
-
-        return subreddit._crosspost(self.fullname, title, send_replies)
+        data = {'sr': str(subreddit),
+                'title': title,
+                'sendreplies': bool(send_replies),
+                'kind': 'crosspost',
+                'crosspost_fullname': self.fullname}
+        return self._reddit.post(API_PATH['submit'], data=data)
 
 
 class SubmissionFlair(object):

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -487,14 +487,6 @@ class Subreddit(RedditBase, MessageableMixin, SubredditListingMixin):
             data.update(kind='link', url=url)
         return self._reddit.post(API_PATH['submit'], data=data)
 
-    def _crosspost(self, fullname, title=None, send_replies=True):
-        data = {'sr': str(self),
-                'title': title,
-                'sendreplies': bool(send_replies),
-                'kind': 'crosspost',
-                'crosspost_fullname': fullname}
-        return self._reddit.post(API_PATH['submit'], data=data)
-
     def subscribe(self, other_subreddits=None):
         """Subscribe to the subreddit.
 

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -487,42 +487,12 @@ class Subreddit(RedditBase, MessageableMixin, SubredditListingMixin):
             data.update(kind='link', url=url)
         return self._reddit.post(API_PATH['submit'], data=data)
 
-    def crosspost(self, crosspost_fullname, title=None, send_replies=True):
-        """Crosspost a submission to the subreddit.
-
-        :param crosspost_fullname: The fullname id of the submission
-        :param title: The title of the submission (default=None).
-            Can be set to `None` to use the original submission title.
-        :param send_replies: When True, messages will be sent to the
-            submission author when comments are made to the submission
-            (default: True).
-        :returns: A :class:`~.Submission` object for the newly created
-            submission.
-
-        """
-        origin = None
-
-        if crosspost_fullname.startswith('t3_'):  # submission
-            origin = self._reddit.submission(id=crosspost_fullname[3:])
-            if title is None:
-                title = origin.title
-        elif crosspost_fullname.startswith('t1_'):  # comment
-            origin = self._reddit.comment(id=crosspost_fullname[3:])
-            if title is None:
-                raise ValueError('`title` must be provided for crossposting'
-                                 + ' comments.')
-            raise NotImplementedError('Crossposting comments is not yet'
-                                      + ' implemented.')
-
-        if not origin.is_crosspostable:
-            raise ValueError('The provided ' + str(origin.__class__.__name__)
-                             + ' is not crosspostable.')
-
+    def _crosspost(self, fullname, title=None, send_replies=True):
         data = {'sr': str(self),
                 'title': title,
                 'sendreplies': bool(send_replies),
                 'kind': 'crosspost',
-                'crosspost_fullname': crosspost_fullname}
+                'crosspost_fullname': fullname}
         return self._reddit.post(API_PATH['submit'], data=data)
 
     def subscribe(self, other_subreddits=None):

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -486,35 +486,43 @@ class Subreddit(RedditBase, MessageableMixin, SubredditListingMixin):
         else:
             data.update(kind='link', url=url)
         return self._reddit.post(API_PATH['submit'], data=data)
-    
+
     def crosspost(self, crosspost_fullname, title=None, send_replies=True):
         """Crosspost a submission to the subreddit.
-        
-        :param crosspost_fullname: The fullname id of the submission
-        :param title: The title of the submission (default=None). Can be set to
-            `None` to use the original submission title.
-        :param send_replies: When True, messages will be sent to the submission
-            author when comments are made to the submission (default: True).
-        :returns: A :class:`~.Submission` object for the newly created submission.
-        """
 
+        :param crosspost_fullname: The fullname id of the submission
+        :param title: The title of the submission (default=None).
+            Can be set to `None` to use the original submission title.
+        :param send_replies: When True, messages will be sent to the
+            submission author when comments are made to the submission
+            (default: True).
+        :returns: A :class:`~.Submission` object for the newly created
+            submission.
+
+        """
         origin = None
 
-        if crosspost_fullname.startswith('t3_'): # submission
+        if crosspost_fullname.startswith('t3_'):  # submission
             origin = self._reddit.submission(id=crosspost_fullname[3:])
             if title is None:
-                title = origin.title    
-        elif crosspost_fullname.startswith('t1_'): # comment
+                title = origin.title
+        elif crosspost_fullname.startswith('t1_'):  # comment
             origin = self._reddit.comment(id=crosspost_fullname[3:])
             if title is None:
-                raise ValueError('`title` must be provided for crossposting comments.')
-            raise NotImplementedError('Crossposting comments is not yet implemented.')
+                raise ValueError('`title` must be provided for crossposting'
+                                 + ' comments.')
+            raise NotImplementedError('Crossposting comments is not yet'
+                                      + ' implemented.')
 
         if not origin.is_crosspostable:
-            raise ValueError('The provided ' + str(origin.__class__.__name__) + ' is not crosspostable.')
-        
-        data = {'sr': str(self), 'title': title, 'sendreplies': bool(send_replies),
-                'kind': 'crosspost', 'crosspost_fullname': crosspost_fullname }
+            raise ValueError('The provided ' + str(origin.__class__.__name__)
+                             + ' is not crosspostable.')
+
+        data = {'sr': str(self),
+                'title': title,
+                'sendreplies': bool(send_replies),
+                'kind': 'crosspost',
+                'crosspost_fullname': crosspost_fullname}
         return self._reddit.post(API_PATH['submit'], data=data)
 
     def subscribe(self, other_subreddits=None):

--- a/tests/integration/cassettes/TestSubmission.test_crosspost.json
+++ b/tests/integration/cassettes/TestSubmission.test_crosspost.json
@@ -1,0 +1,227 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-08-25T08:45:40",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "64",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.2dev0 prawcore/0.11.0"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Fri, 25 Aug 2017 08:45:41 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sea1039-SEA",
+          "X-Timer": "S1503650741.374544,VS0,VE372",
+          "cache-control": "max-age=0, must-revalidate",
+          "set-cookie": "session_tracker=18tTL7gRkgtkDgew2f.0.1503650741424.Z0FBQUFBQlpuLU8xR1NpTVo5U0dsUnlYajJKbUdHOTZJcXJlc0x1aXBRSTZDWC1fMXFIcTBLdndxYXo4Tnd4Q0JkUTBQOHh4MVZ2MXl0ZVJMWnNfZERuME1nRVJjeGdET056anZqRnBVLUR6cm9kOFNZWGNIZ01sVjFIOWstbDFwaFU0TVcycDJDQk4; Domain=reddit.com; Max-Age=7199; Path=/; expires=Fri, 25-Aug-2017 10:45:41 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2017-08-25T08:45:40",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=8Rzduv85LHtt57aITF; session_tracker=18tTL7gRkgtkDgew2f.0.1503650741424.Z0FBQUFBQlpuLU8xR1NpTVo5U0dsUnlYajJKbUdHOTZJcXJlc0x1aXBRSTZDWC1fMXFIcTBLdndxYXo4Tnd4Q0JkUTBQOHh4MVZ2MXl0ZVJMWnNfZERuME1nRVJjeGdET056anZqRnBVLUR6cm9kOFNZWGNIZ01sVjFIOWstbDFwaFU0TVcycDJDQk4",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.2dev0 prawcore/0.11.0"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/comments/6vx01b/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"domain\": \"self.reddit_api_test\", \"approved_at_utc\": null, \"banned_by\": null, \"media_embed\": {}, \"thumbnail_width\": null, \"subreddit\": \"reddit_api_test\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Ecrossposting\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"crossposting\", \"likes\": null, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"link_flair_text\": null, \"id\": \"6vx01b\", \"banned_at_utc\": null, \"view_count\": null, \"archived\": false, \"clicked\": false, \"report_reasons\": null, \"title\": \"Test Title\", \"num_crossposts\": 0, \"saved\": false, \"can_mod_post\": false, \"is_crosspostable\": true, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"self\", \"subreddit_id\": \"t5_2t5o6\", \"hide_score\": true, \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"contest_mode\": false, \"gilded\": 0, \"locked\": false, \"downs\": 0, \"brand_safe\": false, \"secure_media_embed\": {}, \"removal_reason\": null, \"can_gild\": true, \"thumbnail_height\": null, \"parent_whitelist_status\": null, \"name\": \"t3_6vx01b\", \"spoiler\": false, \"permalink\": \"/r/reddit_api_test/comments/6vx01b/test_title/\", \"num_reports\": null, \"whitelist_status\": null, \"stickied\": false, \"created\": 1503675314.0, \"url\": \"https://www.reddit.com/r/reddit_api_test/comments/6vx01b/test_title/\", \"author_flair_text\": null, \"quarantine\": false, \"author\": \"kwwxis2\", \"created_utc\": 1503646514.0, \"subreddit_name_prefixed\": \"r/reddit_api_test\", \"distinguished\": null, \"media\": null, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"is_self\": true, \"visited\": false, \"subreddit_type\": \"public\", \"is_video\": false, \"ups\": 1}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1922",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Fri, 25 Aug 2017 08:45:42 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sea1023-SEA",
+          "X-Timer": "S1503650742.908422,VS0,VE110",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "loid=00000000000boa9ml3.2.1503649840202.Z0FBQUFBQlpuLU8xLVU0clozcGQxZ2RoYUtuemNycklaLXIxbGZ5azJONG1kaHZrcC0wRmxJNm1SZ1VfVmRfSDJjX19NU3BRcXVPNl9uRDE0eTlNbHVlOXlYcmdZNHpIMmlPWTZpa183SGNqN1M1YUpuOXRUci1hbV91cFRrUUdBZWUyd0dRRnN1aXQ; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Sun, 25-Aug-2019 08:45:41 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "599.0",
+          "x-ratelimit-reset": "259",
+          "x-ratelimit-used": "1",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=ME1mIA4RD9fOlmYYD4XCpWOQ4oNvoMGlSIVYoCnbzNXI9aKuzvSYIK6qGgWP%2BevN4pLj%2BpcTrDKofRBJayeH0uPf%2BBhuocxN",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/comments/6vx01b/?limit=2048&sort=best&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-08-25T08:45:41",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&crosspost_fullname=t3_6vx01b&kind=crosspost&sendreplies=True&sr=<TEST_SUBREDDIT>&title=Test+Title"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "103",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=8Rzduv85LHtt57aITF; loid=00000000000boa9ml3.2.1503649840202.Z0FBQUFBQlpuLU8xLVU0clozcGQxZ2RoYUtuemNycklaLXIxbGZ5azJONG1kaHZrcC0wRmxJNm1SZ1VfVmRfSDJjX19NU3BRcXVPNl9uRDE0eTlNbHVlOXlYcmdZNHpIMmlPWTZpa183SGNqN1M1YUpuOXRUci1hbV91cFRrUUdBZWUyd0dRRnN1aXQ; session_tracker=18tTL7gRkgtkDgew2f.0.1503650741952.Z0FBQUFBQlpuLU8xcWFZYWZYek1BRFgwTEZ5Vjh4cnpudm5wN0Ryc2VFYkRHQmZGZDY4Nk1KNXE5dkI5aEdfQkxlWW1vZ3FxUjBnRjlJM0gySmNFOENzMnFMQnJOTnVDd3hfcG5ITmhDRnIzbnhoejRYU3BLX2hvU1pZMU5PSE9GNnlFQVdwRFpIZTY",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.2dev0 prawcore/0.11.0"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/submit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"url\": \"https://www.reddit.com/r/<TEST_SUBREDDIT>/comments/6vx8n0/test_title/\", \"id\": \"6vx8n0\", \"name\": \"t3_6vx8n0\"}}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "143",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Fri, 25 Aug 2017 08:45:42 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sea1023-SEA",
+          "X-Timer": "S1503650742.058557,VS0,VE177",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=18tTL7gRkgtkDgew2f.0.1503650742104.Z0FBQUFBQlpuLU8yX2stbVdZb2tSWjNsVEN5eXFWb1lvQ25tdXhweGttb3pGLXpYOVIzQUxxNTNUTnFGbXlVYWNKRFVkc2NYM3NxNGZBRGcwRVcyNnNwdk4tX09YZkZ6TzVJRzhQSVFZd1Vfa0FGUml1TDJES0ZFcWNlclVCc0VwLThIRGRmVy1CNjQ; Domain=reddit.com; Max-Age=7199; Path=/; expires=Fri, 25-Aug-2017 10:45:42 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "598.0",
+          "x-ratelimit-reset": "258",
+          "x-ratelimit-used": "2",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/submit/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-08-25T08:45:41",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=8Rzduv85LHtt57aITF; loid=00000000000boa9ml3.2.1503649840202.Z0FBQUFBQlpuLU8xLVU0clozcGQxZ2RoYUtuemNycklaLXIxbGZ5azJONG1kaHZrcC0wRmxJNm1SZ1VfVmRfSDJjX19NU3BRcXVPNl9uRDE0eTlNbHVlOXlYcmdZNHpIMmlPWTZpa183SGNqN1M1YUpuOXRUci1hbV91cFRrUUdBZWUyd0dRRnN1aXQ; session_tracker=18tTL7gRkgtkDgew2f.0.1503650742104.Z0FBQUFBQlpuLU8yX2stbVdZb2tSWjNsVEN5eXFWb1lvQ25tdXhweGttb3pGLXpYOVIzQUxxNTNUTnFGbXlVYWNKRFVkc2NYM3NxNGZBRGcwRVcyNnNwdk4tX09YZkZ6TzVJRzhQSVFZd1Vfa0FGUml1TDJES0ZFcWNlclVCc0VwLThIRGRmVy1CNjQ",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.2dev0 prawcore/0.11.0"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/comments/6vx8n0/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"domain\": \"self.reddit_api_test\", \"approved_at_utc\": null, \"banned_by\": null, \"num_reports\": 0, \"media_embed\": {}, \"thumbnail_width\": null, \"subreddit\": \"<TEST_SUBREDDIT>\", \"selftext_html\": null, \"selftext\": \"\", \"likes\": true, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"link_flair_text\": null, \"id\": \"6vx8n0\", \"banned_at_utc\": null, \"view_count\": null, \"archived\": false, \"clicked\": false, \"report_reasons\": [], \"author\": \"<USERNAME>\", \"num_crossposts\": 0, \"saved\": false, \"can_mod_post\": true, \"is_crosspostable\": true, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"default\", \"subreddit_id\": \"t5_3nh3z\", \"hide_score\": false, \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"contest_mode\": false, \"gilded\": 0, \"locked\": false, \"downs\": 0, \"brand_safe\": false, \"secure_media_embed\": {}, \"removal_reason\": null, \"spam\": false, \"can_gild\": false, \"thumbnail_height\": null, \"removed\": false, \"approved\": false, \"parent_whitelist_status\": null, \"name\": \"t3_6vx8n0\", \"crosspost_parent\": \"t3_6vx01b\", \"spoiler\": false, \"permalink\": \"/r/<TEST_SUBREDDIT>/comments/6vx8n0/test_title/\", \"crosspost_parent_list\": [{\"domain\": \"self.reddit_api_test\", \"approved_at_utc\": null, \"banned_by\": null, \"media_embed\": {}, \"thumbnail_width\": null, \"subreddit\": \"reddit_api_test\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Ecrossposting\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"crossposting\", \"likes\": null, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"link_flair_text\": null, \"id\": \"6vx01b\", \"banned_at_utc\": null, \"view_count\": null, \"archived\": false, \"clicked\": false, \"report_reasons\": null, \"title\": \"Test Title\", \"num_crossposts\": 1, \"saved\": false, \"can_mod_post\": false, \"is_crosspostable\": true, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"self\", \"subreddit_id\": \"t5_2t5o6\", \"hide_score\": true, \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"contest_mode\": false, \"gilded\": 0, \"locked\": false, \"downs\": 0, \"brand_safe\": false, \"secure_media_embed\": {}, \"removal_reason\": null, \"can_gild\": true, \"thumbnail_height\": null, \"parent_whitelist_status\": null, \"name\": \"t3_6vx01b\", \"spoiler\": false, \"permalink\": \"/r/reddit_api_test/comments/6vx01b/test_title/\", \"num_reports\": null, \"whitelist_status\": null, \"stickied\": false, \"created\": 1503675314.0, \"url\": \"https://www.reddit.com/r/reddit_api_test/comments/6vx01b/test_title/\", \"author_flair_text\": null, \"quarantine\": false, \"author\": \"kwwxis2\", \"created_utc\": 1503646514.0, \"subreddit_name_prefixed\": \"r/reddit_api_test\", \"distinguished\": null, \"media\": null, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"is_self\": true, \"visited\": false, \"subreddit_type\": \"public\", \"is_video\": false, \"ups\": 1}], \"whitelist_status\": null, \"stickied\": false, \"created\": 1503679542.0, \"url\": \"https://www.reddit.com/r/reddit_api_test/comments/6vx01b/test_title/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Test Title\", \"created_utc\": 1503650742.0, \"subreddit_name_prefixed\": \"r/<TEST_SUBREDDIT>\", \"distinguished\": null, \"media\": null, \"upvote_ratio\": 1.0, \"ignore_reports\": false, \"mod_reports\": [], \"is_self\": false, \"visited\": false, \"subreddit_type\": \"public\", \"is_video\": false, \"ups\": 1}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "3608",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Fri, 25 Aug 2017 08:45:42 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sea1023-SEA",
+          "X-Timer": "S1503650742.266565,VS0,VE135",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=18tTL7gRkgtkDgew2f.0.1503650742313.Z0FBQUFBQlpuLU8yanh6Z3g5VVJfdXJSVXhJY1dnZWVnMEZaaUhpNGJKa1g2bkxBdkR4aTdYclRTc2N4MThoQ0pyRGQ1RUpjekplUWd2dFdhSkE2d0hRcUNXeDluRzhHcHBrdzM5TEZSTTZmS0o5ZlZTQ29oVlNvWUhMekxsbDlISlM5OGkza2RxVmI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Fri, 25-Aug-2017 10:45:42 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "597.0",
+          "x-ratelimit-reset": "258",
+          "x-ratelimit-used": "3",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=6tyABv253ZJ63MLLTC64QPiwVcPPEXVzwBv5oAQNvqYmByTIgEehgcFLEXfK3pnzYT%2Brm2GuuKG1xlD3WLMVu5a4BX2owcep",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/comments/6vx8n0/?limit=2048&sort=best&raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/tests/integration/cassettes/TestSubmission.test_crosspost__custom_title.json
+++ b/tests/integration/cassettes/TestSubmission.test_crosspost__custom_title.json
@@ -1,0 +1,227 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-08-25T08:45:43",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "64",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.2dev0 prawcore/0.11.0"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Fri, 25 Aug 2017 08:45:44 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sea1046-SEA",
+          "X-Timer": "S1503650744.084672,VS0,VE373",
+          "cache-control": "max-age=0, must-revalidate",
+          "set-cookie": "session_tracker=40TTQWnMvDg4TYviAU.0.1503650744129.Z0FBQUFBQlpuLU80Nm10RUs2eVh0WG55OG9qUXR3RGVvRmVUaE45QVNzT2NyRVBVdTZxc2VQb19SZnVhUm1pSWloQzBudkpoYnRFdWlvRFZJWi1VZ1g4TTUxWmFtczFjMTh0VGxzR0FXdGM3UlA2QS1SMTFaVlhUZ09oMFNMbUlDajdhdFJCV2VhODk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Fri, 25-Aug-2017 10:45:44 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2017-08-25T08:45:43",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=EOcvk9YJRO0wTyMvqS; session_tracker=40TTQWnMvDg4TYviAU.0.1503650744129.Z0FBQUFBQlpuLU80Nm10RUs2eVh0WG55OG9qUXR3RGVvRmVUaE45QVNzT2NyRVBVdTZxc2VQb19SZnVhUm1pSWloQzBudkpoYnRFdWlvRFZJWi1VZ1g4TTUxWmFtczFjMTh0VGxzR0FXdGM3UlA2QS1SMTFaVlhUZ09oMFNMbUlDajdhdFJCV2VhODk",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.2dev0 prawcore/0.11.0"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/comments/6vx01b/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"domain\": \"self.reddit_api_test\", \"approved_at_utc\": null, \"banned_by\": null, \"media_embed\": {}, \"thumbnail_width\": null, \"subreddit\": \"reddit_api_test\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Ecrossposting\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"crossposting\", \"likes\": null, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"link_flair_text\": null, \"id\": \"6vx01b\", \"banned_at_utc\": null, \"view_count\": null, \"archived\": false, \"clicked\": false, \"report_reasons\": null, \"title\": \"Test Title\", \"num_crossposts\": 2, \"saved\": false, \"can_mod_post\": false, \"is_crosspostable\": true, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"self\", \"subreddit_id\": \"t5_2t5o6\", \"hide_score\": true, \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"contest_mode\": false, \"gilded\": 0, \"locked\": false, \"downs\": 0, \"brand_safe\": false, \"secure_media_embed\": {}, \"removal_reason\": null, \"can_gild\": true, \"thumbnail_height\": null, \"parent_whitelist_status\": null, \"name\": \"t3_6vx01b\", \"spoiler\": false, \"permalink\": \"/r/reddit_api_test/comments/6vx01b/test_title/\", \"num_reports\": null, \"whitelist_status\": null, \"stickied\": false, \"created\": 1503675314.0, \"url\": \"https://www.reddit.com/r/reddit_api_test/comments/6vx01b/test_title/\", \"author_flair_text\": null, \"quarantine\": false, \"author\": \"kwwxis2\", \"created_utc\": 1503646514.0, \"subreddit_name_prefixed\": \"r/reddit_api_test\", \"distinguished\": null, \"media\": null, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"is_self\": true, \"visited\": false, \"subreddit_type\": \"public\", \"is_video\": false, \"ups\": 1}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1922",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Fri, 25 Aug 2017 08:45:44 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sea1033-SEA",
+          "X-Timer": "S1503650745.670735,VS0,VE145",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "loid=00000000000boa9ml3.2.1503649840202.Z0FBQUFBQlpuLU80SV9USzZrNU5MbkstUExldExQUFdMRmhVMlYzbHFEXzNwQ2toSmZhUkxlMDZGYWxuSDlQdi03SVN5T2dadVhGdzJmalJNRDROZE5PQjBiYmhncHZwbEJkQlBzMzFoQVFFLXVLenZvMTFMcy1LNWVUbXpkbExGSUJTUjR0bzhvOUE; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Sun, 25-Aug-2019 08:45:44 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "593.0",
+          "x-ratelimit-reset": "256",
+          "x-ratelimit-used": "7",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=13DlZzU%2FGhDL%2FT5MRcmG9j7fHv4cmuAX%2BSO5YqUxRFqJmhTj4a6bMKiFWNT7KCSeWa11nOP6f69Zko8%2FvHrjPBF%2BrRzr1r6L",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/comments/6vx01b/?limit=2048&sort=best&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-08-25T08:45:43",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&crosspost_fullname=t3_6vx01b&kind=crosspost&sendreplies=True&sr=<TEST_SUBREDDIT>&title=my+title"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "101",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=EOcvk9YJRO0wTyMvqS; loid=00000000000boa9ml3.2.1503649840202.Z0FBQUFBQlpuLU80SV9USzZrNU5MbkstUExldExQUFdMRmhVMlYzbHFEXzNwQ2toSmZhUkxlMDZGYWxuSDlQdi03SVN5T2dadVhGdzJmalJNRDROZE5PQjBiYmhncHZwbEJkQlBzMzFoQVFFLXVLenZvMTFMcy1LNWVUbXpkbExGSUJTUjR0bzhvOUE; session_tracker=40TTQWnMvDg4TYviAU.0.1503650744716.Z0FBQUFBQlpuLU80dVlSa0k1R3FWR245cVR0RXotNWtSdERfVkVFTDItYm9UMGo1bXpaQWdtZVM1Y2FURDN5Y0MxRXNqU0lTMVpMYnpnMG5FTHhtdUtOeHVCRWgyR1BPVWxSRWFiOVFTVHdHTVFQaHdyX0JkTFVrZ0xCa0txTURQT2EtX01teU53NDI",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.2dev0 prawcore/0.11.0"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/submit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"url\": \"https://www.reddit.com/r/<TEST_SUBREDDIT>/comments/6vx8na/my_title/\", \"id\": \"6vx8na\", \"name\": \"t3_6vx8na\"}}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "141",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Fri, 25 Aug 2017 08:45:45 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sea1033-SEA",
+          "X-Timer": "S1503650745.860890,VS0,VE183",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=40TTQWnMvDg4TYviAU.0.1503650744905.Z0FBQUFBQlpuLU81WUh6UlVpQzdpOWJySkhjaGU5WXczRkVkUWRxNDloWTFyR1RnOEtkWExvSlJ6Z0Z2N0Z0cTY0VUw3WlA1eFEyNFNoTzNvajEyQTAxQm9ZRWM1RmwwMDhmNFIwSWVIUkV6ZFJmOV9tWmlTeUlQNGtIYXo3aXlpVnlLWGVIOFo2aUg; Domain=reddit.com; Max-Age=7199; Path=/; expires=Fri, 25-Aug-2017 10:45:45 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "592.0",
+          "x-ratelimit-reset": "256",
+          "x-ratelimit-used": "8",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/submit/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-08-25T08:45:44",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=EOcvk9YJRO0wTyMvqS; loid=00000000000boa9ml3.2.1503649840202.Z0FBQUFBQlpuLU80SV9USzZrNU5MbkstUExldExQUFdMRmhVMlYzbHFEXzNwQ2toSmZhUkxlMDZGYWxuSDlQdi03SVN5T2dadVhGdzJmalJNRDROZE5PQjBiYmhncHZwbEJkQlBzMzFoQVFFLXVLenZvMTFMcy1LNWVUbXpkbExGSUJTUjR0bzhvOUE; session_tracker=40TTQWnMvDg4TYviAU.0.1503650744905.Z0FBQUFBQlpuLU81WUh6UlVpQzdpOWJySkhjaGU5WXczRkVkUWRxNDloWTFyR1RnOEtkWExvSlJ6Z0Z2N0Z0cTY0VUw3WlA1eFEyNFNoTzNvajEyQTAxQm9ZRWM1RmwwMDhmNFIwSWVIUkV6ZFJmOV9tWmlTeUlQNGtIYXo3aXlpVnlLWGVIOFo2aUg",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.2dev0 prawcore/0.11.0"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/comments/6vx8na/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"domain\": \"self.reddit_api_test\", \"approved_at_utc\": null, \"banned_by\": null, \"num_reports\": 0, \"media_embed\": {}, \"thumbnail_width\": 140, \"subreddit\": \"<TEST_SUBREDDIT>\", \"selftext_html\": null, \"selftext\": \"\", \"likes\": true, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"link_flair_text\": null, \"id\": \"6vx8na\", \"banned_at_utc\": null, \"view_count\": null, \"archived\": false, \"clicked\": false, \"report_reasons\": [], \"author\": \"<USERNAME>\", \"num_crossposts\": 0, \"saved\": false, \"can_mod_post\": true, \"is_crosspostable\": true, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"https://b.thumbs.redditmedia.com/iIFocmcf0z3xu2uHUqWIfwJqeaMz251PQdUTsWui0SM.jpg\", \"subreddit_id\": \"t5_3nh3z\", \"hide_score\": false, \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"contest_mode\": false, \"gilded\": 0, \"locked\": false, \"downs\": 0, \"brand_safe\": false, \"secure_media_embed\": {}, \"removal_reason\": null, \"spam\": false, \"can_gild\": false, \"thumbnail_height\": 140, \"removed\": false, \"approved\": false, \"parent_whitelist_status\": null, \"name\": \"t3_6vx8na\", \"crosspost_parent\": \"t3_6vx01b\", \"spoiler\": false, \"permalink\": \"/r/<TEST_SUBREDDIT>/comments/6vx8na/my_title/\", \"crosspost_parent_list\": [{\"domain\": \"self.reddit_api_test\", \"approved_at_utc\": null, \"banned_by\": null, \"media_embed\": {}, \"thumbnail_width\": null, \"subreddit\": \"reddit_api_test\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Ecrossposting\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"crossposting\", \"likes\": null, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"link_flair_text\": null, \"id\": \"6vx01b\", \"banned_at_utc\": null, \"view_count\": null, \"archived\": false, \"clicked\": false, \"report_reasons\": null, \"title\": \"Test Title\", \"num_crossposts\": 3, \"saved\": false, \"can_mod_post\": false, \"is_crosspostable\": true, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"self\", \"subreddit_id\": \"t5_2t5o6\", \"hide_score\": true, \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"contest_mode\": false, \"gilded\": 0, \"locked\": false, \"downs\": 0, \"brand_safe\": false, \"secure_media_embed\": {}, \"removal_reason\": null, \"can_gild\": true, \"thumbnail_height\": null, \"parent_whitelist_status\": null, \"name\": \"t3_6vx01b\", \"spoiler\": false, \"permalink\": \"/r/reddit_api_test/comments/6vx01b/test_title/\", \"num_reports\": null, \"whitelist_status\": null, \"stickied\": false, \"created\": 1503675314.0, \"url\": \"https://www.reddit.com/r/reddit_api_test/comments/6vx01b/test_title/\", \"author_flair_text\": null, \"quarantine\": false, \"author\": \"kwwxis2\", \"created_utc\": 1503646514.0, \"subreddit_name_prefixed\": \"r/reddit_api_test\", \"distinguished\": null, \"media\": null, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"is_self\": true, \"visited\": false, \"subreddit_type\": \"public\", \"is_video\": false, \"ups\": 1}], \"whitelist_status\": null, \"stickied\": false, \"created\": 1503679544.0, \"url\": \"https://www.reddit.com/r/reddit_api_test/comments/6vx01b/test_title/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"my title\", \"created_utc\": 1503650744.0, \"subreddit_name_prefixed\": \"r/<TEST_SUBREDDIT>\", \"distinguished\": null, \"media\": null, \"upvote_ratio\": 1.0, \"ignore_reports\": false, \"mod_reports\": [], \"is_self\": false, \"visited\": false, \"subreddit_type\": \"public\", \"is_video\": false, \"ups\": 1}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "3675",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Fri, 25 Aug 2017 08:45:45 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sea1033-SEA",
+          "X-Timer": "S1503650745.074820,VS0,VE143",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=40TTQWnMvDg4TYviAU.0.1503650745116.Z0FBQUFBQlpuLU81bS12MGdfalhSYUZnWllienZhMllWdmQwRlNHVmhkRjJwQVBjdThuc1JIdlVHS0xnVkJOX0VEMS1PMU45TEh5cERYWFhNVURRUUprVVBkb2NvUDFGMVhNbm5aaXdoWmZ3amZ2QUwwNDN6d2cydWRGRmltT2FZY01WcWFaMmVsT0s; Domain=reddit.com; Max-Age=7199; Path=/; expires=Fri, 25-Aug-2017 10:45:45 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "591.0",
+          "x-ratelimit-reset": "255",
+          "x-ratelimit-used": "9",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=aOH6Wsw4LGojfPv1PPzJZbaDM5hCTJaJzcT5CmKGqVNU7nifiUKThyjvMWVWsDT2cQ9EAS%2FBxUqL%2FgNvbBlEg1joSwATAInh",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/comments/6vx8na/?limit=2048&sort=best&raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/tests/integration/cassettes/TestSubmission.test_crosspost__subreddit_object.json
+++ b/tests/integration/cassettes/TestSubmission.test_crosspost__subreddit_object.json
@@ -1,0 +1,227 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-08-25T08:45:42",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "64",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.2dev0 prawcore/0.11.0"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Fri, 25 Aug 2017 08:45:43 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sea1036-SEA",
+          "X-Timer": "S1503650743.704776,VS0,VE409",
+          "cache-control": "max-age=0, must-revalidate",
+          "set-cookie": "session_tracker=TKvjVDuN1wyJUnQVGn.0.1503650742753.Z0FBQUFBQlpuLU8zcDY2emxjZGRLV3BNSk9FY3E0anVGSnJGRndvZUwwVVdlRm90NE9BLWRDUzVZS1ZZRFNsRVNQTUJOVVNVakhyY0tfS3pyN0otNW9TWmdzWElKdUREQ21PVFd6M2dRVnplc2d1YW5vRDFsVE55cWlPX3BWMm1lYjBYTzZmN05wYWo; Domain=reddit.com; Max-Age=7199; Path=/; expires=Fri, 25-Aug-2017 10:45:43 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2017-08-25T08:45:42",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=qI8xE2dYVoTV2I6RmA; session_tracker=TKvjVDuN1wyJUnQVGn.0.1503650742753.Z0FBQUFBQlpuLU8zcDY2emxjZGRLV3BNSk9FY3E0anVGSnJGRndvZUwwVVdlRm90NE9BLWRDUzVZS1ZZRFNsRVNQTUJOVVNVakhyY0tfS3pyN0otNW9TWmdzWElKdUREQ21PVFd6M2dRVnplc2d1YW5vRDFsVE55cWlPX3BWMm1lYjBYTzZmN05wYWo",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.2dev0 prawcore/0.11.0"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/comments/6vx01b/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"domain\": \"self.reddit_api_test\", \"approved_at_utc\": null, \"banned_by\": null, \"media_embed\": {}, \"thumbnail_width\": null, \"subreddit\": \"reddit_api_test\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Ecrossposting\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"crossposting\", \"likes\": null, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"link_flair_text\": null, \"id\": \"6vx01b\", \"banned_at_utc\": null, \"view_count\": null, \"archived\": false, \"clicked\": false, \"report_reasons\": null, \"title\": \"Test Title\", \"num_crossposts\": 1, \"saved\": false, \"can_mod_post\": false, \"is_crosspostable\": true, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"self\", \"subreddit_id\": \"t5_2t5o6\", \"hide_score\": true, \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"contest_mode\": false, \"gilded\": 0, \"locked\": false, \"downs\": 0, \"brand_safe\": false, \"secure_media_embed\": {}, \"removal_reason\": null, \"can_gild\": true, \"thumbnail_height\": null, \"parent_whitelist_status\": null, \"name\": \"t3_6vx01b\", \"spoiler\": false, \"permalink\": \"/r/reddit_api_test/comments/6vx01b/test_title/\", \"num_reports\": null, \"whitelist_status\": null, \"stickied\": false, \"created\": 1503675314.0, \"url\": \"https://www.reddit.com/r/reddit_api_test/comments/6vx01b/test_title/\", \"author_flair_text\": null, \"quarantine\": false, \"author\": \"kwwxis2\", \"created_utc\": 1503646514.0, \"subreddit_name_prefixed\": \"r/reddit_api_test\", \"distinguished\": null, \"media\": null, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"is_self\": true, \"visited\": false, \"subreddit_type\": \"public\", \"is_video\": false, \"ups\": 1}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1922",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Fri, 25 Aug 2017 08:45:43 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sea1031-SEA",
+          "X-Timer": "S1503650743.296261,VS0,VE136",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "loid=00000000000boa9ml3.2.1503649840202.Z0FBQUFBQlpuLU8zc0lXdjZDd2kyU0VQbUJrRzZyODhIUTlhZktiSmg4UDNMQkxnMzE0U1p6LU1EdE5jNXNOWEVpTVRXeGJQcW4wTlpXaFhEdG1fWjFiOWVVWTR3dm5WWm4xY1JXNDBOS3hYWG1LaXlhVDM3akJiTkNJSFhkS1o3N1FzRXdWM19tNHY; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Sun, 25-Aug-2019 08:45:43 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "596.0",
+          "x-ratelimit-reset": "257",
+          "x-ratelimit-used": "4",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=rT%2Fkk3h1QtWBCIPliDUYCr5J%2BPWKun1%2BycXjuUEYPxDg0Hg0dK0niixrWkNhxLWln5TrnOYe8gB9xL7PmbbMlXmV50lkDb7f",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/comments/6vx01b/?limit=2048&sort=best&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-08-25T08:45:42",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&crosspost_fullname=t3_6vx01b&kind=crosspost&sendreplies=True&sr=<TEST_SUBREDDIT>&title=Test+Title"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "103",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=qI8xE2dYVoTV2I6RmA; loid=00000000000boa9ml3.2.1503649840202.Z0FBQUFBQlpuLU8zc0lXdjZDd2kyU0VQbUJrRzZyODhIUTlhZktiSmg4UDNMQkxnMzE0U1p6LU1EdE5jNXNOWEVpTVRXeGJQcW4wTlpXaFhEdG1fWjFiOWVVWTR3dm5WWm4xY1JXNDBOS3hYWG1LaXlhVDM3akJiTkNJSFhkS1o3N1FzRXdWM19tNHY; session_tracker=TKvjVDuN1wyJUnQVGn.0.1503650743343.Z0FBQUFBQlpuLU8zUTF4VnF1RHJ1SGIxZ2FvNnhYLVFQTHBYNi1IcjJ3Q1Mwb0JSTW9IN29jalg2ZDBMWVEyTUNnNkZBOVBJWTRibWtjQ3pDZjJBb3Rsc2Y2T1VOUnBBQThJdmFZZWl5N2g3MnlKTVVIQ0FtS1lXSk1XcjliNGd2UFF3cEVaVVQyVGc",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.2dev0 prawcore/0.11.0"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/submit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"url\": \"https://www.reddit.com/r/<TEST_SUBREDDIT>/comments/6vx8n8/test_title/\", \"id\": \"6vx8n8\", \"name\": \"t3_6vx8n8\"}}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "143",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Fri, 25 Aug 2017 08:45:43 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sea1031-SEA",
+          "X-Timer": "S1503650743.484262,VS0,VE182",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=TKvjVDuN1wyJUnQVGn.0.1503650743533.Z0FBQUFBQlpuLU8zeUp6bHdiRlFMZXQyNGgxMVZrQ3llMWZ3TDhZM1lBZ2VaUWdpcmp5NW9TR3hBMEhySmRfMy0xS00yUy1sWEtzbUFxcGZaWWZiYWYzYjhrS1RqakZGSkMzWVRMMGtKSlZGa1g0QUVNWlA4S0ZLQW45c21LNGViNUpfc19oMXRhc3g; Domain=reddit.com; Max-Age=7199; Path=/; expires=Fri, 25-Aug-2017 10:45:43 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "595.0",
+          "x-ratelimit-reset": "257",
+          "x-ratelimit-used": "5",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/submit/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-08-25T08:45:42",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=qI8xE2dYVoTV2I6RmA; loid=00000000000boa9ml3.2.1503649840202.Z0FBQUFBQlpuLU8zc0lXdjZDd2kyU0VQbUJrRzZyODhIUTlhZktiSmg4UDNMQkxnMzE0U1p6LU1EdE5jNXNOWEVpTVRXeGJQcW4wTlpXaFhEdG1fWjFiOWVVWTR3dm5WWm4xY1JXNDBOS3hYWG1LaXlhVDM3akJiTkNJSFhkS1o3N1FzRXdWM19tNHY; session_tracker=TKvjVDuN1wyJUnQVGn.0.1503650743533.Z0FBQUFBQlpuLU8zeUp6bHdiRlFMZXQyNGgxMVZrQ3llMWZ3TDhZM1lBZ2VaUWdpcmp5NW9TR3hBMEhySmRfMy0xS00yUy1sWEtzbUFxcGZaWWZiYWYzYjhrS1RqakZGSkMzWVRMMGtKSlZGa1g0QUVNWlA4S0ZLQW45c21LNGViNUpfc19oMXRhc3g",
+          "User-Agent": "<USER_AGENT> PRAW/5.0.2dev0 prawcore/0.11.0"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/comments/6vx8n8/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [{\"kind\": \"t3\", \"data\": {\"domain\": \"self.reddit_api_test\", \"approved_at_utc\": null, \"banned_by\": null, \"num_reports\": 0, \"media_embed\": {}, \"thumbnail_width\": null, \"subreddit\": \"<TEST_SUBREDDIT>\", \"selftext_html\": null, \"selftext\": \"\", \"likes\": true, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"link_flair_text\": null, \"id\": \"6vx8n8\", \"banned_at_utc\": null, \"view_count\": null, \"archived\": false, \"clicked\": false, \"report_reasons\": [], \"author\": \"<USERNAME>\", \"num_crossposts\": 0, \"saved\": false, \"can_mod_post\": true, \"is_crosspostable\": true, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"default\", \"subreddit_id\": \"t5_3nh3z\", \"hide_score\": false, \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"contest_mode\": false, \"gilded\": 0, \"locked\": false, \"downs\": 0, \"brand_safe\": false, \"secure_media_embed\": {}, \"removal_reason\": null, \"spam\": false, \"can_gild\": false, \"thumbnail_height\": null, \"removed\": false, \"approved\": false, \"parent_whitelist_status\": null, \"name\": \"t3_6vx8n8\", \"crosspost_parent\": \"t3_6vx01b\", \"spoiler\": false, \"permalink\": \"/r/<TEST_SUBREDDIT>/comments/6vx8n8/test_title/\", \"crosspost_parent_list\": [{\"domain\": \"self.reddit_api_test\", \"approved_at_utc\": null, \"banned_by\": null, \"media_embed\": {}, \"thumbnail_width\": null, \"subreddit\": \"reddit_api_test\", \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Ecrossposting\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"selftext\": \"crossposting\", \"likes\": null, \"suggested_sort\": null, \"user_reports\": [], \"secure_media\": null, \"link_flair_text\": null, \"id\": \"6vx01b\", \"banned_at_utc\": null, \"view_count\": null, \"archived\": false, \"clicked\": false, \"report_reasons\": null, \"title\": \"Test Title\", \"num_crossposts\": 2, \"saved\": false, \"can_mod_post\": false, \"is_crosspostable\": true, \"score\": 1, \"approved_by\": null, \"over_18\": false, \"hidden\": false, \"num_comments\": 0, \"thumbnail\": \"self\", \"subreddit_id\": \"t5_2t5o6\", \"hide_score\": true, \"edited\": false, \"link_flair_css_class\": null, \"author_flair_css_class\": null, \"contest_mode\": false, \"gilded\": 0, \"locked\": false, \"downs\": 0, \"brand_safe\": false, \"secure_media_embed\": {}, \"removal_reason\": null, \"can_gild\": true, \"thumbnail_height\": null, \"parent_whitelist_status\": null, \"name\": \"t3_6vx01b\", \"spoiler\": false, \"permalink\": \"/r/reddit_api_test/comments/6vx01b/test_title/\", \"num_reports\": null, \"whitelist_status\": null, \"stickied\": false, \"created\": 1503675314.0, \"url\": \"https://www.reddit.com/r/reddit_api_test/comments/6vx01b/test_title/\", \"author_flair_text\": null, \"quarantine\": false, \"author\": \"kwwxis2\", \"created_utc\": 1503646514.0, \"subreddit_name_prefixed\": \"r/reddit_api_test\", \"distinguished\": null, \"media\": null, \"upvote_ratio\": 1.0, \"mod_reports\": [], \"is_self\": true, \"visited\": false, \"subreddit_type\": \"public\", \"is_video\": false, \"ups\": 1}], \"whitelist_status\": null, \"stickied\": false, \"created\": 1503679543.0, \"url\": \"https://www.reddit.com/r/reddit_api_test/comments/6vx01b/test_title/\", \"author_flair_text\": null, \"quarantine\": false, \"title\": \"Test Title\", \"created_utc\": 1503650743.0, \"subreddit_name_prefixed\": \"r/<TEST_SUBREDDIT>\", \"distinguished\": null, \"media\": null, \"upvote_ratio\": 1.0, \"ignore_reports\": false, \"mod_reports\": [], \"is_self\": false, \"visited\": false, \"subreddit_type\": \"public\", \"is_video\": false, \"ups\": 1}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "3608",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Fri, 25 Aug 2017 08:45:43 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sea1031-SEA",
+          "X-Timer": "S1503650744.700143,VS0,VE134",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=TKvjVDuN1wyJUnQVGn.0.1503650743748.Z0FBQUFBQlpuLU8zelh1Qkl2U1I3R2pGamg5NnZndXVFRkgyZ0pNRUNUTEhJeTZTSXBmSnFGVWxkclI5XzRNRFVDa1I4aWFMOUxWVmQtcFMyRTRUZEEtWFU4b0ZCRHBNX2gtaVNWZjkweV9rbk9FRWZUeDVCVzc1My1CUm96TWZod01MT01QeTU2dks; Domain=reddit.com; Max-Age=7199; Path=/; expires=Fri, 25-Aug-2017 10:45:43 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "594.0",
+          "x-ratelimit-reset": "257",
+          "x-ratelimit-used": "6",
+          "x-reddit-tracking": "https://pixel.redditmedia.com/pixel/of_destiny.png?v=7QWFjFZ0Mr8vi9gi8b727%2FnibYQ50ENWGDlFMVt7Z6dyabmpQ4%2BNY0MANmB8YVU9XSut%2BfHM%2BduSdqzuH%2BdWtW%2FGZ9ozMAly",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/comments/6vx8n8/?limit=2048&sort=best&raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/tests/integration/models/reddit/test_submission.py
+++ b/tests/integration/models/reddit/test_submission.py
@@ -165,7 +165,7 @@ class TestSubmission(IntegrationTest):
             Submission(self.reddit, '4b536p').upvote()
 
     @mock.patch('time.sleep', return_value=None)
-    def test_crosspost(self,_):
+    def test_crosspost(self, _):
         self.reddit.read_only = False
         with self.recorder.use_cassette('TestSubmission.test_crosspost'):
             subreddit = pytest.placeholders.test_subreddit
@@ -177,9 +177,10 @@ class TestSubmission(IntegrationTest):
             assert submission.crosspost_parent == 't3_6vx01b'
 
     @mock.patch('time.sleep', return_value=None)
-    def test_crosspost__subreddit_object(self,_):
+    def test_crosspost__subreddit_object(self, _):
         self.reddit.read_only = False
-        with self.recorder.use_cassette('TestSubmission.test_crosspost__subreddit_object'):
+        with self.recorder.use_cassette(
+                'TestSubmission.test_crosspost__subreddit_object'):
             subreddit = self.reddit.subreddit(
                 pytest.placeholders.test_subreddit)
             crosspost_parent = self.reddit.submission(id='6vx01b')
@@ -190,9 +191,10 @@ class TestSubmission(IntegrationTest):
             assert submission.crosspost_parent == 't3_6vx01b'
 
     @mock.patch('time.sleep', return_value=None)
-    def test_crosspost__custom_title(self,_):
+    def test_crosspost__custom_title(self, _):
         self.reddit.read_only = False
-        with self.recorder.use_cassette('TestSubmission.test_crosspost__custom_title'):
+        with self.recorder.use_cassette(
+                'TestSubmission.test_crosspost__custom_title'):
             subreddit = self.reddit.subreddit(
                 pytest.placeholders.test_subreddit)
             crosspost_parent = self.reddit.submission(id='6vx01b')

--- a/tests/integration/models/reddit/test_submission.py
+++ b/tests/integration/models/reddit/test_submission.py
@@ -164,6 +164,44 @@ class TestSubmission(IntegrationTest):
                 'TestSubmission.test_upvote'):
             Submission(self.reddit, '4b536p').upvote()
 
+    @mock.patch('time.sleep', return_value=None)
+    def test_crosspost(self,_):
+        self.reddit.read_only = False
+        with self.recorder.use_cassette('TestSubmission.test_crosspost'):
+            subreddit = pytest.placeholders.test_subreddit
+            crosspost_parent = self.reddit.submission(id='6vx01b')
+
+            submission = crosspost_parent.crosspost(subreddit)
+            assert submission.author == self.reddit.config.username
+            assert submission.title == 'Test Title'
+            assert submission.crosspost_parent == 't3_6vx01b'
+
+    @mock.patch('time.sleep', return_value=None)
+    def test_crosspost__subreddit_object(self,_):
+        self.reddit.read_only = False
+        with self.recorder.use_cassette('TestSubmission.test_crosspost__subreddit_object'):
+            subreddit = self.reddit.subreddit(
+                pytest.placeholders.test_subreddit)
+            crosspost_parent = self.reddit.submission(id='6vx01b')
+
+            submission = crosspost_parent.crosspost(subreddit)
+            assert submission.author == self.reddit.config.username
+            assert submission.title == 'Test Title'
+            assert submission.crosspost_parent == 't3_6vx01b'
+
+    @mock.patch('time.sleep', return_value=None)
+    def test_crosspost__custom_title(self,_):
+        self.reddit.read_only = False
+        with self.recorder.use_cassette('TestSubmission.test_crosspost__custom_title'):
+            subreddit = self.reddit.subreddit(
+                pytest.placeholders.test_subreddit)
+            crosspost_parent = self.reddit.submission(id='6vx01b')
+
+            submission = crosspost_parent.crosspost(subreddit, 'my title')
+            assert submission.author == self.reddit.config.username
+            assert submission.title == 'my title'
+            assert submission.crosspost_parent == 't3_6vx01b'
+
 
 class TestSubmissionFlair(IntegrationTest):
     @mock.patch('time.sleep', return_value=None)


### PR DESCRIPTION
Fixes n/a

## Feature Summary and Justification

This feature provides support for creating a crosspost. Today (4/24/2017) Reddit [launched the beta for crossposting](https://www.reddit.com/r/modnews/comments/6vths0/beta_crossposting_better_attribution_for_cat/). As the beta launched just today, things could still change so I've marked this pull request as WIP in case of Reddit crosspost API changes between now and when the beta ends.

I have the crosspost method take a thing `fullname` instead of an `id` because Reddit plans to add support for crossposting comments some time in the future.

Maybe it would be better to have the `crosspost` method be on the Submission class and take the subreddit to crosspost to as the parameter?

## Example usage

I can confirm this works:

```
$ py
Python 3.6.0 (v3.6.0:41df79263a11, Dec 23 2016, 07:18:10) [MSC v.1900 32 bit (Intel)] on win32
Type "help", "copyright", "credits" or "license" for more information.
>>> import praw
>>> reddit = praw.Reddit(<REDACTED>)
>>> subreddit.crosspost
<bound method Subreddit.crosspost of Subreddit(display_name='LPT_test')>
>>> subreddit.crosspost('t3_6vqtvb', title='another crosspost test')
Submission(id='6vvund')
>>> quit()
```

Post I crossposted: https://www.reddit.com/r/onionhate/comments/6vqtvb/yes_they_are/
New post created: https://www.reddit.com/r/LPT_test/comments/6vvund/another_crosspost_test/

As for integration tests, this is my first contribution to PRAW so I'm unsure of how to do those yet.

## References

* Modnews post: https://www.reddit.com/r/modnews/comments/6vths0/beta_crossposting_better_attribution_for_cat/
* Admin comment on crossposting comments as submissions: https://www.reddit.com/r/modnews/comments/6vths0/beta_crossposting_better_attribution_for_cat/dm35fb9/?context=2 
