### PR TITLE
Fix a few Sphinx typos

### DIFF
--- a/praw/exceptions.py
+++ b/praw/exceptions.py
@@ -21,10 +21,11 @@ class APIException(PRAWException):
         :param message: The associated message for the error.
         :param field: The input field associated with the error if available.
 
-        .. note: Calling `str()` on the instance returns `unicode_escape`d
-            ASCII string because the message may be localized and may contain
-            UNICODE characters. If you want a non-escaped message, access
-            the `message` atribute on the instance.
+        .. note:: Calling ``str()`` on the instance returns
+            ``unicode_escape``-d ASCII string because the message may be
+            localized and may contain UNICODE characters. If you want a
+            non-escaped message, access the ``message`` attribute on
+            the instance.
 
         """
         error_str = u'{}: \'{}\''.format(error_type, message)


### PR DESCRIPTION
Re #846

## Feature Summary and Justification

* `.. note:` -> `.. note::` to prevent the `note` from being interpreted as a comment, which wouldn't show up when the docs are rendered.
* Double backticks for the code bits.
* Correct typo ("atribute" -> "attribute").
* Sphinx doesn't like characters immediately after the backticks, so add a hyphen in to prevent it from being rendered incorrectly.

## References

N/A
