### PR TITLE
Parse short URLs with trailing slashes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,8 @@ Unreleased
 * Fix bug with positive ``pause_after`` values in streams provided by
   :meth:`.stream_generator` where the wait time was not reset after a yielded
   ``None``.
+* Parse URLs with trailing slashes and no ``'comments'`` element when creating
+  :class:`.Submission` objects.
 
 
 5.3.0 (2017/12/16)

--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -33,7 +33,7 @@ class Submission(RedditBase, SubmissionListingMixin, UserContentMixin):
 
         parts = parsed.path.split('/')
         if 'comments' not in parts:
-            submission_id = parts[-1]
+            submission_id = parts[-1] if parts[-1] else parts[-2]
         else:
             submission_id = parts[parts.index('comments') + 1]
 

--- a/tests/unit/models/reddit/test_submission.py
+++ b/tests/unit/models/reddit/test_submission.py
@@ -64,6 +64,7 @@ class TestSubmission(UnitTest):
     def test_id_from_url(self):
         urls = ['http://my.it/2gmzqe',
                 'https://redd.it/2gmzqe',
+                'https://redd.it/2gmzqe/',
                 'http://reddit.com/comments/2gmzqe',
                 'https://www.reddit.com/r/redditdev/comments/2gmzqe/'
                 'praw_https_enabled_praw_testing_needed/']


### PR DESCRIPTION
## Feature Summary and Justification

Currently, a line like `s = reddit.submission(url='https://redd.it/2gmzqe/')` will raise `ClientException: Invalid URL: https://redd.it/2gmzqe/`. This is due to the way URLs are parsed: if a URL doesn't have the 'comments' component, it only parses properly if there is no trailing slash. 

This PR adds a test case that should pass but fails, and then fixes the issue.