### PR TITLE
Document that "contributor" is another term for "approved submitter"

### DIFF
--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -145,7 +145,17 @@ class Subreddit(RedditBase, MessageableMixin, SubredditListingMixin):
 
     @property
     def contributor(self):
-        """Provide an instance of :class:`.ContributorRelationship`."""
+        """Provide an instance of :class:`.ContributorRelationship`.
+
+        Contributors are also known as approved submitters.
+
+        To add a contributor try:
+
+        .. code-block:: python
+
+           reddit.subreddit('SUBREDDIT').contributor.add('NAME')
+
+        """
         if self._contributor is None:
             self._contributor = ContributorRelationship(self, 'contributor')
         return self._contributor
@@ -1379,6 +1389,8 @@ class SubredditRelationship(object):
 
 class ContributorRelationship(SubredditRelationship):
     """Provides methods to interact with a Subreddit's contributors.
+
+    Contributors are also known as approved submitters.
 
     Contributors of a subreddit can be iterated through like so:
 


### PR DESCRIPTION
## Feature Summary and Justification

This adds an example and a note saying that "contributor" is another term for "approved submitter."

Reddit's API and associated documentation use the term "contributor" where the website uses the term "approved submitter." PRAW currently follows the API documentation only, which makes it hard to find things by searching for "approved submitter."

## References

* https://www.reddit.com/r/redditdev/comments/72v97e/praw_invite_user_to_inviteonly_subreddit/
