### PR TITLE
Clarify subreddit filtering

### DIFF
--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -41,7 +41,11 @@ class Subreddit(RedditBase, MessageableMixin, SubredditListingMixin):
        for submission in reddit.subreddit('redditdev+learnpython').top('all'):
            print(submission)
 
-    Subreddits can be filtered from combined listings as follows:
+    Subreddits can be filtered from combined listings as follows. Note that
+    these filters are ignored by certain methods, including
+    :attr:`~praw.models.Subreddit.comments`,
+    :meth:`~praw.models.Subreddit.gilded`, and
+    :meth:`.SubredditStream.comments`.
 
     .. code:: python
 


### PR DESCRIPTION
Fixes #848

## Feature Summary and Justification

This feature provides clarification in the documentation that subreddit filtering (`reddit.subreddit('all-the_donald')`) does not work for some methods, including methods for returning comments.

## References

* [/r/redditdev thread](https://www.reddit.com/r/redditdev/comments/6yhalr/cant_block_subreddits_with_praw/)