### PR TITLE
Add Redditor.block()

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,7 @@ Unreleased
 
 * :attr:`.Multireddit.stream`, to stream submissions and comments from a
   Multireddit.
+* :meth:`.Redditor.block`
 
 
 5.2.0 (2017/10/24)

--- a/praw/const.py
+++ b/praw/const.py
@@ -17,6 +17,7 @@ API_PATH = {
     'accept_mod_invite':      'r/{subreddit}/api/accept_moderator_invite',
     'approve':                'api/approve/',
     'block':                  'api/block',
+    'block_user':             '/api/block_user/',
     'blocked':                'prefs/blocked/',
     'collapse':               'api/collapse_message/',
     'comment':                'api/comment/',

--- a/praw/models/reddit/mixins/inboxable.py
+++ b/praw/models/reddit/mixins/inboxable.py
@@ -7,13 +7,7 @@ class InboxableMixin(object):
     """Interface for RedditBase classes that originate from the inbox."""
 
     def block(self):
-        """Block the user who sent the item.
-
-        .. note:: Reddit does not permit blocking users unless you have a
-                  :class:`.Comment` or :class:`.Message` from them in your
-                  inbox.
-
-        """
+        """Block the user who sent the item."""
         self._reddit.post(API_PATH['block'], data={'id': self.fullname})
 
     def collapse(self):

--- a/praw/models/reddit/redditor.py
+++ b/praw/models/reddit/redditor.py
@@ -69,6 +69,11 @@ class Redditor(RedditBase, MessageableMixin, RedditorListingMixin):
         url = API_PATH['friend_v1'].format(user=self)
         self._reddit.request(method, url, data=dumps(data))
 
+    def block(self):
+        """Block the Redditor."""
+        self._reddit.post(API_PATH['block_user'],
+                          params={'account_id': self.fullname})
+
     def friend(self, note=None):
         """Friend the Redditor.
 
@@ -106,12 +111,7 @@ class Redditor(RedditBase, MessageableMixin, RedditorListingMixin):
         return self._reddit.get(API_PATH['multireddit_user'].format(user=self))
 
     def unblock(self):
-        """Unblock the Redditor.
-
-        Blocking must be done from a Message, Comment Reply or Submission
-        Reply.
-
-        """
+        """Unblock the Redditor."""
         data = {'container': self._reddit.user.me().fullname,
                 'name': str(self), 'type': 'enemy'}
         url = API_PATH['unfriend'].format(subreddit='all')

--- a/tests/integration/cassettes/TestRedditor.test_block.json
+++ b/tests/integration/cassettes/TestRedditor.test_block.json
@@ -1,0 +1,168 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2017-11-26T20:26:33",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "53",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "<USER_AGENT> PRAW/5.2.1.dev0 prawcore/0.12.0"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 26 Nov 2017 20:26:33 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-pao17432-PAO",
+          "X-Timer": "S1511727993.444402,VS0,VE403",
+          "cache-control": "max-age=0, must-revalidate",
+          "set-cookie": "session_tracker=wqghiy3zXBvDINxxf1.0.1511727993483.Z0FBQUFBQmFHeU41MXhoWUo0Q3BBNW9JX2tNMmhQbEw2RkxkTDlycFdsMnNWTzdGN0dPNndzUk1Ra2xoOFBZcWtVOWhoMXdZTUt5NUd5aG4zUFY1cFI1SGg2NHVaVGF4TjhpM0FsR3ZCWUlQQVNZd3RvNXliN1U3NllSWVBwR0h6UVNBVzFrNnY3SFo; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 26-Nov-2017 22:26:33 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2017-11-26T20:26:34",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=EBeHy3C6giG8hgnL5Y; session_tracker=wqghiy3zXBvDINxxf1.0.1511727993483.Z0FBQUFBQmFHeU41MXhoWUo0Q3BBNW9JX2tNMmhQbEw2RkxkTDlycFdsMnNWTzdGN0dPNndzUk1Ra2xoOFBZcWtVOWhoMXdZTUt5NUd5aG4zUFY1cFI1SGg2NHVaVGF4TjhpM0FsR3ZCWUlQQVNZd3RvNXliN1U3NllSWVBwR0h6UVNBVzFrNnY3SFo",
+          "User-Agent": "<USER_AGENT> PRAW/5.2.1.dev0 prawcore/0.12.0"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/user/PyAPITestUser3/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t2\", \"data\": {\"is_employee\": false, \"verified\": false, \"name\": \"PyAPITestUser3\", \"is_friend\": false, \"created\": 1322581753.0, \"has_subscribed\": true, \"hide_from_robots\": false, \"created_utc\": 1322552953.0, \"subreddit\": null, \"comment_karma\": 0, \"is_gold\": false, \"is_mod\": false, \"pref_show_snoovatar\": false, \"link_karma\": 1, \"has_verified_email\": true, \"id\": \"6c1xj\"}}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "380",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 26 Nov 2017 20:26:34 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-pao17435-PAO",
+          "X-Timer": "S1511727994.031148,VS0,VE115",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "loid=0000000000014g6bq9.2.1494785872695.Z0FBQUFBQmFHeU42NkdXY29BS2VEQTViLWlmT3didk1pZlRVcE5PUGh5Y1ZycDFGRzFGQTdmdkZETEp3azZwdnlnbk5FazR2OVhTN01kcjBwTXpGU3RIZk1FNk50RGtmc0NlQ1dVVjlmdzVKOEdHX0NZLWN3Q1ZpMFBNaEV2dWFmdDlXNE1TeFlycFI; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Tue, 26-Nov-2019 20:26:34 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "599.0",
+          "x-ratelimit-reset": "206",
+          "x-ratelimit-used": "1",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/user/PyAPITestUser3/about/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2017-11-26T20:26:34",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "13",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=EBeHy3C6giG8hgnL5Y; loid=0000000000014g6bq9.2.1494785872695.Z0FBQUFBQmFHeU42NkdXY29BS2VEQTViLWlmT3didk1pZlRVcE5PUGh5Y1ZycDFGRzFGQTdmdkZETEp3azZwdnlnbk5FazR2OVhTN01kcjBwTXpGU3RIZk1FNk50RGtmc0NlQ1dVVjlmdzVKOEdHX0NZLWN3Q1ZpMFBNaEV2dWFmdDlXNE1TeFlycFI; session_tracker=wqghiy3zXBvDINxxf1.0.1511727994075.Z0FBQUFBQmFHeU42VExLTFcxWVprZnJoWlBjNGtOYjNBelRDVjZuTnRJTjJNWXRodjNpOHM1aHpiekZUbExrMkdIZG9UdHp1bmxyUFBRRWdUSHRwR3JNRjhSSEtvZi1kYWtQQ1RRSXFJN1FGekRVdk4zU2Q1WTFDdzhxUkQzc0FoOTJFcTFYZk5TOEk",
+          "User-Agent": "<USER_AGENT> PRAW/5.2.1.dev0 prawcore/0.12.0"
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/block_user/?account_id=t2_6c1xj&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "2",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sun, 26 Nov 2017 20:26:34 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-pao17435-PAO",
+          "X-Timer": "S1511727994.170878,VS0,VE100",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=wqghiy3zXBvDINxxf1.0.1511727994211.Z0FBQUFBQmFHeU42ZDkxRXpSdmRVeG1qSGVlTGxvSEFaQVliXzBmWjJ3M1Y5MjgwQldpTUVQVFc1bXFXUDlmbWo2YU41cUZfU0ZrMFBZazlJaVFPd3lKOFVqb2xFcktjX0FmMUFFT3NLT0FkRllweXBMTl9teGRrNmtOUGRZRDVjSzNvVWNtTDltaW8; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 26-Nov-2017 22:26:34 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "598.0",
+          "x-ratelimit-reset": "206",
+          "x-ratelimit-used": "2",
+          "x-ua-compatible": "IE=edge",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/block_user/?account_id=t2_6c1xj&raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/tests/integration/models/reddit/test_redditor.py
+++ b/tests/integration/models/reddit/test_redditor.py
@@ -10,6 +10,13 @@ from ... import IntegrationTest
 class TestRedditor(IntegrationTest):
     FRIEND = 'PyAPITestUser3'
 
+    @mock.patch('time.sleep', return_value=None)
+    def test_block(self, _):
+        self.reddit.read_only = False
+        with self.recorder.use_cassette('TestRedditor.test_block'):
+            redditor = self.reddit.redditor(self.FRIEND)
+            redditor.block()
+
     def test_friend(self):
         self.reddit.read_only = False
         with self.recorder.use_cassette('TestRedditor.test_friend'):


### PR DESCRIPTION
## Feature Summary and Justification

This feature provides support for the API endpoint /api/block_user, which I believe is fairly new. Specifically, it adds the `Redditor.block()` method, which accepts no params and blocks the Redditor it belongs to.

## References

* https://www.reddit.com/dev/api/#POST_api_block_user
