### PR TITLE
Further improve URL parsing for submissions

### DIFF
--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -31,9 +31,12 @@ class Submission(RedditBase, SubmissionListingMixin, UserContentMixin):
         if not parsed.netloc:
             raise ClientException('Invalid URL: {}'.format(url))
 
-        parts = parsed.path.split('/')
+        parts = parsed.path.rstrip('/').split('/')
         if 'comments' not in parts:
-            submission_id = parts[-1] if parts[-1] else parts[-2]
+            submission_id = parts[-1]
+            if '/r/' in parsed.path:
+                raise ClientException('Invalid URL (subreddit, '
+                                      'not submission): {}'.format(url))
         else:
             submission_id = parts[parts.index('comments') + 1]
 

--- a/tests/unit/models/reddit/test_submission.py
+++ b/tests/unit/models/reddit/test_submission.py
@@ -75,7 +75,9 @@ class TestSubmission(UnitTest):
         urls = ['', '1', '/', 'my.it/2gmzqe',
                 'http://my.it/_',
                 'https://redd.it/_/',
-                'http://reddit.com/comments/_/2gmzqe']
+                'http://reddit.com/comments/_/2gmzqe',
+                'https://reddit.com/r/wallpapers/',
+                'https://reddit.com/r/wallpapers']
         for url in urls:
             with pytest.raises(ClientException):
                 Submission.id_from_url(url)


### PR DESCRIPTION
Fixes https://github.com/praw-dev/praw/issues/885#issuecomment-359636839 (bboe's note in the linked comment)

## Feature Summary and Justification

This feature provides more robust parsing of URLs for submissions. Specifically, it attempts to deny subreddit links such as https://reddit.com/r/wallpapers from being turned into submission objects. This is probably an area that can be improved further in the future. 