### PR TITLE
Escape API Exception message with `unicode_escape` encoding

### DIFF
--- a/praw/exceptions.py
+++ b/praw/exceptions.py
@@ -21,10 +21,17 @@ class APIException(PRAWException):
         :param message: The associated message for the error.
         :param field: The input field associated with the error if available.
 
+        .. note: Calling `str()` on the instance returns `unicode_escape`d
+            ASCII string because the message may be localized and may contain
+            UNICODE characters. If you want a non-escaped message, access
+            the `message` atribute on the instance.
+
         """
-        error_str = '{}: \'{}\''.format(error_type, message)
+        error_str = u'{}: \'{}\''.format(error_type, message)
         if field:
-            error_str += ' on field \'{}\''.format(field)
+            error_str += u' on field \'{}\''.format(field)
+        error_str = error_str.encode('unicode_escape').decode('ascii')
+
         super(APIException, self).__init__(error_str)
         self.error_type = error_type
         self.message = message

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -1,3 +1,4 @@
+# coding: utf-8
 from praw.exceptions import APIException, ClientException, PRAWException
 
 
@@ -19,6 +20,14 @@ class TestAPIException(object):
                                  'some_field')
         assert str(exception) == ('BAD_SOMETHING: \'invalid something\' on '
                                   'field \'some_field\'')
+
+    def test_str_for_localized_error_string(self):
+        exception = APIException(
+                'RATELIMIT', u'実行回数が多すぎます', u'フィールド')
+        assert str(exception) == (
+                'RATELIMIT: \'\\u5b9f\\u884c\\u56de\\u6570\\u304c\\u591a'
+                '\\u3059\\u304e\\u307e\\u3059\' on field '
+                '\'\\u30d5\\u30a3\\u30fc\\u30eb\\u30c9\'')
 
 
 class TestClientException(object):

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ skipsdist = true
 [testenv]
 deps =
     betamax >=0.8, <0.9
-    betamax-matchers >=0.3.0, <0.4
+    betamax-matchers >=0.3.0, <0.5
     betamax-serializers >=0.2, <0.3
     mock >=0.8
     pytest ==2.7.3


### PR DESCRIPTION
Fixes #845

## Feature Summary and Justification

Now APIException's error message string is escaped with `unicode_escape`.

```
$ python2
Python 2.7.13 (default, Jul 18 2017, 09:16:53)
[GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from praw.exceptions import APIException
>>> ex = APIException('RATELIMIT', u'実行回数が多すぎます', u フィールド')
>>> str(ex)
"RATELIMIT: '\\u5b9f\\u884c\\u56de\\u6570\\u304c\\u591a\\u3059\\u304e\\u307e\\u3059' on field '\\u30d5\\u30a3\\u30fc\\u30eb\\u30c9'"
>>> ex.message
u'\u5b9f\u884c\u56de\u6570\u304c\u591a\u3059\u304e\u307e\u3059'

$ python3
Python 3.6.2 (default, Jul 17 2017, 16:44:47)
[GCC 4.2.1 Compatible Apple LLVM 8.0.0 (clang-800.0.42.1)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> from praw.exceptions import APIException
>>> ex = APIException('RATELIMIT', '実行回数が多すぎます',  フィールド')
>>> str(ex)
"RATELIMIT: '\\u5b9f\\u884c\\u56de\\u6570\\u304c\\u591a\\u3059\\u304e\\u307e\\u3059' on field '\\u30d5\\u30a3\\u30fc\\u30eb\\u30c9'"
>>> ex.message
'実行回数が多すぎます'
>>> str(APIException('RATELIMIT', 'Too many requests', 'some field'))
"RATELIMIT: 'Too many requests' on field 'some field'"
```

I had thought that changing APIException's error message from str to unicode will suffice, but [the unittest](https://github.com/praw-dev/praw/blob/master/tests/unit/test_exceptions.py) assumes the exception can be passed to str(), so to encode the messge from unicode to ASCII is inevitable.


## References

For `unicode_escape` encoding:

* https://docs.python.org/2/library/codecs.html#python-specific-encodings
* https://docs.python.org/3/library/codecs.html#text-encodings