### PR TITLE
Fixes URL-escape password placeholder for Betamax

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,7 +61,6 @@ placeholders = {x: env_default(x) for x in
                  'test_subreddit user_agent username').split()}
 placeholders['basic_auth'] = b64_string(
     '{}:{}'.format(placeholders['client_id'], placeholders['client_secret']))
-placeholders['password'] = quote_plus(placeholders['password'])
 
 
 betamax.Betamax.register_serializer(pretty_json.PrettyJSONSerializer)
@@ -70,6 +69,8 @@ with betamax.Betamax.configure() as config:
     config.default_cassette_options['serialize_with'] = 'prettyjson'
     config.before_record(callback=filter_access_token)
     for key, value in placeholders.items():
+        if key == 'password':
+            value = quote_plus(value)
         config.define_cassette_placeholder('<{}>'.format(key.upper()), value)
 
 


### PR DESCRIPTION
Fixes issues with #788 

This fixes the password problems I had in my previous pull request (#835).

My password contains two symbols: a `*` and a `!`, however my password was showing up in the cassettes JSON files with the two symbols encoded as `%252A` and `%2521` respectively rather than `%2A` and `%21`. This would mean that the password is getting URL-encoded twice.

So my guess is that Betamax is already automatically doing URL-encoding, so I removed the `placeholders['password'] = quote_plus(placeholders['password'])` line. And then I set it so that `password` is URL-encoded only when being passed into `define_cassette_placeholder`.

This worked for me. Can anyone else confirm?

Mentioning @leviroth 