### PR TITLE
Add note about dynamically provided attributes to all Models

### DIFF
--- a/docs/code_overview/models/comment.rst
+++ b/docs/code_overview/models/comment.rst
@@ -4,4 +4,4 @@ Comment
 .. autoclass:: praw.models.Comment
    :inherited-members:
 
-.. note:: |note-dynamically-provided-attributes|
+.. include:: note_dynamically_provided_attributes.txt

--- a/docs/code_overview/models/comment.rst
+++ b/docs/code_overview/models/comment.rst
@@ -3,10 +3,5 @@ Comment
 
 .. autoclass:: praw.models.Comment
    :inherited-members:
-.. note:: This list of attributes is not complete. PRAW dynamically provides
-          the attributes that Reddit returns via the API. Because those
-          attributes are subject to change on Reddit's end, PRAW makes no
-          effort to document them, other than to instruct you on how to
-          discover what is available. See
-          :ref:`determine-available-attributes-of-an-object` for detailed
-          information.
+
+.. note:: |note-dynamically-provided-attributes|

--- a/docs/code_overview/models/livethread.rst
+++ b/docs/code_overview/models/livethread.rst
@@ -3,3 +3,5 @@ LiveThread
 
 .. autoclass:: praw.models.LiveThread
    :inherited-members:
+
+.. note:: |note-dynamically-provided-attributes|

--- a/docs/code_overview/models/livethread.rst
+++ b/docs/code_overview/models/livethread.rst
@@ -4,4 +4,4 @@ LiveThread
 .. autoclass:: praw.models.LiveThread
    :inherited-members:
 
-.. note:: |note-dynamically-provided-attributes|
+.. include:: note_dynamically_provided_attributes.txt

--- a/docs/code_overview/models/liveupdate.rst
+++ b/docs/code_overview/models/liveupdate.rst
@@ -3,3 +3,5 @@ LiveUpdate
 
 .. autoclass:: praw.models.LiveUpdate
    :inherited-members:
+
+.. note:: |note-dynamically-provided-attributes|

--- a/docs/code_overview/models/liveupdate.rst
+++ b/docs/code_overview/models/liveupdate.rst
@@ -4,4 +4,4 @@ LiveUpdate
 .. autoclass:: praw.models.LiveUpdate
    :inherited-members:
 
-.. note:: |note-dynamically-provided-attributes|
+.. include:: note_dynamically_provided_attributes.txt

--- a/docs/code_overview/models/message.rst
+++ b/docs/code_overview/models/message.rst
@@ -4,4 +4,4 @@ Message
 .. autoclass:: praw.models.Message
    :inherited-members:
 
-.. note:: |note-dynamically-provided-attributes|
+.. include:: note_dynamically_provided_attributes.txt

--- a/docs/code_overview/models/message.rst
+++ b/docs/code_overview/models/message.rst
@@ -3,3 +3,5 @@ Message
 
 .. autoclass:: praw.models.Message
    :inherited-members:
+
+.. note:: |note-dynamically-provided-attributes|

--- a/docs/code_overview/models/modmailconversation.rst
+++ b/docs/code_overview/models/modmailconversation.rst
@@ -4,4 +4,4 @@ ModmailConversation
 .. autoclass:: praw.models.ModmailConversation
    :inherited-members:
 
-.. note:: |note-dynamically-provided-attributes|
+.. include:: note_dynamically_provided_attributes.txt

--- a/docs/code_overview/models/modmailconversation.rst
+++ b/docs/code_overview/models/modmailconversation.rst
@@ -3,3 +3,5 @@ ModmailConversation
 
 .. autoclass:: praw.models.ModmailConversation
    :inherited-members:
+
+.. note:: |note-dynamically-provided-attributes|

--- a/docs/code_overview/models/more.rst
+++ b/docs/code_overview/models/more.rst
@@ -3,3 +3,5 @@ MoreComments
 
 .. autoclass:: praw.models.MoreComments
    :inherited-members:
+
+.. note:: |note-dynamically-provided-attributes|

--- a/docs/code_overview/models/more.rst
+++ b/docs/code_overview/models/more.rst
@@ -4,4 +4,4 @@ MoreComments
 .. autoclass:: praw.models.MoreComments
    :inherited-members:
 
-.. note:: |note-dynamically-provided-attributes|
+.. include:: note_dynamically_provided_attributes.txt

--- a/docs/code_overview/models/multireddit.rst
+++ b/docs/code_overview/models/multireddit.rst
@@ -4,4 +4,4 @@ Multireddit
 .. autoclass:: praw.models.Multireddit
    :inherited-members:
 
-.. note:: |note-dynamically-provided-attributes|
+.. include:: note_dynamically_provided_attributes.txt

--- a/docs/code_overview/models/multireddit.rst
+++ b/docs/code_overview/models/multireddit.rst
@@ -3,3 +3,5 @@ Multireddit
 
 .. autoclass:: praw.models.Multireddit
    :inherited-members:
+
+.. note:: |note-dynamically-provided-attributes|

--- a/docs/code_overview/models/note_dynamically_provided_attributes.txt
+++ b/docs/code_overview/models/note_dynamically_provided_attributes.txt
@@ -1,3 +1,9 @@
+..
+   This file contains a note about dynamically provided attributes. The note
+   is supposed to appear in every PRAW Model's docs page. Therefore, this
+   file will be appended to their reStructuredText files with the include
+   directive.
+
 .. note:: This list of attributes is not complete. PRAW dynamically provides
           the attributes that Reddit returns via the API. Because those
           attributes are subject to change on Reddit's end, PRAW makes no

--- a/docs/code_overview/models/note_dynamically_provided_attributes.txt
+++ b/docs/code_overview/models/note_dynamically_provided_attributes.txt
@@ -1,0 +1,7 @@
+.. note:: This list of attributes is not complete. PRAW dynamically provides
+          the attributes that Reddit returns via the API. Because those
+          attributes are subject to change on Reddit's end, PRAW makes no
+          effort to document them, other than to instruct you on how to
+          discover what is available. See
+          :ref:`determine-available-attributes-of-an-object` for detailed
+          information.

--- a/docs/code_overview/models/redditor.rst
+++ b/docs/code_overview/models/redditor.rst
@@ -4,4 +4,4 @@ Redditor
 .. autoclass:: praw.models.Redditor
    :inherited-members:
 
-.. note:: |note-dynamically-provided-attributes|
+.. include:: note_dynamically_provided_attributes.txt

--- a/docs/code_overview/models/redditor.rst
+++ b/docs/code_overview/models/redditor.rst
@@ -3,3 +3,5 @@ Redditor
 
 .. autoclass:: praw.models.Redditor
    :inherited-members:
+
+.. note:: |note-dynamically-provided-attributes|

--- a/docs/code_overview/models/submission.rst
+++ b/docs/code_overview/models/submission.rst
@@ -3,3 +3,5 @@ Submission
 
 .. autoclass:: praw.models.Submission
    :inherited-members:
+
+.. note:: |note-dynamically-provided-attributes|

--- a/docs/code_overview/models/submission.rst
+++ b/docs/code_overview/models/submission.rst
@@ -4,4 +4,4 @@ Submission
 .. autoclass:: praw.models.Submission
    :inherited-members:
 
-.. note:: |note-dynamically-provided-attributes|
+.. include:: note_dynamically_provided_attributes.txt

--- a/docs/code_overview/models/subreddit.rst
+++ b/docs/code_overview/models/subreddit.rst
@@ -3,3 +3,5 @@ Subreddit
 
 .. autoclass:: praw.models.Subreddit
    :inherited-members:
+
+.. note:: |note-dynamically-provided-attributes|

--- a/docs/code_overview/models/subreddit.rst
+++ b/docs/code_overview/models/subreddit.rst
@@ -4,4 +4,4 @@ Subreddit
 .. autoclass:: praw.models.Subreddit
    :inherited-members:
 
-.. note:: |note-dynamically-provided-attributes|
+.. include:: note_dynamically_provided_attributes.txt

--- a/docs/code_overview/models/wikipage.rst
+++ b/docs/code_overview/models/wikipage.rst
@@ -4,4 +4,4 @@ WikiPage
 .. autoclass:: praw.models.WikiPage
    :inherited-members:
 
-.. note:: |note-dynamically-provided-attributes|
+.. include:: note_dynamically_provided_attributes.txt

--- a/docs/code_overview/models/wikipage.rst
+++ b/docs/code_overview/models/wikipage.rst
@@ -3,3 +3,5 @@ WikiPage
 
 .. autoclass:: praw.models.WikiPage
    :inherited-members:
+
+.. note:: |note-dynamically-provided-attributes|

--- a/docs/code_overview/praw_models.rst
+++ b/docs/code_overview/praw_models.rst
@@ -16,3 +16,12 @@ Working with PRAW's Models
    models/submission
    models/subreddit
    models/wikipage
+
+.. |note-dynamically-provided-attributes| replace::
+   This list of attributes is not complete. PRAW dynamically provides
+   the attributes that Reddit returns via the API. Because those
+   attributes are subject to change on Reddit's end, PRAW makes no
+   effort to document them, other than to instruct you on how to
+   discover what is available. See
+   :ref:`determine-available-attributes-of-an-object` for detailed
+   information.

--- a/docs/code_overview/praw_models.rst
+++ b/docs/code_overview/praw_models.rst
@@ -16,12 +16,3 @@ Working with PRAW's Models
    models/submission
    models/subreddit
    models/wikipage
-
-.. |note-dynamically-provided-attributes| replace::
-   This list of attributes is not complete. PRAW dynamically provides
-   the attributes that Reddit returns via the API. Because those
-   attributes are subject to change on Reddit's end, PRAW makes no
-   effort to document them, other than to instruct you on how to
-   discover what is available. See
-   :ref:`determine-available-attributes-of-an-object` for detailed
-   information.


### PR DESCRIPTION
This new pull request is about the first point on my list in #862 which seems to have been overlooked:

> * For now, this pull request consists only of changes made to `comment.rst`. However, if you like my suggestion, of course the note should be appended to each file in `docs/code_overview/models/`.

I'm sorry, I only now found time to have a look at my previous pull request again and saw that it's been merged already. What did I do wrong? Maybe I should have put a certain label on the pull request? I'm sorry for the inconvenience.

So this is a new pull request to add the note about dynamically provided attributes to all Models - not only to `comment.rst`. My commits for this pull request do

* add a substitution definition (which contains the content of the previously already added note from #862) to `docs/code_overview/praw_models.rst` **(⚠ This seems to be a wrong approach - see below for more details)**
* remove the note with text from `comment.rst` because we can use the new substitution definition there as well
* use the new substitution definition in all files from `docs/code_overview/models/`

---

**Edit:** The build failed with the following error:

> ```
> Warning, treated as error:
> 
> /home/travis/build/praw-dev/praw/docs/code_overview/models/comment.rst:7:Undefined substitution referenced: "note-dynamically-provided-attributes".```

~Where do I have to put the substitution definition of `note-dynamically-provided-attributes` so it will be properly defined when it's being used within the files from `docs/code_overview/models/`?~
**(See possible solutions below)**

---

**Edit 2:**

Huh, substitution definitions don't seem to be remembered from file to file but can only be used inside the file they're defined in. Otherwise one will have to do something like this:

> If you want to use some substitutions for all documents, put them into rst_prolog or put them into a separate file and include it into all documents you want to use them in, using the include directive. (Be sure to give the include file a file name extension differing from that of other source files, to avoid Sphinx finding it as a standalone document.)

(from [http://www.sphinx-doc.org/en/stable/rest.html](http://www.sphinx-doc.org/en/stable/rest.html))

Which of the following options 1, 2 or 3 do you want me to do to fix this? I guess, it depends on personal preference.

1. Add `rst_prolog` with the substitution definition to `docs/conf.py`
2. Create an extra file in `docs/code_overview/models/` which will be included in the other files
3. Use the full text note without substitution in all files which would the violate Don't-repeat-yourself principle
