### PR TITLE
Add support for interfacing with Reddit preferences

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,7 +20,7 @@ Unreleased
   :class:`.Submission` objects.
 * Fix bug where ``subreddit.submissions()`` returns a same submission more than
   once
-  * Fix bug where ``ListingGenerator`` fetches the same batch of submissions in
+* Fix bug where ``ListingGenerator`` fetches the same batch of submissions in
   an infinite loop when ``'before'`` parameter is provided.
 
 **Removed**

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,14 @@ Change Log
 Unreleased
 ----------
 
+**Added**
+
+* Add method :meth:`~.Reddit.patch` to :class:`.Reddit` class to support HTTP
+  PATCH requests.
+* Add class :class:`.Preferences` to access and update Reddit preferences.
+* Add attribute :attr:`.User.preferences` to access an instance of
+  :class:`.Preferences`.
+
 **Deprecated**
 
 * ``subreddit.submissions`` as the API endpoint backing the method is going

--- a/docs/code_overview/other.rst
+++ b/docs/code_overview/other.rst
@@ -61,6 +61,7 @@ instances of them bound to an attribute of one of the PRAW models.
    other/listinggenerator
    other/modmail
    other/modmailmessage
+   other/preferences
    other/redditbase
    other/redditorlist
    other/sublisting

--- a/docs/code_overview/other/preferences.rst
+++ b/docs/code_overview/other/preferences.rst
@@ -1,0 +1,5 @@
+Preferences
+===========
+
+.. autoclass:: praw.models.Preferences
+   :inherited-members:

--- a/praw/const.py
+++ b/praw/const.py
@@ -114,7 +114,7 @@ API_PATH = {
     'multireddit_update':     'api/multi/user/{user}/m/{multi}/r/{subreddit}',
     'multireddit_user':       'api/multi/user/{user}/',
     'mute_sender':            'api/mute_message_author/',
-    'prefs':                  'api/v1/me/prefs',
+    'preferences':            'api/v1/me/prefs',
     'quarantine_opt_in':      'api/quarantine_optin',
     'quarantine_opt_out':     'api/quarantine_optout',
     'read_message':           'api/read_message/',

--- a/praw/const.py
+++ b/praw/const.py
@@ -114,6 +114,7 @@ API_PATH = {
     'multireddit_update':     'api/multi/user/{user}/m/{multi}/r/{subreddit}',
     'multireddit_user':       'api/multi/user/{user}/',
     'mute_sender':            'api/mute_message_author/',
+    'prefs':                  'api/v1/me/prefs',
     'quarantine_opt_in':      'api/quarantine_optin',
     'quarantine_opt_out':     'api/quarantine_optout',
     'read_message':           'api/read_message/',

--- a/praw/models/__init__.py
+++ b/praw/models/__init__.py
@@ -27,6 +27,6 @@ from .user import User  # NOQA
 __all__ = ('Auth', 'Comment', 'DomainListing', 'Front', 'Inbox', 'Listing',
            'ListingGenerator', 'LiveHelper', 'LiveThread', 'Message',
            'ModAction', 'ModmailConversation', 'MoreComments', 'Multireddit',
-           'MultiredditHelper', 'Redditor', 'RedditorList', 'Stylesheet',
-           'Submission', 'Subreddit', 'SubredditHelper', 'SubredditMessage',
-           'Subreddits', 'User', 'WikiPage')
+           'MultiredditHelper', 'Preferences', 'Redditor', 'RedditorList',
+           'Stylesheet', 'Submission', 'Subreddit', 'SubredditHelper',
+           'SubredditMessage', 'Subreddits', 'User', 'WikiPage')

--- a/praw/models/__init__.py
+++ b/praw/models/__init__.py
@@ -8,6 +8,7 @@ from .listing.domain import DomainListing  # NOQA
 from .listing.generator import ListingGenerator  # NOQA
 from .listing.listing import Listing  # NOQA
 from .modaction import ModAction  # NOQA
+from .preferences import Preferences  # NOQA
 from .reddit.comment import Comment  # NOQA
 from .reddit.live import LiveThread, LiveUpdate  # NOQA
 from .reddit.message import Message, SubredditMessage  # NOQA

--- a/praw/models/preferences.py
+++ b/praw/models/preferences.py
@@ -89,7 +89,7 @@ class Preferences(object):
         :param hide_locationbar: Hide location bar (boolean).
         :param hide_ups: Don't show me submissions after I've upvoted them,
             except my own (boolean).
-        :param highlight_controversial: Show a dagger (†) on comments voted
+        :param highlight_controversial: Show a dagger on comments voted
             controversial (boolean).
         :param highlight_new_comments: Highlight new comments (boolean).
         :param ignore_suggested_sort: Ignore suggested sorts (boolean).

--- a/praw/models/preferences.py
+++ b/praw/models/preferences.py
@@ -8,8 +8,24 @@ class Preferences(object):
     """A class for Reddit preferences.
 
     The Preferences class provides access to the Reddit preferences of the
-    currently logged in user.
+    currently authenticated user.
     """
+
+    def __call__(self):
+        """Return the preference settings of the authenticated user as a dict.
+
+        This method is intended to be accessed as ``reddit.user.preferences()``
+        like so:
+
+        .. code-block:: python
+
+           preferences = reddit.user.preferences()
+           print(preferences['show_link_flair'])
+
+        See https://www.reddit.com/dev/api#GET_api_v1_me_prefs for the list
+        of possible values.
+        """
+        return self._reddit.get(API_PATH['preferences'])
 
     def __init__(self, reddit):
         """Create a Preferences instance.
@@ -18,23 +34,7 @@ class Preferences(object):
         """
         self._reddit = reddit
 
-    def __call__(self):
-        """Return the preference settings of the logged in user as a dict.
-
-        This is intended to be accessed as ``reddit.user.preferences()``
-        like so:
-
-        .. code-block:: python
-
-           prefs = reddit.user.preferences()
-           print(prefs['show_link_flair'])
-
-        See https://www.reddit.com/dev/api#GET_api_v1_me_prefs for the list
-        of possible values.
-        """
-        return self._reddit.get(API_PATH['prefs'])
-
-    def update(self, **prefs):
+    def update(self, **preferences):
         """Modify the specified settings.
 
         :param 3rd_party_data_personalized_ads: Allow Reddit to use data
@@ -168,9 +168,9 @@ class Preferences(object):
 
         .. code-block:: python
 
-           original_prefs = reddit.user.preferences()
-           new_prefs = reddit.user.preferences.update(invalid_param=123)
-           print(original_prefs == new_prefs)  # True; there was no change
+           original_preferences = reddit.user.preferences()
+           new_preferences = reddit.user.preferences.update(invalid_param=123)
+           print(original_preferences == new_preferences)  # True, no change
 
         .. warning:: Passing an unknown parameter name or an illegal value
                      (such as an int when a boolean is expected) does not
@@ -180,6 +180,15 @@ class Preferences(object):
                      method, which is a dict of the preferences after the
                      update action has been performed.
 
+        Some preferences have names that are not valid keyword arguments in
+        Python. To update these, construct a ``dict`` and use ``**`` to unpack
+        it as keyword arguments:
+
+        .. code-block:: python
+
+           reddit.user.preferences.update(
+                **{'3rd_party_data_personalized_ads': False})
+
         """
-        return self._reddit.patch(API_PATH['prefs'],
-                                  data=dict(json=dumps(prefs)))
+        return self._reddit.patch(API_PATH['preferences'],
+                                  data={'json': dumps(preferences)})

--- a/praw/models/preferences.py
+++ b/praw/models/preferences.py
@@ -1,0 +1,185 @@
+"""Provide the Preferences class."""
+from json import dumps
+
+from ..const import API_PATH
+
+
+class Preferences(object):
+    """A class for Reddit preferences.
+
+    The Preferences class provides access to the Reddit preferences of the
+    currently logged in user.
+    """
+
+    def __init__(self, reddit):
+        """Create a Preferences instance.
+
+        :param reddit: The Reddit instance.
+        """
+        self._reddit = reddit
+
+    def __call__(self):
+        """Return the preference settings of the logged in user as a dict.
+
+        This is intended to be accessed as ``reddit.user.preferences()``
+        like so:
+
+        .. code-block:: python
+
+           prefs = reddit.user.preferences()
+           print(prefs['show_link_flair'])
+
+        See https://www.reddit.com/dev/api#GET_api_v1_me_prefs for the list
+        of possible values.
+        """
+        return self._reddit.get(API_PATH['prefs'])
+
+    def update(self, **prefs):
+        """Modify the specified settings.
+
+        :param 3rd_party_data_personalized_ads: Allow Reddit to use data
+            provided by third-parties to show you more relevant
+            advertisements on Reddit (boolean).
+        :param 3rd_party_site_data_personalized_ads: Allow personalization
+            of advertisements using third-party website data (boolean).
+        :param 3rd_party_site_data_personalized_content: Allow personalization
+            of content using third-party website data (boolean).
+        :param activity_relevant_ads: Allow Reddit to use your activity on
+            Reddit to show you more relevant advertisements (boolean).
+        :param allow_clicktracking: Allow Reddit to log my outbound clicks
+            for personalization (boolean).
+        :param beta: I would like to beta test features for Reddit (boolean).
+        :param clickgadget: Show me links I've recently viewed (boolean).
+        :param collapse_read_messages: Collapse messages after I've read
+            them (boolean).
+        :param compress: Compress the link display (boolean).
+        :param creddit_autorenew: Use a creddit to automatically renew my
+            gold if it expires (boolean).
+        :param default_comment_sort: Default comment sort (one of
+            ``'confidence'``, ``'top'``, ``'new'``, ``'controversial'``,
+            ``'old'``, ``'random'``, ``'qa'``, ``'live'``).
+        :param domain_details: Show additional details in the domain text
+            when available, such as the source subreddit or the content
+            author's url/name (boolean).
+        :param email_digests: Send email digests (boolean).
+        :param email_messages: Send messages as emails (boolean).
+        :param email_unsubscribe_all: Unsubscribe from all emails (boolean).
+        :param enable_default_themes: Use reddit theme (boolean).
+        :param g: Location (one of ``'GLOBAL'``, ``'US'``, ``'AR'``,
+            ``'AU'``, ``'BG'``, ``'CA'``, ``'CL'``, ``'CO'``, ``'HR'``,
+            ``'CZ'``, ``'FI'``, ``'GR'``, ``'HU'``, ``'IS'``, ``'IN'``,
+            ``'IE'``, ``'JP'``, ``'MY'``, ``'MX'``, ``'NZ'``, ``'PH'``,
+            ``'PL'``, ``'PT'``, ``'PR'``, ``'RO'``, ``'RS'``, ``'SG'``,
+            ``'SE'``, ``'TW'``, ``'TH'``, ``'TR'``, ``'GB'``, ``'US_WA'``,
+            ``'US_DE'``, ``'US_DC'``, ``'US_WI'``, ``'US_WV'``, ``'US_HI'``,
+            ``'US_FL'``, ``'US_WY'``, ``'US_NH'``, ``'US_NJ'``, ``'US_NM'``,
+            ``'US_TX'``, ``'US_LA'``, ``'US_NC'``, ``'US_ND'``, ``'US_NE'``,
+            ``'US_TN'``, ``'US_NY'``, ``'US_PA'``, ``'US_CA'``, ``'US_NV'``,
+            ``'US_VA'``, ``'US_CO'``, ``'US_AK'``, ``'US_AL'``, ``'US_AR'``,
+            ``'US_VT'``, ``'US_IL'``, ``'US_GA'``, ``'US_IN'``, ``'US_IA'``,
+            ``'US_OK'``, ``'US_AZ'``, ``'US_ID'``, ``'US_CT'``, ``'US_ME'``,
+            ``'US_MD'``, ``'US_MA'``, ``'US_OH'``, ``'US_UT'``, ``'US_MO'``,
+            ``'US_MN'``, ``'US_MI'``, ``'US_RI'``, ``'US_KS'``, ``'US_MT'``,
+            ``'US_MS'``, ``'US_SC'``, ``'US_KY'``, ``'US_OR'``, ``'US_SD'``).
+        :param hide_ads: Hide ads (boolean).
+        :param hide_downs: Don't show me submissions after I've downvoted them,
+            except my own (boolean).
+        :param hide_from_robots: Don't allow search engines to index my user
+            profile (boolean).
+        :param hide_locationbar: Hide location bar (boolean).
+        :param hide_ups: Don't show me submissions after I've upvoted them,
+            except my own (boolean).
+        :param highlight_controversial: Show a dagger (†) on comments voted
+            controversial (boolean).
+        :param highlight_new_comments: Highlight new comments (boolean).
+        :param ignore_suggested_sort: Ignore suggested sorts (boolean).
+        :param in_redesign_beta: In redesign beta (boolean).
+        :param label_nsfw: Label posts that are not safe for work (boolean).
+        :param lang: Interface language (IETF language tag, underscore
+            separated).
+        :param legacy_search: Show legacy search page (boolean).
+        :param live_orangereds: Send message notifications in my browser
+            (boolean).
+        :param mark_messages_read: Mark messages as read when I open my inbox
+            (boolean).
+        :param media: Thumbnail preference (one of ``'on'``, ``'off'``,
+            ``'subreddit'``).
+        :param media_preview: Media preview preference (one of ``'on'``,
+            ``'off'``, ``'subreddit'``).
+        :param min_comment_score: Don't show me comments with a score less than
+            this number (int between ``-100`` and ``100``).
+        :param min_link_score: Don't show me submissions with a score less than
+            this number (int between ``-100`` and ``100``).
+        :param monitor_mentions: Notify me when people say my username
+            (boolean).
+        :param newwindow: Open links in a new window (boolean).
+        :param no_profanity: Don't show thumbnails or media previews for
+            anything labeled NSFW (boolean).
+        :param no_video_autoplay: Don't autoplay Reddit videos on the
+            desktop comments page (boolean).
+        :param num_comments: Display this many comments by default (int
+            between ``1`` and ``500``).
+        :param numsites: Number of links to display at once (int between ``1``
+            and ``100``).
+        :param organic: Show the spotlight box on the home feed (boolean).
+        :param other_theme: Subreddit theme to use (subreddit name).
+        :param over_18: I am over eighteen years old and willing to view adult
+            content (boolean).
+        :param private_feeds: Enable private RSS feeds (boolean).
+        :param profile_opt_out: View user profiles on desktop using legacy mode
+            (boolean).
+        :param public_votes: Make my votes public (boolean).
+        :param research: Allow my data to be used for research purposes
+            (boolean).
+        :param search_include_over_18: Include not safe for work (NSFW)
+            search results in searches (boolean).
+        :param show_flair: Show user flair (boolean).
+        :param show_gold_expiration: Show how much gold you have remaining
+            on your userpage (boolean).
+        :param show_link_flair: Show link flair (boolean).
+        :param show_promote: Show promote (boolean).
+        :param show_stylesheets: Allow subreddits to show me custom themes
+            (boolean).
+        :param show_trending: Show trending subreddits on the home feed
+            (boolean).
+        :param store_visits: Store visits (boolean)
+        :param theme_selector: Theme selector (subreddit name).
+        :param threaded_messages: Show message conversations in the inbox (
+            boolean).
+        :param threaded_modmail: Enable threaded modmail display (boolean).
+        :param top_karma_subreddits: Top karma subreddits (boolean).
+        :param use_global_defaults: Use global defaults (boolean).
+
+        Additional keyword arguments can be provided to handle new settings as
+        Reddit introduces them.
+
+        See https://www.reddit.com/dev/api#PATCH_api_v1_me_prefs for the
+        most up-to-date list of possible parameters.
+
+        This is intended to be used like so:
+
+        .. code-block:: python
+
+           reddit.user.preferences.update(show_link_flair=True)
+
+        This method returns the new state of the
+        preferences as a ``dict``, which can be used to check whether a
+        change went through.
+
+        .. code-block:: python
+
+           original_prefs = reddit.user.preferences()
+           new_prefs = reddit.user.preferences.update(invalid_param=123)
+           print(original_prefs == new_prefs)  # True; there was no change
+
+        .. warning:: Passing an unknown parameter name or an illegal value
+                     (such as an int when a boolean is expected) does not
+                     result in an error from the Reddit API. As a consequence,
+                     any invalid input will fail silently. To verify that
+                     changes have been made, use the return value of this
+                     method, which is a dict of the preferences after the
+                     update action has been performed.
+
+        """
+        return self._reddit.patch(API_PATH['prefs'],
+                                  data=dict(json=dumps(prefs)))

--- a/praw/models/user.py
+++ b/praw/models/user.py
@@ -1,10 +1,10 @@
 """Provides the User class."""
+from ..const import API_PATH
+from ..models import Preferences
 from .base import PRAWBase
 from .listing.generator import ListingGenerator
 from .reddit.redditor import Redditor
 from .reddit.subreddit import Subreddit
-from ..const import API_PATH
-from ..models import Preferences
 
 
 class User(PRAWBase):
@@ -18,8 +18,8 @@ class User(PRAWBase):
 
         .. code-block:: python
 
-           prefs = reddit.user.preferences()
-           print(prefs['show_link_flair'])
+           preferences = reddit.user.preferences()
+           print(preferences['show_link_flair'])
 
         Preferences can be updated via:
 
@@ -34,9 +34,9 @@ class User(PRAWBase):
 
         .. code-block:: python
 
-           original_prefs = reddit.user.preferences()
-           new_prefs = reddit.user.preferences.update(invalid_param=123)
-           print(original_prefs == new_prefs)  # True; there was no change
+           original_preferences = reddit.user.preferences()
+           new_preferences = reddit.user.preferences.update(invalid_param=123)
+           print(original_preferences == new_preferences)  # True, no change
 
 
         """

--- a/praw/models/user.py
+++ b/praw/models/user.py
@@ -1,13 +1,48 @@
 """Provides the User class."""
-from ..const import API_PATH
 from .base import PRAWBase
 from .listing.generator import ListingGenerator
 from .reddit.redditor import Redditor
 from .reddit.subreddit import Subreddit
+from ..const import API_PATH
+from ..models import Preferences
 
 
 class User(PRAWBase):
     """The user class provides methods for the currently authenticated user."""
+
+    @property
+    def preferences(self):
+        """Get an instance of :class:`.Preferences`.
+
+        The preferences can be accessed as a ``dict`` like so:
+
+        .. code-block:: python
+
+           prefs = reddit.user.preferences()
+           print(prefs['show_link_flair'])
+
+        Preferences can be updated via:
+
+        .. code-block:: python
+
+           reddit.user.preferences.update(show_link_flair=True)
+
+        The :meth:`.Preferences.update` method returns the new state of the
+        preferences as a ``dict``, which can be used to check whether a
+        change went through. Changes with invalid types or parameter names
+        fail silently.
+
+        .. code-block:: python
+
+           original_prefs = reddit.user.preferences()
+           new_prefs = reddit.user.preferences.update(invalid_param=123)
+           print(original_prefs == new_prefs)  # True; there was no change
+
+
+        """
+        if self._preferences is None:
+            self._preferences = Preferences(self._reddit)
+        return self._preferences
 
     def __init__(self, reddit):
         """Initialize a User instance.
@@ -16,7 +51,7 @@ class User(PRAWBase):
 
         """
         super(User, self).__init__(reddit, None)
-        self._me = None
+        self._me = self._preferences = None
 
     def blocked(self):
         """Return a RedditorList of blocked Redditors."""

--- a/praw/reddit.py
+++ b/praw/reddit.py
@@ -418,6 +418,17 @@ class Reddit(object):
             except Exception:
                 raise TypeError('Invalid URL or no posts exist')
 
+    def patch(self, path, data=None):
+        """Return parsed objects returned from a PATCH request to ``path``.
+
+        :param path: The path to fetch.
+        :param data: Dictionary, bytes, or file-like object to send in the body
+            of the request (default: None).
+
+        """
+        data = self.request('PATCH', path, data=data)
+        return self._objector.objectify(data)
+
     def post(self, path, data=None, files=None, params=None):
         """Return parsed objects returned from a POST request to ``path``.
 

--- a/tests/integration/cassettes/TestPreferences.test_update.json
+++ b/tests/integration/cassettes/TestPreferences.test_update.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2018-02-24T04:01:20",
+      "recorded_at": "2018-02-24T04:38:54",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -29,17 +29,17 @@
           "Connection": "keep-alive",
           "Content-Length": "105",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:20 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:54 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Via": "1.1 varnish",
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3627-SJC",
-          "X-Timer": "S1519444880.739720,VS0,VE856",
+          "X-Served-By": "cache-sjc3631-SJC",
+          "X-Timer": "S1519447134.865024,VS0,VE1002",
           "cache-control": "max-age=0, must-revalidate",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444879773.Z0FBQUFBQmFrT09RMzBqaDhYYk5rUS1SWV8zMG5vWHFVUHN6WUF1NjREb0c5cmtwdW5EMnJQRXpvQ0prYjVZam9QdlVKc0lzUjZMd2pzYWRPcUV1YnF4QkRZWngzX3pXQ0dEZTRjMjk5ZjUzRXJ5WE04a3lGanhPZmhCbDlUQXU1clNZZS1Nb3lqanQ; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:20 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447133904.Z0FBQUFBQmFrT3hlZjZfcnRiYkRYMUhTRlhpbk5sTXBnS0NBX2VqdDdIbWFJVXl6MGR2RXRKSy04amU0U3Riclk1OVdqeUktSTI3bS1DbkU5WkRZUUF2XzRKX1l6dmhUV0w2LXczeHBIWkZHYzhUVUJSQU03X1JCS0dUcGVicTNaZVB5STVpQnA1Rlc; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:54 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
           "x-xss-protection": "1; mode=block"
@@ -52,7 +52,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:20",
+      "recorded_at": "2018-02-24T04:38:55",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -65,7 +65,7 @@
           "Connection": "keep-alive",
           "Content-Length": "25",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444879773.Z0FBQUFBQmFrT09RMzBqaDhYYk5rUS1SWV8zMG5vWHFVUHN6WUF1NjREb0c5cmtwdW5EMnJQRXpvQ0prYjVZam9QdlVKc0lzUjZMd2pzYWRPcUV1YnF4QkRZWngzX3pXQ0dEZTRjMjk5ZjUzRXJ5WE04a3lGanhPZmhCbDlUQXU1clNZZS1Nb3lqanQ",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447133904.Z0FBQUFBQmFrT3hlZjZfcnRiYkRYMUhTRlhpbk5sTXBnS0NBX2VqdDdIbWFJVXl6MGR2RXRKSy04amU0U3Riclk1OVdqeUktSTI3bS1DbkU5WkRZUUF2XzRKX1l6dmhUV0w2LXczeHBIWkZHYzhUVUJSQU03X1JCS0dUcGVicTNaZVB5STVpQnA1Rlc",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -74,14 +74,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 50, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1684",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:20 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:55 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -89,16 +89,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444881.720913,VS0,VE92",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447135.996615,VS0,VE90",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444880756.Z0FBQUFBQmFrT09RZncwOVd5aG5FSkFvZUMzQmQ4ME9XaFc5S0EwUzBmdlpXb0RaN3ZtNFlPYTFuaDhudml0RGNOWVBHQlVVV2J0SDRucTNiby1qVUdER2dlanRXcUZwUnAzZGFnNUFyQW1Oa1ZQLVNlZXJmLUJhSnhRc01pc1VoYW5hNkh6ZEJ1VHg; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:20 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447135033.Z0FBQUFBQmFrT3hmT000SjhGd2hEajNfTS1RcVFiSzRnZnZ6dWp0cUV6RVpzSTJSdmc4dndjbVVmUFprLVpHd09hbV9NaWk5RjNkRTNPaTduSV9SRWFWSk9vV0NmSm42amFFMlBxY19wRnE4bFNaSkVhUjNDbk9zbHFsekN6UGItOW1fVkRtYVljSzk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:55 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "585.0",
-          "x-ratelimit-reset": "520",
-          "x-ratelimit-used": "15",
+          "x-ratelimit-remaining": "595.0",
+          "x-ratelimit-reset": "65",
+          "x-ratelimit-used": "5",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -109,7 +109,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:20",
+      "recorded_at": "2018-02-24T04:38:55",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -122,7 +122,7 @@
           "Connection": "keep-alive",
           "Content-Length": "53",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444880756.Z0FBQUFBQmFrT09RZncwOVd5aG5FSkFvZUMzQmQ4ME9XaFc5S0EwUzBmdlpXb0RaN3ZtNFlPYTFuaDhudml0RGNOWVBHQlVVV2J0SDRucTNiby1qVUdER2dlanRXcUZwUnAzZGFnNUFyQW1Oa1ZQLVNlZXJmLUJhSnhRc01pc1VoYW5hNkh6ZEJ1VHg",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447135033.Z0FBQUFBQmFrT3hmT000SjhGd2hEajNfTS1RcVFiSzRnZnZ6dWp0cUV6RVpzSTJSdmc4dndjbVVmUFprLVpHd09hbV9NaWk5RjNkRTNPaTduSV9SRWFWSk9vV0NmSm42amFFMlBxY19wRnE4bFNaSkVhUjNDbk9zbHFsekN6UGItOW1fVkRtYVljSzk",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -131,14 +131,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 1, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 50, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 1, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1684",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:20 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:55 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -146,16 +146,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444881.838403,VS0,VE95",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447135.117875,VS0,VE102",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444880880.Z0FBQUFBQmFrT09ROGstT1huNjl1Rl91SjNsU1dRaWRaTlFkQWxjbjktWmRGVzhyRlAyYTdac3F3X3pvd0VsdFpkMlhqYUszSmR6aFl2MG1GVVI5WGFRbjZaZGNEVlRnQjdpeVBudkRMeEFfT2NhelpxYUh2bldSOGk5RGlfUjIxMjgycDZZTlRldE8; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:20 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447135150.Z0FBQUFBQmFrT3hmcW9ncGNxTzQ4azNOWmE3NDh1ZjVYaXpZb3FxRTllVGRLS1Q1YnRnUmh4cjdDQnlrdlVtNWZHN2FHRE9JWC1wM0VhZDhxOXdxREU5UDJacFZ0Y2poTEVRbzBzWGk2Uk01M0daRWhneHBibTNKRmlDX3BxaG1HeGRSVlJmaFh4YXI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:55 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "584.0",
-          "x-ratelimit-reset": "520",
-          "x-ratelimit-used": "16",
+          "x-ratelimit-remaining": "594.0",
+          "x-ratelimit-reset": "65",
+          "x-ratelimit-used": "6",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -166,7 +166,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:21",
+      "recorded_at": "2018-02-24T04:38:55",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -179,7 +179,7 @@
           "Connection": "keep-alive",
           "Content-Length": "53",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444880880.Z0FBQUFBQmFrT09ROGstT1huNjl1Rl91SjNsU1dRaWRaTlFkQWxjbjktWmRGVzhyRlAyYTdac3F3X3pvd0VsdFpkMlhqYUszSmR6aFl2MG1GVVI5WGFRbjZaZGNEVlRnQjdpeVBudkRMeEFfT2NhelpxYUh2bldSOGk5RGlfUjIxMjgycDZZTlRldE8",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447135150.Z0FBQUFBQmFrT3hmcW9ncGNxTzQ4azNOWmE3NDh1ZjVYaXpZb3FxRTllVGRLS1Q1YnRnUmh4cjdDQnlrdlVtNWZHN2FHRE9JWC1wM0VhZDhxOXdxREU5UDJacFZ0Y2poTEVRbzBzWGk2Uk01M0daRWhneHBibTNKRmlDX3BxaG1HeGRSVlJmaFh4YXI",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -188,14 +188,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 50, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1684",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:21 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:55 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -203,16 +203,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444881.959729,VS0,VE94",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447135.246525,VS0,VE99",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444880996.Z0FBQUFBQmFrT09SdGtDTklacDlQTFZYVW54bE5iLVVnYXRjY21DM0kzX3ZhLVF1X08zRlkwTFA4Nm1MZUFhU3VlYlYyWTIzaVQzY1BHNzVZNWc0QjA3aHNVc0NRenZUbVNvNTZzblZIWG9mOE44bHdMWGcxajRkYmplWFJfTkF0ZlV6MWVpZmtkSDc; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:21 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447135283.Z0FBQUFBQmFrT3hmWHNZb1lHRWY4U3FaVkl6X2x6aV94WjdiRGpOUm5QNllYVGx6eS1ERmZXZm5DM0JWdUFCZU1SNW90MU0yNTBrWHFSbzNJMGEwdmZWRXotTl9mTmZPT3R2ZWlHUTRZZ0JERlFpOFBSVU85cU52ejVodEd5eUZBTFVUVHFvNEUxam4; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:55 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "583.0",
-          "x-ratelimit-reset": "519",
-          "x-ratelimit-used": "17",
+          "x-ratelimit-remaining": "593.0",
+          "x-ratelimit-reset": "65",
+          "x-ratelimit-used": "7",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -223,7 +223,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:21",
+      "recorded_at": "2018-02-24T04:38:55",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -236,7 +236,7 @@
           "Connection": "keep-alive",
           "Content-Length": "50",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444880996.Z0FBQUFBQmFrT09SdGtDTklacDlQTFZYVW54bE5iLVVnYXRjY21DM0kzX3ZhLVF1X08zRlkwTFA4Nm1MZUFhU3VlYlYyWTIzaVQzY1BHNzVZNWc0QjA3aHNVc0NRenZUbVNvNTZzblZIWG9mOE44bHdMWGcxajRkYmplWFJfTkF0ZlV6MWVpZmtkSDc",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447135283.Z0FBQUFBQmFrT3hmWHNZb1lHRWY4U3FaVkl6X2x6aV94WjdiRGpOUm5QNllYVGx6eS1ERmZXZm5DM0JWdUFCZU1SNW90MU0yNTBrWHFSbzNJMGEwdmZWRXotTl9mTmZPT3R2ZWlHUTRZZ0JERlFpOFBSVU85cU52ejVodEd5eUZBTFVUVHFvNEUxam4",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -245,14 +245,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 1, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 50, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 1, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1684",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:21 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:55 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -260,16 +260,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444881.080191,VS0,VE106",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447135.372499,VS0,VE98",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444881117.Z0FBQUFBQmFrT09SZTVRUWFNSy1MVm9QaWkzV0REbkpma3E5RmpXdzJfajNYVEFybVlzR2tuRzg1R05lWFZVU01yNWU0M2x4WVBKVEF0T2x0MWRXUmJLbk82Tm9vR0U4OE9oYTNRVGRWT3N3UldERGlBcktEVEtpbXpSemNxVlJKeGJBM21NZEtIQm0; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:21 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447135408.Z0FBQUFBQmFrT3hmR2YwSnVZSzRxd0tzcWoySVEtR2hDS2RKUlVqVzA4WERVZ2ZWZGdMeGhmVDJDb3M3UTYxa0xLOWJ5NzIzRGFTZnUxZ1NMb1ZyQ25aWWRpTnp6dXFOTjBfdTExN21HMW1KUktTOFBWemYyeGt0aUp0ckRQR1BaYk8zLXlyQ2NjX2U; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:55 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "582.0",
-          "x-ratelimit-reset": "519",
-          "x-ratelimit-used": "18",
+          "x-ratelimit-remaining": "592.0",
+          "x-ratelimit-reset": "65",
+          "x-ratelimit-used": "8",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -280,7 +280,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:21",
+      "recorded_at": "2018-02-24T04:38:55",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -293,7 +293,7 @@
           "Connection": "keep-alive",
           "Content-Length": "50",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444881117.Z0FBQUFBQmFrT09SZTVRUWFNSy1MVm9QaWkzV0REbkpma3E5RmpXdzJfajNYVEFybVlzR2tuRzg1R05lWFZVU01yNWU0M2x4WVBKVEF0T2x0MWRXUmJLbk82Tm9vR0U4OE9oYTNRVGRWT3N3UldERGlBcktEVEtpbXpSemNxVlJKeGJBM21NZEtIQm0",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447135408.Z0FBQUFBQmFrT3hmR2YwSnVZSzRxd0tzcWoySVEtR2hDS2RKUlVqVzA4WERVZ2ZWZGdMeGhmVDJDb3M3UTYxa0xLOWJ5NzIzRGFTZnUxZ1NMb1ZyQ25aWWRpTnp6dXFOTjBfdTExN21HMW1KUktTOFBWemYyeGt0aUp0ckRQR1BaYk8zLXlyQ2NjX2U",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -302,14 +302,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 50, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1684",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:21 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:55 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -317,16 +317,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444881.212305,VS0,VE98",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447136.514647,VS0,VE97",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444881247.Z0FBQUFBQmFrT09SVXU1M3FVc2E1ZmdnU1hVSXFGU3lrNUo1SzZRdjh0RW01ZVNuY2JOcnhCdDFjbDNPVWZ1Z3ZjeWNKbDBVZFNUR1Ewem9uQnB0SnI1VlJmdEFWR0FrbzlFZUM5RzRoZ0tTOGZjeTVVR3VMS0pTN25oRG8teU9aZFBCbF9XU3Z0RFg; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:21 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447135549.Z0FBQUFBQmFrT3hmcXlkb19PNGpSSkI2d0NmYk9qN05tdXNEV21ndDdEZk5SZmFOSHQ2dm9xbmtKTThYVG9MUmw5V1hySXV4b3ZMTkNoSlZ0VHlhRkZqZXpUdEhpdk1qdUpUUEhYczBxVzZnLWdJM0VmaXVzZDdIU3dyMDRwTjVzUlpud29iZFFCajg; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:55 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "581.0",
-          "x-ratelimit-reset": "519",
-          "x-ratelimit-used": "19",
+          "x-ratelimit-remaining": "591.0",
+          "x-ratelimit-reset": "65",
+          "x-ratelimit-used": "9",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -337,7 +337,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:21",
+      "recorded_at": "2018-02-24T04:38:55",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -350,7 +350,7 @@
           "Connection": "keep-alive",
           "Content-Length": "48",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444881247.Z0FBQUFBQmFrT09SVXU1M3FVc2E1ZmdnU1hVSXFGU3lrNUo1SzZRdjh0RW01ZVNuY2JOcnhCdDFjbDNPVWZ1Z3ZjeWNKbDBVZFNUR1Ewem9uQnB0SnI1VlJmdEFWR0FrbzlFZUM5RzRoZ0tTOGZjeTVVR3VMS0pTN25oRG8teU9aZFBCbF9XU3Z0RFg",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447135549.Z0FBQUFBQmFrT3hmcXlkb19PNGpSSkI2d0NmYk9qN05tdXNEV21ndDdEZk5SZmFOSHQ2dm9xbmtKTThYVG9MUmw5V1hySXV4b3ZMTkNoSlZ0VHlhRkZqZXpUdEhpdk1qdUpUUEhYczBxVzZnLWdJM0VmaXVzZDdIU3dyMDRwTjVzUlpud29iZFFCajg",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -359,14 +359,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 1, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 50, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 1, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1684",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:21 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:55 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -374,16 +374,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444881.339583,VS0,VE95",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447136.641153,VS0,VE105",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444881378.Z0FBQUFBQmFrT09SUmx0LVdFeDNXMjFzcmQtY2NpdHhrQnFkOFdNLTZPbE5jTHduNHAtWDFPREJUNDJDN2lJb0syVzlkaFdqUmxIMlRlNjZuSU5WWllvSnp2blc4ckNObHduY1dRRFg0bzZFQkFHMDBiX1l6d1hUWDlLS2dpaE9JVFQwZG5jNTBkTUo; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:21 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447135674.Z0FBQUFBQmFrT3hmczU5c1dYc2NXQzdaMjg4X3lvYndoOEFNVjhpaDlLbWRJb00zVHpwckdWQm83bW52TkZkUkdYbkdxb1lZalRVc0c2bEZlbl93VmNKNWE1bWw3VFFJX0tZRzZkQU83ZFIwM0plS1plcFBmdmZBMGctc18yNTZQcDR0T2xibUFWa2g; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:55 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "580.0",
-          "x-ratelimit-reset": "519",
-          "x-ratelimit-used": "20",
+          "x-ratelimit-remaining": "590.0",
+          "x-ratelimit-reset": "65",
+          "x-ratelimit-used": "10",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -394,7 +394,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:21",
+      "recorded_at": "2018-02-24T04:38:55",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -407,7 +407,7 @@
           "Connection": "keep-alive",
           "Content-Length": "48",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444881378.Z0FBQUFBQmFrT09SUmx0LVdFeDNXMjFzcmQtY2NpdHhrQnFkOFdNLTZPbE5jTHduNHAtWDFPREJUNDJDN2lJb0syVzlkaFdqUmxIMlRlNjZuSU5WWllvSnp2blc4ckNObHduY1dRRFg0bzZFQkFHMDBiX1l6d1hUWDlLS2dpaE9JVFQwZG5jNTBkTUo",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447135674.Z0FBQUFBQmFrT3hmczU5c1dYc2NXQzdaMjg4X3lvYndoOEFNVjhpaDlLbWRJb00zVHpwckdWQm83bW52TkZkUkdYbkdxb1lZalRVc0c2bEZlbl93VmNKNWE1bWw3VFFJX0tZRzZkQU83ZFIwM0plS1plcFBmdmZBMGctc18yNTZQcDR0T2xibUFWa2g",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -416,14 +416,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 50, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1684",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:21 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:55 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -431,16 +431,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444881.461160,VS0,VE96",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447136.772549,VS0,VE105",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444881496.Z0FBQUFBQmFrT09ScVpyalo2c2c0RU5UOW5XVm9vS0xzU1RMQ1hEYy1abUM3OEdraUdMUWwyVEtNc09pQngxZm1aTF9WYUVsT1Z2Nk5EeV9NeG02MVNLZ3dWX1FQVG1xNEN2Wm5FaGs3bzZOcVUxYl9wZzIwVGlTY1cycEtuR0o1MHpxVHRsbnZncFU; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:21 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447135810.Z0FBQUFBQmFrT3hmNjBQUzdkNzVRUnFncUdweGxObTNEOEtYVFJtb0lyWFhBZXY1QnZDX2xKVVZScGVXWlM5TWNoMWNpUk81VWJ6azI5aC16S0dpMzQ4MnlCN0RUR3FSWjBrZXFMQ1RKVGo1TE5xUXpCSUpXdjZYUkFJemtBY3VDYzBtTXZSZTJwZGs; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:55 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "579.0",
-          "x-ratelimit-reset": "519",
-          "x-ratelimit-used": "21",
+          "x-ratelimit-remaining": "589.0",
+          "x-ratelimit-reset": "65",
+          "x-ratelimit-used": "11",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -451,7 +451,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:21",
+      "recorded_at": "2018-02-24T04:38:56",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -464,7 +464,7 @@
           "Connection": "keep-alive",
           "Content-Length": "44",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444881496.Z0FBQUFBQmFrT09ScVpyalo2c2c0RU5UOW5XVm9vS0xzU1RMQ1hEYy1abUM3OEdraUdMUWwyVEtNc09pQngxZm1aTF9WYUVsT1Z2Nk5EeV9NeG02MVNLZ3dWX1FQVG1xNEN2Wm5FaGs3bzZOcVUxYl9wZzIwVGlTY1cycEtuR0o1MHpxVHRsbnZncFU",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447135810.Z0FBQUFBQmFrT3hmNjBQUzdkNzVRUnFncUdweGxObTNEOEtYVFJtb0lyWFhBZXY1QnZDX2xKVVZScGVXWlM5TWNoMWNpUk81VWJ6azI5aC16S0dpMzQ4MnlCN0RUR3FSWjBrZXFMQ1RKVGo1TE5xUXpCSUpXdjZYUkFJemtBY3VDYzBtTXZSZTJwZGs",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -473,14 +473,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 1, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 1, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:21 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:56 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -488,16 +488,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444882.583366,VS0,VE106",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447136.902428,VS0,VE106",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444881621.Z0FBQUFBQmFrT09Sd1Jfa3VzcU5kWmFVNy1Ed0dRaFJnUEVjVEs5WURaX196TmpGSF9qbHpPc0o1cldBSkNMMENWS0hLVWttWEV0aHVNRTF6VHkzcm5ldWFJc3hhdWVwU2JWamVVQWpyZmdOcXdHbGtqUm9ibm5NM18tcUxPWVRpSUZYS3JoSkFLdHM; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:21 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447135936.Z0FBQUFBQmFrT3hmX1VKTXNsNE1idXlNZ2NzOVR1RURsQ0J6b285UGQwTS0xZ2hNVjkwYUpIaDExLTBXakNqQzNvQngtRU1FTktGWXM1a2tVcXdpcEx2WE00SmRtTlBucF9lcURDY2xLTzFDR2tzalhWalpCbU9ZM2s0X3RoSzR4M2FLRDFEZlNWc1U; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:55 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "578.0",
-          "x-ratelimit-reset": "519",
-          "x-ratelimit-used": "22",
+          "x-ratelimit-remaining": "588.0",
+          "x-ratelimit-reset": "65",
+          "x-ratelimit-used": "12",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -508,7 +508,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:21",
+      "recorded_at": "2018-02-24T04:38:56",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -521,7 +521,7 @@
           "Connection": "keep-alive",
           "Content-Length": "44",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444881621.Z0FBQUFBQmFrT09Sd1Jfa3VzcU5kWmFVNy1Ed0dRaFJnUEVjVEs5WURaX196TmpGSF9qbHpPc0o1cldBSkNMMENWS0hLVWttWEV0aHVNRTF6VHkzcm5ldWFJc3hhdWVwU2JWamVVQWpyZmdOcXdHbGtqUm9ibm5NM18tcUxPWVRpSUZYS3JoSkFLdHM",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447135936.Z0FBQUFBQmFrT3hmX1VKTXNsNE1idXlNZ2NzOVR1RURsQ0J6b285UGQwTS0xZ2hNVjkwYUpIaDExLTBXakNqQzNvQngtRU1FTktGWXM1a2tVcXdpcEx2WE00SmRtTlBucF9lcURDY2xLTzFDR2tzalhWalpCbU9ZM2s0X3RoSzR4M2FLRDFEZlNWc1U",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -530,14 +530,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:21 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:56 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -545,16 +545,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444882.716224,VS0,VE101",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447136.034261,VS0,VE103",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444881744.Z0FBQUFBQmFrT09Sa1hvSm1ORHgxOFZLSnUzRjNiYTV3LU5fSjJIRWVPYlRrYzJxZmFpSTZpaWV2WXRQTXpRMjFJSGV2R2djWEd5WTJ6NnpYRkJ6NWVHaHF4NGdnWUlGUWVzandpYWpKRThmRGUtQWVsMXY3QXN3NUpxeHFienlaQlFHYjFaVGFFSWk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:21 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447136068.Z0FBQUFBQmFrT3hnTDZDbW54SG1MNGZpSzZjanI1R2lHQnBneW5HV2prVjc4dWlHUV9nMjFKY2ppa19Fc0RmVlNpblpFSFlRVmR5Mm5USS1XNy1iMDVzVXBHdTUycnIwSzBtUUtUb0tuamJVbTRiR0hJSzlhbmpxanBtVDEwbGxXT2J0d0oyYlpLbzU; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:56 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "577.0",
-          "x-ratelimit-reset": "519",
-          "x-ratelimit-used": "23",
+          "x-ratelimit-remaining": "587.0",
+          "x-ratelimit-reset": "64",
+          "x-ratelimit-used": "13",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -565,7 +565,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:21",
+      "recorded_at": "2018-02-24T04:38:56",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -578,7 +578,7 @@
           "Connection": "keep-alive",
           "Content-Length": "58",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444881744.Z0FBQUFBQmFrT09Sa1hvSm1ORHgxOFZLSnUzRjNiYTV3LU5fSjJIRWVPYlRrYzJxZmFpSTZpaWV2WXRQTXpRMjFJSGV2R2djWEd5WTJ6NnpYRkJ6NWVHaHF4NGdnWUlGUWVzandpYWpKRThmRGUtQWVsMXY3QXN3NUpxeHFienlaQlFHYjFaVGFFSWk",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447136068.Z0FBQUFBQmFrT3hnTDZDbW54SG1MNGZpSzZjanI1R2lHQnBneW5HV2prVjc4dWlHUV9nMjFKY2ppa19Fc0RmVlNpblpFSFlRVmR5Mm5USS1XNy1iMDVzVXBHdTUycnIwSzBtUUtUb0tuamJVbTRiR0hJSzlhbmpxanBtVDEwbGxXT2J0d0oyYlpLbzU",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -587,14 +587,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": true, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": true, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1682",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:21 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:56 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -602,16 +602,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444882.845785,VS0,VE107",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447136.167904,VS0,VE96",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444881881.Z0FBQUFBQmFrT09SdlVEYV9fMTZNRWJZVEtjaFYwMjROUm1WdGZUX2xPeEdZeTBkRFBQWHZmYmp4aC1UWjZlMHhyUnJMcjJZRHh4V0d0OFRPcTk5T2xTUHVaMW1zNk16dDRIUzFxenByWVhrVkhWWWxoWUMxWldMMkVfcHpNNnlya2NxRlhzaTN0WF8; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:21 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447136206.Z0FBQUFBQmFrT3hnbk5hY0tISHNOSGh2cnBMV0xWVmFabTlSblFfVW85ZDVVc1Nkb3h5N1d1RDI0RDNYZ29vdUJVTldCNkxyMVRWUTBSYlpCaVJJWmpRYll2cjNkSEFvUVFERERGeFFsOXhhLUNZSTY0ejFIcERLaDJyNHVaelB3NXRCR2czZFNTOVM; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:56 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "576.0",
-          "x-ratelimit-reset": "519",
-          "x-ratelimit-used": "24",
+          "x-ratelimit-remaining": "586.0",
+          "x-ratelimit-reset": "64",
+          "x-ratelimit-used": "14",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -622,7 +622,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:22",
+      "recorded_at": "2018-02-24T04:38:56",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -635,7 +635,7 @@
           "Connection": "keep-alive",
           "Content-Length": "59",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444881881.Z0FBQUFBQmFrT09SdlVEYV9fMTZNRWJZVEtjaFYwMjROUm1WdGZUX2xPeEdZeTBkRFBQWHZmYmp4aC1UWjZlMHhyUnJMcjJZRHh4V0d0OFRPcTk5T2xTUHVaMW1zNk16dDRIUzFxenByWVhrVkhWWWxoWUMxWldMMkVfcHpNNnlya2NxRlhzaTN0WF8",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447136206.Z0FBQUFBQmFrT3hnbk5hY0tISHNOSGh2cnBMV0xWVmFabTlSblFfVW85ZDVVc1Nkb3h5N1d1RDI0RDNYZ29vdUJVTldCNkxyMVRWUTBSYlpCaVJJWmpRYll2cjNkSEFvUVFERERGeFFsOXhhLUNZSTY0ejFIcERLaDJyNHVaelB3NXRCR2czZFNTOVM",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -644,14 +644,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:22 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:56 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -659,16 +659,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444882.980047,VS0,VE105",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447136.289579,VS0,VE101",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444882011.Z0FBQUFBQmFrT09TUzF0Y2JwMDA2X3dCTHExenNxOHJvWGI4cjBFUGZiWGpfWWU0MjBLaDNEZlM1Z3F6VWdsV1ZWUWNBN2pmWTNpMjVieEk5cFlYMlI2UXVRY1JkU0hwOF9QbWdsY1MwMjNqUjlteWdmTmRLclNOeGQ1MmlwcndmaXZxVGZCZGk3cmQ; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:22 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447136324.Z0FBQUFBQmFrT3hnNll3bDlZdmQ0UUdhaU0wZC1kRDdGY2doQk1qVVItaWtBY2thMGtWQ2o1aXNTcjBUR0xHV2pzRmdHMFMzOXFkLWNQNFcxRi1zM05lc3FYdVFwclg4SDhmR0lqTjhGSXlWUTVkVUZ3YXM0U2ptNFJTSkJaelZYTGs4OF9zR3lXSmE; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:56 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "575.0",
-          "x-ratelimit-reset": "518",
-          "x-ratelimit-used": "25",
+          "x-ratelimit-remaining": "585.0",
+          "x-ratelimit-reset": "64",
+          "x-ratelimit-used": "15",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -679,7 +679,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:22",
+      "recorded_at": "2018-02-24T04:38:56",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -692,7 +692,7 @@
           "Connection": "keep-alive",
           "Content-Length": "43",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444882011.Z0FBQUFBQmFrT09TUzF0Y2JwMDA2X3dCTHExenNxOHJvWGI4cjBFUGZiWGpfWWU0MjBLaDNEZlM1Z3F6VWdsV1ZWUWNBN2pmWTNpMjVieEk5cFlYMlI2UXVRY1JkU0hwOF9QbWdsY1MwMjNqUjlteWdmTmRLclNOeGQ1MmlwcndmaXZxVGZCZGk3cmQ",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447136324.Z0FBQUFBQmFrT3hnNll3bDlZdmQ0UUdhaU0wZC1kRDdGY2doQk1qVVItaWtBY2thMGtWQ2o1aXNTcjBUR0xHV2pzRmdHMFMzOXFkLWNQNFcxRi1zM05lc3FYdVFwclg4SDhmR0lqTjhGSXlWUTVkVUZ3YXM0U2ptNFJTSkJaelZYTGs4OF9zR3lXSmE",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -701,14 +701,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": true, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": true, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1682",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:22 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:56 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -716,16 +716,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444882.112408,VS0,VE102",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447136.417060,VS0,VE109",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444882151.Z0FBQUFBQmFrT09TcDJ3OHlKVV9mNFA1dHJLUTBYYWptR1cwZXZ5Y2JCQ0VuaTVROUNrRXdZaWlKbEFFMWVnSHVHOVN1dkhsaUFoTUNNVG9qRE1EYTJ3azMxaXNUTk5fVnVWM1RWVFRad3NBVTQxZmlzdnZHYVBUczI0RXNpSlFRZU1jRzVFTjVzRHM; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:22 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447136455.Z0FBQUFBQmFrT3hnZnNLZ3BJbzUzWlljM1Bjd294RDVwV2k1dWIzejROR3lLVk9QbnVQU2x4TWJUZzBlNTNDNkFTUTlRLXdwWnM5R2hMdk8yRTRkQ3FXc09yWENMTU9nSzVSUU85NndsRDE4b0pHdXZMbl91YUFWNVVRNEVmZ1JSSW5WZnRPckpzSVY; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:56 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "574.0",
-          "x-ratelimit-reset": "518",
-          "x-ratelimit-used": "26",
+          "x-ratelimit-remaining": "584.0",
+          "x-ratelimit-reset": "64",
+          "x-ratelimit-used": "16",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -736,7 +736,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:22",
+      "recorded_at": "2018-02-24T04:38:56",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -749,7 +749,7 @@
           "Connection": "keep-alive",
           "Content-Length": "44",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444882151.Z0FBQUFBQmFrT09TcDJ3OHlKVV9mNFA1dHJLUTBYYWptR1cwZXZ5Y2JCQ0VuaTVROUNrRXdZaWlKbEFFMWVnSHVHOVN1dkhsaUFoTUNNVG9qRE1EYTJ3azMxaXNUTk5fVnVWM1RWVFRad3NBVTQxZmlzdnZHYVBUczI0RXNpSlFRZU1jRzVFTjVzRHM",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447136455.Z0FBQUFBQmFrT3hnZnNLZ3BJbzUzWlljM1Bjd294RDVwV2k1dWIzejROR3lLVk9QbnVQU2x4TWJUZzBlNTNDNkFTUTlRLXdwWnM5R2hMdk8yRTRkQ3FXc09yWENMTU9nSzVSUU85NndsRDE4b0pHdXZMbl91YUFWNVVRNEVmZ1JSSW5WZnRPckpzSVY",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -758,14 +758,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:22 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:56 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -773,16 +773,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444882.240647,VS0,VE95",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447137.551899,VS0,VE95",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444882278.Z0FBQUFBQmFrT09TWTRJUWU1NjAyWElNVTRTMlVBTjRNY3VXbzFVM01zZk9vVUdNTWpLZ19Xell6dnNsdllVVUx1NlE3Ynk5dWxQYWxRM2taaTR2SnMxOVh2NzFMU2x5NGExdlJOMGNZZWszM1FyMG85RjBKbWxCbEFVMDFUcks2bVVUQ3Vfb29GV3Q; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:22 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447136574.Z0FBQUFBQmFrT3hnRFVpMWItZ3N1Nm9Lcl9oMXdQZzdtWWpVSGlJQjJ5WV81VUQ3M1Z6d0RoN1NwalRyOG10WEl4bmtXblNWY1RKZmgzSFRNZUJ3ZnBJLUJ2MGF6OVZMN2tLNGpkTFFXSGZNeFpqd3hqMWlVcTNybktXSkNtUFJWMUM4YWdmMk1HTlA; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:56 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "573.0",
-          "x-ratelimit-reset": "518",
-          "x-ratelimit-used": "27",
+          "x-ratelimit-remaining": "583.0",
+          "x-ratelimit-reset": "64",
+          "x-ratelimit-used": "17",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -793,7 +793,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:22",
+      "recorded_at": "2018-02-24T04:38:56",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -806,7 +806,7 @@
           "Connection": "keep-alive",
           "Content-Length": "50",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444882278.Z0FBQUFBQmFrT09TWTRJUWU1NjAyWElNVTRTMlVBTjRNY3VXbzFVM01zZk9vVUdNTWpLZ19Xell6dnNsdllVVUx1NlE3Ynk5dWxQYWxRM2taaTR2SnMxOVh2NzFMU2x5NGExdlJOMGNZZWszM1FyMG85RjBKbWxCbEFVMDFUcks2bVVUQ3Vfb29GV3Q",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447136574.Z0FBQUFBQmFrT3hnRFVpMWItZ3N1Nm9Lcl9oMXdQZzdtWWpVSGlJQjJ5WV81VUQ3M1Z6d0RoN1NwalRyOG10WEl4bmtXblNWY1RKZmgzSFRNZUJ3ZnBJLUJ2MGF6OVZMN2tLNGpkTFFXSGZNeFpqd3hqMWlVcTNybktXSkNtUFJWMUM4YWdmMk1HTlA",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -815,14 +815,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": true, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": true, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1682",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:22 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:56 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -830,16 +830,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444882.363650,VS0,VE107",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447137.675142,VS0,VE99",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444882399.Z0FBQUFBQmFrT09TY3I3c3FTUlhZY2tfWTg1eDZhU2NFQTdDR1o2TW50bUhlUUplT1FZNFdBMWc3dE9wUTNvcGIwUGdNZ05OcEVfUkx4QVd4OHI2UGhTZXRIeHVHZTVuS0VIeGNLdlFLRTdOMGczeVVlYnFRU29DeGFldERHeFcxd3JuaWlza3dZems; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:22 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447136710.Z0FBQUFBQmFrT3hnd0p6TUU0YUVOdW9JWXRORms4YUlLbHdmRkgwSUYyTVJmeW1nS042QmhJTUFZaWozNUYyOHJyNUhjMDE3MG9TSFRDZ2laRk9wMlhldzZhM2JPN1hKOWpFTm5GT0diUnFuYkNtTHNtSDJMOVhQS1loMklLT1hoVWt5dU1qcl9kaGI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:56 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "572.0",
-          "x-ratelimit-reset": "518",
-          "x-ratelimit-used": "28",
+          "x-ratelimit-remaining": "582.0",
+          "x-ratelimit-reset": "64",
+          "x-ratelimit-used": "18",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -850,7 +850,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:22",
+      "recorded_at": "2018-02-24T04:38:56",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -863,7 +863,7 @@
           "Connection": "keep-alive",
           "Content-Length": "51",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444882399.Z0FBQUFBQmFrT09TY3I3c3FTUlhZY2tfWTg1eDZhU2NFQTdDR1o2TW50bUhlUUplT1FZNFdBMWc3dE9wUTNvcGIwUGdNZ05OcEVfUkx4QVd4OHI2UGhTZXRIeHVHZTVuS0VIeGNLdlFLRTdOMGczeVVlYnFRU29DeGFldERHeFcxd3JuaWlza3dZems",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447136710.Z0FBQUFBQmFrT3hnd0p6TUU0YUVOdW9JWXRORms4YUlLbHdmRkgwSUYyTVJmeW1nS042QmhJTUFZaWozNUYyOHJyNUhjMDE3MG9TSFRDZ2laRk9wMlhldzZhM2JPN1hKOWpFTm5GT0diUnFuYkNtTHNtSDJMOVhQS1loMklLT1hoVWt5dU1qcl9kaGI",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -872,14 +872,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:22 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:56 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -887,16 +887,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444882.498520,VS0,VE103",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447137.798792,VS0,VE97",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444882536.Z0FBQUFBQmFrT09TUXpWVDk5a05lazU4Z19EVFZWTTc0a0xCMHdaX3VfMnUtVmdkOFJ4c2hSdTczLUNGSWZXb2tfV0tIT3ZLMG5ISFJNb2kzdlMtR3Jsall2aUFtX2QteUtXY1V2VXJ2Umh4Uk5kNy0yZjZiaGlRNjEwanc3YmtDdWVuejVZaDBHcWQ; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:22 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447136837.Z0FBQUFBQmFrT3hnM013VXFlZnBMRFFZSDVkOFk3ZDVrZDFNX0tWalYtUm5fX3ptSkRRc19iWjEteFlmMXJLSXJ0WEtlWXMwdnVnQkRueWlUcHBTQjN6V2pjd1RjWmJjbWlBc3Zxd0VkM3RlYnoyNGpkdUhQc1o4eXFUQWhSQlBjMDBtWWpHLW9JNlQ; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:56 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "571.0",
-          "x-ratelimit-reset": "518",
-          "x-ratelimit-used": "29",
+          "x-ratelimit-remaining": "581.0",
+          "x-ratelimit-reset": "64",
+          "x-ratelimit-used": "19",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -907,7 +907,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:22",
+      "recorded_at": "2018-02-24T04:38:57",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -920,7 +920,7 @@
           "Connection": "keep-alive",
           "Content-Length": "61",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444882536.Z0FBQUFBQmFrT09TUXpWVDk5a05lazU4Z19EVFZWTTc0a0xCMHdaX3VfMnUtVmdkOFJ4c2hSdTczLUNGSWZXb2tfV0tIT3ZLMG5ISFJNb2kzdlMtR3Jsall2aUFtX2QteUtXY1V2VXJ2Umh4Uk5kNy0yZjZiaGlRNjEwanc3YmtDdWVuejVZaDBHcWQ",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447136837.Z0FBQUFBQmFrT3hnM013VXFlZnBMRFFZSDVkOFk3ZDVrZDFNX0tWalYtUm5fX3ptSkRRc19iWjEteFlmMXJLSXJ0WEtlWXMwdnVnQkRueWlUcHBTQjN6V2pjd1RjWmJjbWlBc3Zxd0VkM3RlYnoyNGpkdUhQc1o4eXFUQWhSQlBjMDBtWWpHLW9JNlQ",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -929,14 +929,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": true, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": true, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1682",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:22 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:57 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -944,16 +944,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444883.629155,VS0,VE98",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447137.921176,VS0,VE97",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444882666.Z0FBQUFBQmFrT09TbGlFS2R2RktldVl5SXpPOWNKSlQ4WkJsVHo5ZFNWc1gxNzJmdC0wRVQ4Sko2eXo5bFFnREF0d0xvbmYwcWVIZ1Rucmw2bVhMOXIzMXo2Z2xQd3N5UjVfZ0ZmcVBxeXM5ZmNucW1DOExsUlNnYklJeVNRYTV2Zkptb29YejJ2OXg; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:22 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447136958.Z0FBQUFBQmFrT3hnRlhsV041T3BDNXBsQnc0S0xVemJCUzhMaWRybkhvZ3hBQVVsdlRZVmVyaGlUTW9ZTjdrREp3NHQtU2lGNlNWeElBOFVzaDY1X2RYaFNPMUpjamdlaVpYSlgtWksza2gwRnU3alJoVzd0TkdFal8tOUtueDlvQ2dGZFNqZkxFOG8; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:56 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "570.0",
-          "x-ratelimit-reset": "518",
-          "x-ratelimit-used": "30",
+          "x-ratelimit-remaining": "580.0",
+          "x-ratelimit-reset": "64",
+          "x-ratelimit-used": "20",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -964,7 +964,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:22",
+      "recorded_at": "2018-02-24T04:38:57",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -977,7 +977,7 @@
           "Connection": "keep-alive",
           "Content-Length": "62",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444882666.Z0FBQUFBQmFrT09TbGlFS2R2RktldVl5SXpPOWNKSlQ4WkJsVHo5ZFNWc1gxNzJmdC0wRVQ4Sko2eXo5bFFnREF0d0xvbmYwcWVIZ1Rucmw2bVhMOXIzMXo2Z2xQd3N5UjVfZ0ZmcVBxeXM5ZmNucW1DOExsUlNnYklJeVNRYTV2Zkptb29YejJ2OXg",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447136958.Z0FBQUFBQmFrT3hnRlhsV041T3BDNXBsQnc0S0xVemJCUzhMaWRybkhvZ3hBQVVsdlRZVmVyaGlUTW9ZTjdrREp3NHQtU2lGNlNWeElBOFVzaDY1X2RYaFNPMUpjamdlaVpYSlgtWksza2gwRnU3alJoVzd0TkdFal8tOUtueDlvQ2dGZFNqZkxFOG8",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -986,14 +986,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:22 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:57 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -1001,16 +1001,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444883.753228,VS0,VE100",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447137.043140,VS0,VE97",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444882791.Z0FBQUFBQmFrT09TY0EwREZKVkI4VG5ra29seFBBVGNDdGpkU01Kbm1ST3Z1SDdPZWZLX1BPYWRfYkllcWcyUzROQWRfeXc5VWFTenltb2tlMDN6eGJKRS1ibk1ZeXpIeGI2dk5hQktoemN5TGNmZ3dVdDZzUWctMm4tVEVtTjZVSm5SMFo2VFhRN2o; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:22 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447137065.Z0FBQUFBQmFrT3hoRDhWUV9WaVo0emljSTRqRUVKZUMxank4Y0JmcFltT3hEa2l2SDVTMlI2ZWdtM1M1aFlQUmlxWE92RVZYNGpRbnRySFdxOWduU1k0c3RYTzBrczZXOVFMSFFjSzBHU0xzVlBZV2JBdWdUdmpXbEZCR01SNGxUa2Rlc3hQdGdnd28; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:57 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "569.0",
-          "x-ratelimit-reset": "518",
-          "x-ratelimit-used": "31",
+          "x-ratelimit-remaining": "579.0",
+          "x-ratelimit-reset": "63",
+          "x-ratelimit-used": "21",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -1021,7 +1021,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:22",
+      "recorded_at": "2018-02-24T04:38:57",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -1034,7 +1034,7 @@
           "Connection": "keep-alive",
           "Content-Length": "47",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444882791.Z0FBQUFBQmFrT09TY0EwREZKVkI4VG5ra29seFBBVGNDdGpkU01Kbm1ST3Z1SDdPZWZLX1BPYWRfYkllcWcyUzROQWRfeXc5VWFTenltb2tlMDN6eGJKRS1ibk1ZeXpIeGI2dk5hQktoemN5TGNmZ3dVdDZzUWctMm4tVEVtTjZVSm5SMFo2VFhRN2o",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447137065.Z0FBQUFBQmFrT3hoRDhWUV9WaVo0emljSTRqRUVKZUMxank4Y0JmcFltT3hEa2l2SDVTMlI2ZWdtM1M1aFlQUmlxWE92RVZYNGpRbnRySFdxOWduU1k0c3RYTzBrczZXOVFMSFFjSzBHU0xzVlBZV2JBdWdUdmpXbEZCR01SNGxUa2Rlc3hQdGdnd28",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -1043,14 +1043,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": true, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": true, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1682",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:22 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:57 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -1058,16 +1058,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444883.880230,VS0,VE102",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447137.168867,VS0,VE94",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444882917.Z0FBQUFBQmFrT09TVXJYU3h2cFlnMkZXMVRkb0NOaUZVSW1Dck9FRzRPQ1kydENZMTNKTHlQeGFMU1Z1d3R3b0VFQ0NSY3BFQ0Zmam9aNHB2R2xnVkQwQ09wTnRWOURaM1VtOWZxLVNYV3A5SWNXdllpOXdQUlF1MXBWbFhqbVBpX2VtRkdEaW1PN3Q; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:22 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447137205.Z0FBQUFBQmFrT3hoZU0zbkltdEhmSVJieHlTZ28ySmFUcFFhVXdUajhUWnNmRWVWWHJJcUVValRmWEdMRThIeEFzWnBBZ2xYYnhPYk9YZFJhUmpSY3czZjA1SkFmZ0hPUVR3ckNnVjRlWHRsODc3eGN5cVVjUEt4MFdQMmhLLXdFdmRTdzJsUWpFOFo; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:57 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "568.0",
-          "x-ratelimit-reset": "518",
-          "x-ratelimit-used": "32",
+          "x-ratelimit-remaining": "578.0",
+          "x-ratelimit-reset": "63",
+          "x-ratelimit-used": "22",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -1078,7 +1078,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:23",
+      "recorded_at": "2018-02-24T04:38:57",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -1091,7 +1091,7 @@
           "Connection": "keep-alive",
           "Content-Length": "48",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444882917.Z0FBQUFBQmFrT09TVXJYU3h2cFlnMkZXMVRkb0NOaUZVSW1Dck9FRzRPQ1kydENZMTNKTHlQeGFMU1Z1d3R3b0VFQ0NSY3BFQ0Zmam9aNHB2R2xnVkQwQ09wTnRWOURaM1VtOWZxLVNYV3A5SWNXdllpOXdQUlF1MXBWbFhqbVBpX2VtRkdEaW1PN3Q",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447137205.Z0FBQUFBQmFrT3hoZU0zbkltdEhmSVJieHlTZ28ySmFUcFFhVXdUajhUWnNmRWVWWHJJcUVValRmWEdMRThIeEFzWnBBZ2xYYnhPYk9YZFJhUmpSY3czZjA1SkFmZ0hPUVR3ckNnVjRlWHRsODc3eGN5cVVjUEt4MFdQMmhLLXdFdmRTdzJsUWpFOFo",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -1100,14 +1100,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:23 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:57 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -1115,16 +1115,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444883.008112,VS0,VE102",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447137.288778,VS0,VE105",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444883042.Z0FBQUFBQmFrT09UeWRXNlhpZXhyZ3pCQmpzdXg1MW9DUUkxWWd3UDQyWmhPVTQ5ZWNfYWVnQTV6R0NSX3NYWG4ydXpTOGt3RklhMFJ2a0JwOFpDUEFJczVfcTAxWUoxNjlSTHJiVHJIQWZWTHBVWUpuSTVRcWRhMkFRUWVKVDBIcGpkZUhwRnl2T2c; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:23 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447137325.Z0FBQUFBQmFrT3hoYWp1S3BpMTh4eUdwdjA4WVdiVHJVMDBzREdSUXUtU3FTNklyMmgxUEJnTzEtbG55S1BGTUhnanlXR2FfT1pUamRBbmVsOV9KQnAxSkpDeXp3NzVWM0tnUVRJVGFhVUFzalcyQURZazhjOGQ3ZzVJbFA5YUF5MHFSQkNjZzZvZWE; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:57 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "567.0",
-          "x-ratelimit-reset": "517",
-          "x-ratelimit-used": "33",
+          "x-ratelimit-remaining": "577.0",
+          "x-ratelimit-reset": "63",
+          "x-ratelimit-used": "23",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -1135,7 +1135,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:23",
+      "recorded_at": "2018-02-24T04:38:57",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -1148,7 +1148,7 @@
           "Connection": "keep-alive",
           "Content-Length": "56",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444883042.Z0FBQUFBQmFrT09UeWRXNlhpZXhyZ3pCQmpzdXg1MW9DUUkxWWd3UDQyWmhPVTQ5ZWNfYWVnQTV6R0NSX3NYWG4ydXpTOGt3RklhMFJ2a0JwOFpDUEFJczVfcTAxWUoxNjlSTHJiVHJIQWZWTHBVWUpuSTVRcWRhMkFRUWVKVDBIcGpkZUhwRnl2T2c",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447137325.Z0FBQUFBQmFrT3hoYWp1S3BpMTh4eUdwdjA4WVdiVHJVMDBzREdSUXUtU3FTNklyMmgxUEJnTzEtbG55S1BGTUhnanlXR2FfT1pUamRBbmVsOV9KQnAxSkpDeXp3NzVWM0tnUVRJVGFhVUFzalcyQURZazhjOGQ3ZzVJbFA5YUF5MHFSQkNjZzZvZWE",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -1157,14 +1157,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": true, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": true, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1682",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:23 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:57 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -1172,16 +1172,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444883.137259,VS0,VE105",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447137.425787,VS0,VE102",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444883174.Z0FBQUFBQmFrT09UVHV5VkY3c0hEQTk2RU5MUjlxTlRYbVZTYnplT09tUy1nY21teHIzYmlobV9aT0owaXY4d01Qb1YwcmFQZTZ2blNrT2V2VGN0NlJneHBRRE5xS3pzLWNZbHRWMm9fYzNwYmpxRy0zUF93ZExCNmtjQU5teC1sNWlBT3RmNXpNYUE; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:23 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447137462.Z0FBQUFBQmFrT3hoTGJNNnBpNlp4dmFieUFXM1BFd1B4aVZOR2x0LTRUTTdCRWJIRlNPTlpiSWZGdWRiS0YwS3NManVEWjc5Q2xiNm1BaWhyMjE0ODBsdG5oTVRVT0hMVmF4MjEwUEVVOUFVcmoyUjZybEsxMEJTOWFiTzVDakNjWFJzY2syQTJUNTg; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:57 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "566.0",
-          "x-ratelimit-reset": "517",
-          "x-ratelimit-used": "34",
+          "x-ratelimit-remaining": "576.0",
+          "x-ratelimit-reset": "63",
+          "x-ratelimit-used": "24",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -1192,7 +1192,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:23",
+      "recorded_at": "2018-02-24T04:38:57",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -1205,7 +1205,7 @@
           "Connection": "keep-alive",
           "Content-Length": "57",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444883174.Z0FBQUFBQmFrT09UVHV5VkY3c0hEQTk2RU5MUjlxTlRYbVZTYnplT09tUy1nY21teHIzYmlobV9aT0owaXY4d01Qb1YwcmFQZTZ2blNrT2V2VGN0NlJneHBRRE5xS3pzLWNZbHRWMm9fYzNwYmpxRy0zUF93ZExCNmtjQU5teC1sNWlBT3RmNXpNYUE",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447137462.Z0FBQUFBQmFrT3hoTGJNNnBpNlp4dmFieUFXM1BFd1B4aVZOR2x0LTRUTTdCRWJIRlNPTlpiSWZGdWRiS0YwS3NManVEWjc5Q2xiNm1BaWhyMjE0ODBsdG5oTVRVT0hMVmF4MjEwUEVVOUFVcmoyUjZybEsxMEJTOWFiTzVDakNjWFJzY2syQTJUNTg",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -1214,14 +1214,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:23 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:57 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -1229,16 +1229,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444883.267698,VS0,VE105",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447138.555603,VS0,VE107",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444883301.Z0FBQUFBQmFrT09UYloxSHV5Mi1UekJaUDhMNmJzZTJNVnhyZkp3R2p3VG5aZXVIZnN2ZWM3aThzcW1GMG54TkMzN2E2ZElpbEZ3eUR4RDNfNFNuWVZPMXpzMldqUmFKd2lvbVBMSWE1OW9sZ1ZIZWdyeExoV3VJbXhmTTU5NU1wVVZsWV9uUm1fQ1U; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:23 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447137591.Z0FBQUFBQmFrT3hoOWR0cGgzaWJ4c2IxUGlNWXpIUUY5cDNuaHViQkxZOGlkd2RiQjQ5UXhLOEhoVF9CM3dlYWxianUtWllCWnZ1UGRsVmU5czZCaV84UXU1d0N2alpJY3JjVjFnbnRFQVhaOWJ6LTdmSWZEVnhYb3BuN3VsZnVzNXZ4c1Z3MUduaXY; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:57 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "565.0",
-          "x-ratelimit-reset": "517",
-          "x-ratelimit-used": "35",
+          "x-ratelimit-remaining": "575.0",
+          "x-ratelimit-reset": "63",
+          "x-ratelimit-used": "25",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -1249,7 +1249,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:23",
+      "recorded_at": "2018-02-24T04:38:57",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -1262,7 +1262,7 @@
           "Connection": "keep-alive",
           "Content-Length": "53",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444883301.Z0FBQUFBQmFrT09UYloxSHV5Mi1UekJaUDhMNmJzZTJNVnhyZkp3R2p3VG5aZXVIZnN2ZWM3aThzcW1GMG54TkMzN2E2ZElpbEZ3eUR4RDNfNFNuWVZPMXpzMldqUmFKd2lvbVBMSWE1OW9sZ1ZIZWdyeExoV3VJbXhmTTU5NU1wVVZsWV9uUm1fQ1U",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447137591.Z0FBQUFBQmFrT3hoOWR0cGgzaWJ4c2IxUGlNWXpIUUY5cDNuaHViQkxZOGlkd2RiQjQ5UXhLOEhoVF9CM3dlYWxianUtWllCWnZ1UGRsVmU5czZCaV84UXU1d0N2alpJY3JjVjFnbnRFQVhaOWJ6LTdmSWZEVnhYb3BuN3VsZnVzNXZ4c1Z3MUduaXY",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -1271,14 +1271,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": true, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": true, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1682",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:23 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:57 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -1286,16 +1286,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444883.398894,VS0,VE104",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447138.688038,VS0,VE106",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444883441.Z0FBQUFBQmFrT09UQmhxRzRDNUV4b2trREdUaV81N2loTmRiNExNTGxyWnhrSkhmdktLbF9wazV2TTlGUU5qLVNhUnU3bmNVRHJOUE16N3IyTnBuYXZSaVZMZWV0NjdlRkRuQ3JXakxpZUFNVTk0em56OWdXZlR2Nm5IZUYxblk5YWw3VmYtUkNhNDI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:23 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447137726.Z0FBQUFBQmFrT3hoMXU2SF9nSXZtN2t4MklZdFpXNVdDcjdtMllmeldVMElUTnR5bXYyMF9CMU9DT1BMbXBJamMyMmxUUWJ1aVUwZGQyMEZ0WEtIZXE1MGVNenFFVnBObzdWYVhDdC1BRHA5M3c3djhxSmFYQlV3Wnp0cUZxQnJYNWRLaGtnQ3ZERzc; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:57 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "564.0",
-          "x-ratelimit-reset": "517",
-          "x-ratelimit-used": "36",
+          "x-ratelimit-remaining": "574.0",
+          "x-ratelimit-reset": "63",
+          "x-ratelimit-used": "26",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -1306,7 +1306,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:23",
+      "recorded_at": "2018-02-24T04:38:57",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -1319,7 +1319,7 @@
           "Connection": "keep-alive",
           "Content-Length": "54",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444883441.Z0FBQUFBQmFrT09UQmhxRzRDNUV4b2trREdUaV81N2loTmRiNExNTGxyWnhrSkhmdktLbF9wazV2TTlGUU5qLVNhUnU3bmNVRHJOUE16N3IyTnBuYXZSaVZMZWV0NjdlRkRuQ3JXakxpZUFNVTk0em56OWdXZlR2Nm5IZUYxblk5YWw3VmYtUkNhNDI",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447137726.Z0FBQUFBQmFrT3hoMXU2SF9nSXZtN2t4MklZdFpXNVdDcjdtMllmeldVMElUTnR5bXYyMF9CMU9DT1BMbXBJamMyMmxUUWJ1aVUwZGQyMEZ0WEtIZXE1MGVNenFFVnBObzdWYVhDdC1BRHA5M3c3djhxSmFYQlV3Wnp0cUZxQnJYNWRLaGtnQ3ZERzc",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -1328,14 +1328,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:23 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:57 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -1343,16 +1343,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444884.529530,VS0,VE101",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447138.819080,VS0,VE101",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444883566.Z0FBQUFBQmFrT09USjZWd2EyRTc1bml1SHBlTmI3RTRRME1JeU44M19PdVBNU3doUVp5d0ZLNVZjdHBUeUNqa2s3ZTdBSnZ6dUllZG9SaldXTkJQS1hudEMwVWpoOUNPcTYweXctbzRGdEFVSUFPU25yQkN5cURWQlpWWFYwX28xNWNRbWRPYkhVeGw; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:23 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447137853.Z0FBQUFBQmFrT3hoVy1FQWhwYTRsa1N1TGR6NU5wSmpRS2xmc1lXeXh0X05DeGxjVld4UnZLanpqZXZ2MW82UHRoWl9xSnBHUFR0MDJwMlQzb3dyWjBpV3gwaGUtaEVma3lYTlNmaDduM0JjMlk4TFcta0dhcWpmU1phQkNmNE5SZy1jUHhoVWdQQ2Y; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:57 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "563.0",
-          "x-ratelimit-reset": "517",
-          "x-ratelimit-used": "37",
+          "x-ratelimit-remaining": "573.0",
+          "x-ratelimit-reset": "63",
+          "x-ratelimit-used": "27",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -1363,7 +1363,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:23",
+      "recorded_at": "2018-02-24T04:38:58",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -1376,7 +1376,7 @@
           "Connection": "keep-alive",
           "Content-Length": "52",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444883566.Z0FBQUFBQmFrT09USjZWd2EyRTc1bml1SHBlTmI3RTRRME1JeU44M19PdVBNU3doUVp5d0ZLNVZjdHBUeUNqa2s3ZTdBSnZ6dUllZG9SaldXTkJQS1hudEMwVWpoOUNPcTYweXctbzRGdEFVSUFPU25yQkN5cURWQlpWWFYwX28xNWNRbWRPYkhVeGw",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447137853.Z0FBQUFBQmFrT3hoVy1FQWhwYTRsa1N1TGR6NU5wSmpRS2xmc1lXeXh0X05DeGxjVld4UnZLanpqZXZ2MW82UHRoWl9xSnBHUFR0MDJwMlQzb3dyWjBpV3gwaGUtaEVma3lYTlNmaDduM0JjMlk4TFcta0dhcWpmU1phQkNmNE5SZy1jUHhoVWdQQ2Y",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -1385,14 +1385,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": true, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": true, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1682",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:23 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:58 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -1400,16 +1400,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444884.657142,VS0,VE103",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447138.945885,VS0,VE90",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444883719.Z0FBQUFBQmFrT09Ub043MmFXNFZlZ1FzeGZLSGtaOGhCVUY2RDRybF92NHFocmo4eHNybnpQRzNJcG9JekphSm0zY21CNkVybEFEYlhsRC01NS16cjYwWTVlZHVSbjJwbUxMdnNVcWQ1Z0FqSlJNYmQ3anZyamZCdTdmTGRRZ2RxTnA2VFJucHJTajA; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:23 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447137981.Z0FBQUFBQmFrT3hobmtVcHkyLXZaNXNUckpsMThmUWdqcWM4SjFEVTdzY3hqYXBmZG9aZ2w5N3k0SU1MX1NUVEtUTElHMWxKcnBoMTZ2VU0wMGQ4c2ctdGRUTEFYcTBfWUFmOXBxOGdOOHBBR24zYjd0ZjRhWnNxcXpMUVhKd3BqUnd4czVnOW81OHM; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:57 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "562.0",
-          "x-ratelimit-reset": "517",
-          "x-ratelimit-used": "38",
+          "x-ratelimit-remaining": "572.0",
+          "x-ratelimit-reset": "63",
+          "x-ratelimit-used": "28",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -1420,7 +1420,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:23",
+      "recorded_at": "2018-02-24T04:38:58",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -1433,7 +1433,7 @@
           "Connection": "keep-alive",
           "Content-Length": "53",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444883719.Z0FBQUFBQmFrT09Ub043MmFXNFZlZ1FzeGZLSGtaOGhCVUY2RDRybF92NHFocmo4eHNybnpQRzNJcG9JekphSm0zY21CNkVybEFEYlhsRC01NS16cjYwWTVlZHVSbjJwbUxMdnNVcWQ1Z0FqSlJNYmQ3anZyamZCdTdmTGRRZ2RxTnA2VFJucHJTajA",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447137981.Z0FBQUFBQmFrT3hobmtVcHkyLXZaNXNUckpsMThmUWdqcWM4SjFEVTdzY3hqYXBmZG9aZ2w5N3k0SU1MX1NUVEtUTElHMWxKcnBoMTZ2VU0wMGQ4c2ctdGRUTEFYcTBfWUFmOXBxOGdOOHBBR24zYjd0ZjRhWnNxcXpMUVhKd3BqUnd4czVnOW81OHM",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -1442,14 +1442,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:23 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:58 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -1457,16 +1457,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444884.785260,VS0,VE90",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447138.061906,VS0,VE345",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444883823.Z0FBQUFBQmFrT09UVWdKYnJoUXJucnpXQVB5QXVBRDJfYTJGU01SUWJCcjFBb2lIT1BaWmFhQkNYLUdRTmRTTUcwNWpmOVBiNUJ1c2hHai1yMFY3MWx3Ny1iNzdlSDRlcy1rUm8tcWJvSE5MLWZJaXRRRWU5R2ROYk1jUjhJMVBPMTFwM0U0TG5xMFg; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:23 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447138344.Z0FBQUFBQmFrT3hpRGZiR2Y4SG1zNEVDRjhSQ0h1N2k4ckV1ZGV1X2owb1VxdEY4SWhFaHdUd05SYS1aRmthU0tkcFdGdUN2Rm5OR2FpN1R3TXJqUi1uYTVQTUc5dm9mcFNiQ0JaY3gzeXhuaEQyTFFKaG9udWx1N0g3eXRzYmQ5VHBIV2xMc1FiQm4; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:58 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "561.0",
-          "x-ratelimit-reset": "517",
-          "x-ratelimit-used": "39",
+          "x-ratelimit-remaining": "571.0",
+          "x-ratelimit-reset": "62",
+          "x-ratelimit-used": "29",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -1477,7 +1477,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:24",
+      "recorded_at": "2018-02-24T04:38:58",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -1490,7 +1490,7 @@
           "Connection": "keep-alive",
           "Content-Length": "53",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444883823.Z0FBQUFBQmFrT09UVWdKYnJoUXJucnpXQVB5QXVBRDJfYTJGU01SUWJCcjFBb2lIT1BaWmFhQkNYLUdRTmRTTUcwNWpmOVBiNUJ1c2hHai1yMFY3MWx3Ny1iNzdlSDRlcy1rUm8tcWJvSE5MLWZJaXRRRWU5R2ROYk1jUjhJMVBPMTFwM0U0TG5xMFg",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447138344.Z0FBQUFBQmFrT3hpRGZiR2Y4SG1zNEVDRjhSQ0h1N2k4ckV1ZGV1X2owb1VxdEY4SWhFaHdUd05SYS1aRmthU0tkcFdGdUN2Rm5OR2FpN1R3TXJqUi1uYTVQTUc5dm9mcFNiQ0JaY3gzeXhuaEQyTFFKaG9udWx1N0g3eXRzYmQ5VHBIV2xMc1FiQm4",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -1499,14 +1499,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": true, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": true, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1682",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:23 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:58 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -1514,16 +1514,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444884.901101,VS0,VE94",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447138.493571,VS0,VE108",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444883936.Z0FBQUFBQmFrT09UdVdaampHSXRkdnN5QTZaRmo0el9HTFdtUGJfSE9Ia1BPa3BTelZHVFRlWUdIV19CakpqVDZOSTgzS2FIZmlJSGtGTGdKZFpZUUg1NndnaVo4ZjNHa3RlcW9obXJJMjlfOE1lT1FlRktsalVpTkV4SHRNLVlNdDNvMkR2NkZVZ0M; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:23 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447138531.Z0FBQUFBQmFrT3hpNlFrc2NkQS1rMkMyOEN1MnZYZkJiaW01STdZSHR1eFY3dXh6YVJ0V0F6dzhMcC1WQ0dKRWdHTXFqTkVzcGI4NF9jUkhnVjkzREtJYXZHOGtZSWJXdk5iTzdxbXFBR2V6c3ZjUWxraHZ5RHVqSjd1NDhob0NxQWZTSWFXWno4SlI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:58 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "560.0",
-          "x-ratelimit-reset": "517",
-          "x-ratelimit-used": "40",
+          "x-ratelimit-remaining": "570.0",
+          "x-ratelimit-reset": "62",
+          "x-ratelimit-used": "30",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -1534,7 +1534,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:24",
+      "recorded_at": "2018-02-24T04:38:58",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -1547,7 +1547,7 @@
           "Connection": "keep-alive",
           "Content-Length": "54",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444883936.Z0FBQUFBQmFrT09UdVdaampHSXRkdnN5QTZaRmo0el9HTFdtUGJfSE9Ia1BPa3BTelZHVFRlWUdIV19CakpqVDZOSTgzS2FIZmlJSGtGTGdKZFpZUUg1NndnaVo4ZjNHa3RlcW9obXJJMjlfOE1lT1FlRktsalVpTkV4SHRNLVlNdDNvMkR2NkZVZ0M",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447138531.Z0FBQUFBQmFrT3hpNlFrc2NkQS1rMkMyOEN1MnZYZkJiaW01STdZSHR1eFY3dXh6YVJ0V0F6dzhMcC1WQ0dKRWdHTXFqTkVzcGI4NF9jUkhnVjkzREtJYXZHOGtZSWJXdk5iTzdxbXFBR2V6c3ZjUWxraHZ5RHVqSjd1NDhob0NxQWZTSWFXWno4SlI",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -1556,14 +1556,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:24 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:58 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -1571,16 +1571,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444884.022822,VS0,VE97",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447139.633930,VS0,VE103",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444884058.Z0FBQUFBQmFrT09VbEdiX0dqNWI5R2xJdHZwTXpHSG5ZTnFLMHlPRkFaNXJrQWxnZUdKdHBYUl92Sk04NHlwRVN1UXNmdER0Nmw3WWIydExqZFJFYTVzdUZMMnlWaGRBaFpvZjVfX0pJSHA2RTRWVXhRSDJkc2lnVDJKWW0yMUJwaWhVUzZqcGVPWHA; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:24 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447138669.Z0FBQUFBQmFrT3hpNFV5SmVmV01hdmZXT2tCX3JyU1lqNzlVY2FxUF92bElSblJ1VDY2c2xPejlXMVNFUjA4Sy1FaS1CNkpRZGlUOWRLYkFGLWdjLWZxOExuNHVxSDFMUnVhUmY0dzltc2dxSkxjSl90dmthM3FGclQzeEY1STB5cVQzQmE4UzJEci0; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:58 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "559.0",
-          "x-ratelimit-reset": "516",
-          "x-ratelimit-used": "41",
+          "x-ratelimit-remaining": "569.0",
+          "x-ratelimit-reset": "62",
+          "x-ratelimit-used": "31",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -1591,7 +1591,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:24",
+      "recorded_at": "2018-02-24T04:38:58",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -1604,7 +1604,7 @@
           "Connection": "keep-alive",
           "Content-Length": "60",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444884058.Z0FBQUFBQmFrT09VbEdiX0dqNWI5R2xJdHZwTXpHSG5ZTnFLMHlPRkFaNXJrQWxnZUdKdHBYUl92Sk04NHlwRVN1UXNmdER0Nmw3WWIydExqZFJFYTVzdUZMMnlWaGRBaFpvZjVfX0pJSHA2RTRWVXhRSDJkc2lnVDJKWW0yMUJwaWhVUzZqcGVPWHA",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447138669.Z0FBQUFBQmFrT3hpNFV5SmVmV01hdmZXT2tCX3JyU1lqNzlVY2FxUF92bElSblJ1VDY2c2xPejlXMVNFUjA4Sy1FaS1CNkpRZGlUOWRLYkFGLWdjLWZxOExuNHVxSDFMUnVhUmY0dzltc2dxSkxjSl90dmthM3FGclQzeEY1STB5cVQzQmE4UzJEci0",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -1613,14 +1613,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": true, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": true, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1682",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:24 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:58 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -1628,16 +1628,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444884.146600,VS0,VE100",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447139.763654,VS0,VE112",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444884182.Z0FBQUFBQmFrT09VM0d0dFlYdmhJakREUWg3Z0w3T1YtVjlaM25xYWZkVDdJYjkycmV6SEhnRUR0d3BQejRfQVhQRks2T1gzWWJOYzhjWVBhY19valRNallkRDVXOUpPOHpWN2hoek1KMDZGNVo3Q2ZDTkxRZ28xeXdFQlVZWkxzTHZRNTE0MHliT2k; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:24 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447138818.Z0FBQUFBQmFrT3hpVVg3QjhyZGZoSmVpUUExSGtuWkNWTExGcGNJX3k2TlFuVTVEaFVlb1B6WUVNQUtYbXFVMm9CbDVZOGtQNml4ZE5NNE9aVUNuYVRpcjc5YnVjUlBubHNJMkRfc3hNSkFXcDZta1I5WGpYZm91RUplS1JpTHJieUJfdE9weld6NHY; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:58 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "558.0",
-          "x-ratelimit-reset": "516",
-          "x-ratelimit-used": "42",
+          "x-ratelimit-remaining": "568.0",
+          "x-ratelimit-reset": "62",
+          "x-ratelimit-used": "32",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -1648,7 +1648,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:24",
+      "recorded_at": "2018-02-24T04:38:59",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -1661,7 +1661,7 @@
           "Connection": "keep-alive",
           "Content-Length": "61",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444884182.Z0FBQUFBQmFrT09VM0d0dFlYdmhJakREUWg3Z0w3T1YtVjlaM25xYWZkVDdJYjkycmV6SEhnRUR0d3BQejRfQVhQRks2T1gzWWJOYzhjWVBhY19valRNallkRDVXOUpPOHpWN2hoek1KMDZGNVo3Q2ZDTkxRZ28xeXdFQlVZWkxzTHZRNTE0MHliT2k",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447138818.Z0FBQUFBQmFrT3hpVVg3QjhyZGZoSmVpUUExSGtuWkNWTExGcGNJX3k2TlFuVTVEaFVlb1B6WUVNQUtYbXFVMm9CbDVZOGtQNml4ZE5NNE9aVUNuYVRpcjc5YnVjUlBubHNJMkRfc3hNSkFXcDZta1I5WGpYZm91RUplS1JpTHJieUJfdE9weld6NHY",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -1670,14 +1670,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:24 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:58 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -1685,16 +1685,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444884.272815,VS0,VE96",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447139.900354,VS0,VE100",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444884307.Z0FBQUFBQmFrT09VZXBqQzBleV9WSWlTRXlyNGJtemxnQ0xvVmlJcDJ1N2h6WVRJMlF4NXRoVFJLNUNSbmJkODFwcFE0ZElwRFVLR0lxTFlwdm9hYmpUeERSRzZlUVFYRDBaeko4bkhuUDd3a1p6WHZnR2ZhcURYZW9TZ19tQVdnbUFpZlNxd3JxM1g; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:24 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447138936.Z0FBQUFBQmFrT3hpcDM1Q2JfR29VS2txclRUX3lPRDhoNzRqSUpwRXd3NG9LRnBqZ3hmaVNRMC1hazVuWFdzYlJJWnh1ZXdaSko4VGxQRVJHd0hpNzg5RExnZVA5R3VBaWM1MjhXMmxpc2FUb1dQNFZsZW11OVZqT1NSU2QwX04tbFhHTTlWMS0tWG4; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:58 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "557.0",
-          "x-ratelimit-reset": "516",
-          "x-ratelimit-used": "43",
+          "x-ratelimit-remaining": "567.0",
+          "x-ratelimit-reset": "62",
+          "x-ratelimit-used": "33",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -1705,7 +1705,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:24",
+      "recorded_at": "2018-02-24T04:38:59",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -1718,7 +1718,7 @@
           "Connection": "keep-alive",
           "Content-Length": "60",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444884307.Z0FBQUFBQmFrT09VZXBqQzBleV9WSWlTRXlyNGJtemxnQ0xvVmlJcDJ1N2h6WVRJMlF4NXRoVFJLNUNSbmJkODFwcFE0ZElwRFVLR0lxTFlwdm9hYmpUeERSRzZlUVFYRDBaeko4bkhuUDd3a1p6WHZnR2ZhcURYZW9TZ19tQVdnbUFpZlNxd3JxM1g",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447138936.Z0FBQUFBQmFrT3hpcDM1Q2JfR29VS2txclRUX3lPRDhoNzRqSUpwRXd3NG9LRnBqZ3hmaVNRMC1hazVuWFdzYlJJWnh1ZXdaSko4VGxQRVJHd0hpNzg5RExnZVA5R3VBaWM1MjhXMmxpc2FUb1dQNFZsZW11OVZqT1NSU2QwX04tbFhHTTlWMS0tWG4",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -1727,14 +1727,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": true, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": true, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1682",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:24 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:59 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -1742,16 +1742,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444884.395988,VS0,VE106",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447139.025105,VS0,VE110",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444884437.Z0FBQUFBQmFrT09VWHNLZzBST0NOR3BWM1ZscU9YcnIwLW9zcWFSb2hGUlk4ZGFjdkMzQVNETzlKMXVNU3ExQzNOMDdyN2RYWlNBbE5Vd2lKOUlwZVFYVDNFT21oZkxsVXRPZFBuTko0TzFLM29rdFFHUVlWX3prYVI0Q05ONzV5NTNkNnNHZ0ExZ20; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:24 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447139070.Z0FBQUFBQmFrT3hqUG5uLU53S2dVcWgxMTVrN3AwMDFfZ0xUTXNQY2FETEpTQUp4eHVaLUlaR3JYNDZlUjltb2RGLVJGWV85TTBPazVvUlVGZHRaMkhNOVFEX1ZTUmlYMXpCYmdFQ2d6VjdPR0FUcFoyV0pGZ2Q4VmJtUzdYblBLYWdUeVRuamlfNnE; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:59 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "556.0",
-          "x-ratelimit-reset": "516",
-          "x-ratelimit-used": "44",
+          "x-ratelimit-remaining": "566.0",
+          "x-ratelimit-reset": "61",
+          "x-ratelimit-used": "34",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -1762,7 +1762,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:24",
+      "recorded_at": "2018-02-24T04:38:59",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -1775,7 +1775,7 @@
           "Connection": "keep-alive",
           "Content-Length": "61",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444884437.Z0FBQUFBQmFrT09VWHNLZzBST0NOR3BWM1ZscU9YcnIwLW9zcWFSb2hGUlk4ZGFjdkMzQVNETzlKMXVNU3ExQzNOMDdyN2RYWlNBbE5Vd2lKOUlwZVFYVDNFT21oZkxsVXRPZFBuTko0TzFLM29rdFFHUVlWX3prYVI0Q05ONzV5NTNkNnNHZ0ExZ20",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447139070.Z0FBQUFBQmFrT3hqUG5uLU53S2dVcWgxMTVrN3AwMDFfZ0xUTXNQY2FETEpTQUp4eHVaLUlaR3JYNDZlUjltb2RGLVJGWV85TTBPazVvUlVGZHRaMkhNOVFEX1ZTUmlYMXpCYmdFQ2d6VjdPR0FUcFoyV0pGZ2Q4VmJtUzdYblBLYWdUeVRuamlfNnE",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -1784,14 +1784,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:24 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:59 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -1799,16 +1799,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444885.527951,VS0,VE101",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447139.164154,VS0,VE103",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444884569.Z0FBQUFBQmFrT09VTjIySnV3VGgyazFiV0hoaE1iNlBHMmFkVS1rMzJQVDNRT296VVdLU2lvMy01dHhtd3k5akd3aUtYZURERTVmd2RnMF9NV2xYREtmcU5qYWhPYktZeVVOYzhMNVkzR2VuS3J2czRybjZMaW1jVnVMTjhnVUh5LUkxYjVGQW1aR2w; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:24 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447139208.Z0FBQUFBQmFrT3hqU3oyaHdwTWxneGlSenAxMVg0S1ZxcmgzdHRjdlQ5ZTRMS3lVNnBlYXRXaHQ2QzJSTlRSeHBfSlRIaV9CdC1Bc1FqWkY4MzhjdTg4N1JhaS1EME1xTm1HbFFxSGUwcXA4M0twYkdvdHFfc0FGU0YtOTZueUFrRXVIN2RDR2RlSU8; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:59 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "555.0",
-          "x-ratelimit-reset": "516",
-          "x-ratelimit-used": "45",
+          "x-ratelimit-remaining": "565.0",
+          "x-ratelimit-reset": "61",
+          "x-ratelimit-used": "35",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -1819,7 +1819,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:24",
+      "recorded_at": "2018-02-24T04:38:59",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -1832,7 +1832,7 @@
           "Connection": "keep-alive",
           "Content-Length": "49",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444884569.Z0FBQUFBQmFrT09VTjIySnV3VGgyazFiV0hoaE1iNlBHMmFkVS1rMzJQVDNRT296VVdLU2lvMy01dHhtd3k5akd3aUtYZURERTVmd2RnMF9NV2xYREtmcU5qYWhPYktZeVVOYzhMNVkzR2VuS3J2czRybjZMaW1jVnVMTjhnVUh5LUkxYjVGQW1aR2w",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447139208.Z0FBQUFBQmFrT3hqU3oyaHdwTWxneGlSenAxMVg0S1ZxcmgzdHRjdlQ5ZTRMS3lVNnBlYXRXaHQ2QzJSTlRSeHBfSlRIaV9CdC1Bc1FqWkY4MzhjdTg4N1JhaS1EME1xTm1HbFFxSGUwcXA4M0twYkdvdHFfc0FGU0YtOTZueUFrRXVIN2RDR2RlSU8",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -1841,14 +1841,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": true, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": true, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1682",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:24 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:59 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -1856,16 +1856,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444885.655250,VS0,VE105",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447139.293362,VS0,VE97",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444884692.Z0FBQUFBQmFrT09VWU9iMDAwNFQwd0JkbjJTRFZWd0tiaXh4ckRRaFVXWDZJRGwwOHJWSEFmbFVWWERGVy16RmMwZWo2a3lrQzBWck1sbkZMdTQyc0pnQ0ZRcVg5UkdoSmFHMlZ2b0JfMG9sRFZ0UW5DUXBXSU95Zlh5ZUw1SEU2eVBJbVY0QWx2dFo; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:24 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447139316.Z0FBQUFBQmFrT3hqSk1xS1o1Zk1feDNLNDc5NDdBOU1hZ3N0eGlxMUlNb3dGN08wbUs0QW8tVXBMSy1BVFhhbkp0Yy1pUER5WW1KbkNHZzc2TW9ObzQ2bFAyQXphMW9uQ2ZaelFSUFBzQzlURkxYNTVBay1fMG0zWG1kejhGQTU3cTNnNWRGb1A0NS0; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:59 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "554.0",
-          "x-ratelimit-reset": "516",
-          "x-ratelimit-used": "46",
+          "x-ratelimit-remaining": "564.0",
+          "x-ratelimit-reset": "61",
+          "x-ratelimit-used": "36",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -1876,7 +1876,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:24",
+      "recorded_at": "2018-02-24T04:38:59",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -1889,7 +1889,7 @@
           "Connection": "keep-alive",
           "Content-Length": "50",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444884692.Z0FBQUFBQmFrT09VWU9iMDAwNFQwd0JkbjJTRFZWd0tiaXh4ckRRaFVXWDZJRGwwOHJWSEFmbFVWWERGVy16RmMwZWo2a3lrQzBWck1sbkZMdTQyc0pnQ0ZRcVg5UkdoSmFHMlZ2b0JfMG9sRFZ0UW5DUXBXSU95Zlh5ZUw1SEU2eVBJbVY0QWx2dFo",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447139316.Z0FBQUFBQmFrT3hqSk1xS1o1Zk1feDNLNDc5NDdBOU1hZ3N0eGlxMUlNb3dGN08wbUs0QW8tVXBMSy1BVFhhbkp0Yy1pUER5WW1KbkNHZzc2TW9ObzQ2bFAyQXphMW9uQ2ZaelFSUFBzQzlURkxYNTVBay1fMG0zWG1kejhGQTU3cTNnNWRGb1A0NS0",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -1898,14 +1898,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:24 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:59 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -1913,16 +1913,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444885.785844,VS0,VE105",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447139.417425,VS0,VE102",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444884817.Z0FBQUFBQmFrT09VSk5Cck1kOTdfaVQzLXViWi1XNGFjRUpRUEJ3R1JIbTRYNVFYMENZS2tnT0lDMXpvdHdXODJ0S2RqdElCeUVWbTFtQmRRTVBTR3N3U2lXdFk5Z21HUU9ocnBhc1R6MTFGZTJvNnUtZjY2cDVtcGliTU9hSFJZeTNBR0R2bzlGWVk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:24 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447139452.Z0FBQUFBQmFrT3hqVTIzRkpDbE9GY2RaeEpxTzZiME1sdzdySXU3eERMaGdicU8taHQ5LWptdVFRU1JRY3NaemYwa2F6SWJxeTF6ZjJnMXRiOS1DWVZhVEJDR1JyRnZzVU5pNUlmeW0zRkQ5N2JfbmN1SlU5OUVyRng1T1JrTFhyNFRsSDlIT2R1QVI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:59 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "553.0",
-          "x-ratelimit-reset": "516",
-          "x-ratelimit-used": "47",
+          "x-ratelimit-remaining": "563.0",
+          "x-ratelimit-reset": "61",
+          "x-ratelimit-used": "37",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -1933,7 +1933,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:25",
+      "recorded_at": "2018-02-24T04:38:59",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -1946,7 +1946,7 @@
           "Connection": "keep-alive",
           "Content-Length": "55",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444884817.Z0FBQUFBQmFrT09VSk5Cck1kOTdfaVQzLXViWi1XNGFjRUpRUEJ3R1JIbTRYNVFYMENZS2tnT0lDMXpvdHdXODJ0S2RqdElCeUVWbTFtQmRRTVBTR3N3U2lXdFk5Z21HUU9ocnBhc1R6MTFGZTJvNnUtZjY2cDVtcGliTU9hSFJZeTNBR0R2bzlGWVk",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447139452.Z0FBQUFBQmFrT3hqVTIzRkpDbE9GY2RaeEpxTzZiME1sdzdySXU3eERMaGdicU8taHQ5LWptdVFRU1JRY3NaemYwa2F6SWJxeTF6ZjJnMXRiOS1DWVZhVEJDR1JyRnZzVU5pNUlmeW0zRkQ5N2JfbmN1SlU5OUVyRng1T1JrTFhyNFRsSDlIT2R1QVI",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -1955,14 +1955,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": true, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": true, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1682",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:25 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:59 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -1970,16 +1970,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444885.917578,VS0,VE104",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447140.546129,VS0,VE104",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444884955.Z0FBQUFBQmFrT09VTzhEbzFnWTFMd04wTmtjYjJwXzNOZDgyTnYtbGE5U3VNelRqdlJ5R2Z5Z1JvMWxxaXFrT1h1Y0RlYk4xWnBFeURkOWFHME1nTjVWZV9sUmZtZUpwZ2NrLXh0RzQ5dy1NSkMyZkk4V0h1d0Z1dUQ1cVpuMjYtY2l6LTFRZ2pZQXc; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:24 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447139591.Z0FBQUFBQmFrT3hqTmlzcjgyeEM5TEh1NmpNTHFxaDNCRmxXZ0RBaGdlc1NVemowN0RxM09rMHAwN3dTeXY0LXlGN1J6T0NBNWpKYUFOakNsdHJFbXZxNF9MTWxmVk9uaVdyX2JyR29QSDlXeFc0M1ROYTNheGh2Uld0bUVJVkg2VXk0Ulc3TnRZQmM; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:59 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "552.0",
-          "x-ratelimit-reset": "516",
-          "x-ratelimit-used": "48",
+          "x-ratelimit-remaining": "562.0",
+          "x-ratelimit-reset": "61",
+          "x-ratelimit-used": "38",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -1990,7 +1990,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:25",
+      "recorded_at": "2018-02-24T04:38:59",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -2003,7 +2003,7 @@
           "Connection": "keep-alive",
           "Content-Length": "56",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444884955.Z0FBQUFBQmFrT09VTzhEbzFnWTFMd04wTmtjYjJwXzNOZDgyTnYtbGE5U3VNelRqdlJ5R2Z5Z1JvMWxxaXFrT1h1Y0RlYk4xWnBFeURkOWFHME1nTjVWZV9sUmZtZUpwZ2NrLXh0RzQ5dy1NSkMyZkk4V0h1d0Z1dUQ1cVpuMjYtY2l6LTFRZ2pZQXc",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447139591.Z0FBQUFBQmFrT3hqTmlzcjgyeEM5TEh1NmpNTHFxaDNCRmxXZ0RBaGdlc1NVemowN0RxM09rMHAwN3dTeXY0LXlGN1J6T0NBNWpKYUFOakNsdHJFbXZxNF9MTWxmVk9uaVdyX2JyR29QSDlXeFc0M1ROYTNheGh2Uld0bUVJVkg2VXk0Ulc3TnRZQmM",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -2012,14 +2012,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:25 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:59 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -2027,16 +2027,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444885.047710,VS0,VE102",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447140.676757,VS0,VE124",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444885082.Z0FBQUFBQmFrT09WdGo1OXVieE1PalpYb3lPeURBQnBYRWFqbm5SUXc3cFB0VGo0aUc5RVh4YVJLcXNuUmlZQ211amotSlRUVlpMNlViQl9vRWpQTktvUWtOODl5M0ZldnB5bmc4dWR0MG5hZ2w2SDQtYjdVYmMyRDJHWVRWbVhYM2FRX1RWTGpycTE; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:25 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447139711.Z0FBQUFBQmFrT3hqd25pb09lVzlYVkpYZnRVcmRnQW14WkMyWUd0WEZ2eUNKYnl4REpxbTJqZ0dsUUN5QTByeHJrU2xIYUJYR3laaWhzZXpmaWVhMjA5eHNIU2w3TnNzQTFrMjdad0RHTWdTMWQ0c3k2azlldG9GSWtRRldNT3A4YWlLd244REdlZmc; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:59 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "551.0",
-          "x-ratelimit-reset": "515",
-          "x-ratelimit-used": "49",
+          "x-ratelimit-remaining": "561.0",
+          "x-ratelimit-reset": "61",
+          "x-ratelimit-used": "39",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -2047,7 +2047,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:25",
+      "recorded_at": "2018-02-24T04:38:59",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -2060,7 +2060,7 @@
           "Connection": "keep-alive",
           "Content-Length": "55",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444885082.Z0FBQUFBQmFrT09WdGo1OXVieE1PalpYb3lPeURBQnBYRWFqbm5SUXc3cFB0VGo0aUc5RVh4YVJLcXNuUmlZQ211amotSlRUVlpMNlViQl9vRWpQTktvUWtOODl5M0ZldnB5bmc4dWR0MG5hZ2w2SDQtYjdVYmMyRDJHWVRWbVhYM2FRX1RWTGpycTE",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447139711.Z0FBQUFBQmFrT3hqd25pb09lVzlYVkpYZnRVcmRnQW14WkMyWUd0WEZ2eUNKYnl4REpxbTJqZ0dsUUN5QTByeHJrU2xIYUJYR3laaWhzZXpmaWVhMjA5eHNIU2w3TnNzQTFrMjdad0RHTWdTMWQ0c3k2azlldG9GSWtRRldNT3A4YWlLd244REdlZmc",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -2069,14 +2069,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": true, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": true, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1682",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:25 GMT",
+          "Date": "Sat, 24 Feb 2018 04:38:59 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -2084,16 +2084,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444885.176718,VS0,VE97",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447140.829857,VS0,VE96",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444885212.Z0FBQUFBQmFrT09WZ3JScnlHWk1YNkhuaWRWcjV2QjAtNGVpSGxhYzhmdjY2NHRCS1hEN0E2OTNQbWxZOTlIdFc2YnlGaEh4Q1E2S3FqcUhYZWN6dEo3bDBNX3BnRUZVV1hWYTBkakpzX0pjNmlla2lzOWJrcXhPU0FtQVdnSnczUTlNZDVRbjFjbXc; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:25 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447139867.Z0FBQUFBQmFrT3hqYkhtR0xxWTFUU3dPTlZjV2dQN1JXd1NfcDM4aVctSHlyVld0VUljRkwwQVA5VmJZRXlTSmJSSkRZMGhvQ3A0ZkhROWZyYk0tek1RY24zbW1Pb0IwTGFhdG92SlkyS0VsQk9SUW5qOFBIdklRblpmRm1qUEozeWlRSUhVdHhvM3I; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:38:59 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "550.0",
-          "x-ratelimit-reset": "515",
-          "x-ratelimit-used": "50",
+          "x-ratelimit-remaining": "560.0",
+          "x-ratelimit-reset": "61",
+          "x-ratelimit-used": "40",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -2104,7 +2104,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:25",
+      "recorded_at": "2018-02-24T04:39:00",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -2117,7 +2117,7 @@
           "Connection": "keep-alive",
           "Content-Length": "56",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444885212.Z0FBQUFBQmFrT09WZ3JScnlHWk1YNkhuaWRWcjV2QjAtNGVpSGxhYzhmdjY2NHRCS1hEN0E2OTNQbWxZOTlIdFc2YnlGaEh4Q1E2S3FqcUhYZWN6dEo3bDBNX3BnRUZVV1hWYTBkakpzX0pjNmlla2lzOWJrcXhPU0FtQVdnSnczUTlNZDVRbjFjbXc",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447139867.Z0FBQUFBQmFrT3hqYkhtR0xxWTFUU3dPTlZjV2dQN1JXd1NfcDM4aVctSHlyVld0VUljRkwwQVA5VmJZRXlTSmJSSkRZMGhvQ3A0ZkhROWZyYk0tek1RY24zbW1Pb0IwTGFhdG92SlkyS0VsQk9SUW5qOFBIdklRblpmRm1qUEozeWlRSUhVdHhvM3I",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -2126,14 +2126,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:25 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:00 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -2141,16 +2141,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444885.299637,VS0,VE102",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447140.955666,VS0,VE106",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444885336.Z0FBQUFBQmFrT09WbHBBZTQ0ZWk1NGZOblJ0bFZ2RW1PU1g3cTI1ZDd6Y19fdDBMVmZ4WGpjc0ZHNlktU2RseGE0bk91Z2hvcm9lR2FKQ2w3cFhHNHpPVXBfM2pULVJ2TjlfTzFQS2QxZkEwVTdsSWMxdElZRDFHdUE0Z0JxbE9saHBsMmIzc2hVNF8; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:25 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447139987.Z0FBQUFBQmFrT3hrRG4yT1pqX1o4SVFOTElsOFNOM2hGem9LandfT3dmZFBMRTBUdUZvbjdRY2ZWYXRFYnZ2VWdLR2JMVEtmVERmRExjbWxCUGFxMVpFWjRRQy13aWdaSHc3aHVvTS1CMndzSEh5VXNkazQzVW04NUZiZkE3UjYzTHpNa0x0RDRsa2I; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:00 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "549.0",
-          "x-ratelimit-reset": "515",
-          "x-ratelimit-used": "51",
+          "x-ratelimit-remaining": "559.0",
+          "x-ratelimit-reset": "61",
+          "x-ratelimit-used": "41",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -2161,7 +2161,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:25",
+      "recorded_at": "2018-02-24T04:39:00",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -2174,7 +2174,7 @@
           "Connection": "keep-alive",
           "Content-Length": "47",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444885336.Z0FBQUFBQmFrT09WbHBBZTQ0ZWk1NGZOblJ0bFZ2RW1PU1g3cTI1ZDd6Y19fdDBMVmZ4WGpjc0ZHNlktU2RseGE0bk91Z2hvcm9lR2FKQ2w3cFhHNHpPVXBfM2pULVJ2TjlfTzFQS2QxZkEwVTdsSWMxdElZRDFHdUE0Z0JxbE9saHBsMmIzc2hVNF8",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447139987.Z0FBQUFBQmFrT3hrRG4yT1pqX1o4SVFOTElsOFNOM2hGem9LandfT3dmZFBMRTBUdUZvbjdRY2ZWYXRFYnZ2VWdLR2JMVEtmVERmRExjbWxCUGFxMVpFWjRRQy13aWdaSHc3aHVvTS1CMndzSEh5VXNkazQzVW04NUZiZkE3UjYzTHpNa0x0RDRsa2I",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -2183,14 +2183,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": true, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": true, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1682",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:25 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:00 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -2198,16 +2198,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444885.428635,VS0,VE138",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447140.088038,VS0,VE102",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444885461.Z0FBQUFBQmFrT09WWURpaDVSbWtyOS1kN0ZHMFBYYnkyYmE2dU5ERHZqajJrMFpUaTk1UFM1UDJVWUhfaF9GV05WLVFZQW5GZW53T24yX0V1eW10SHAtZFJ4VEpETF9WRUVoM1NpdFZ0TTNiTGJBeUcxS3NOTndmd1RCZlc5RFV3dzJZalpmS2l3Q1g; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:25 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447140121.Z0FBQUFBQmFrT3hrRHh4TWRMQU1sYXBxUlNyUV9kTHlVV3JYUmtycFN6TmlJcVZZallLemJBN09QQTlWUlhDbllacEo0NXlWVVpKa2FGYjNlWjBIczVKVERSYkVQZ0JEbU4xLWpycngyODkxUThLV0lqSXJsMi1Yc0RsVlg4dDU5U3lfblFMOW9Sam0; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:00 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "548.0",
-          "x-ratelimit-reset": "515",
-          "x-ratelimit-used": "52",
+          "x-ratelimit-remaining": "558.0",
+          "x-ratelimit-reset": "60",
+          "x-ratelimit-used": "42",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -2218,7 +2218,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:25",
+      "recorded_at": "2018-02-24T04:39:00",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -2231,7 +2231,7 @@
           "Connection": "keep-alive",
           "Content-Length": "48",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444885461.Z0FBQUFBQmFrT09WWURpaDVSbWtyOS1kN0ZHMFBYYnkyYmE2dU5ERHZqajJrMFpUaTk1UFM1UDJVWUhfaF9GV05WLVFZQW5GZW53T24yX0V1eW10SHAtZFJ4VEpETF9WRUVoM1NpdFZ0TTNiTGJBeUcxS3NOTndmd1RCZlc5RFV3dzJZalpmS2l3Q1g",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447140121.Z0FBQUFBQmFrT3hrRHh4TWRMQU1sYXBxUlNyUV9kTHlVV3JYUmtycFN6TmlJcVZZallLemJBN09QQTlWUlhDbllacEo0NXlWVVpKa2FGYjNlWjBIczVKVERSYkVQZ0JEbU4xLWpycngyODkxUThLV0lqSXJsMi1Yc0RsVlg4dDU5U3lfblFMOW9Sam0",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -2240,14 +2240,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:25 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:00 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -2255,16 +2255,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444886.592838,VS0,VE101",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447140.216694,VS0,VE109",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444885629.Z0FBQUFBQmFrT09WTkdJTWN1VDVDR3NzWmZJeUY3d3BqSU4wSkZwR3pCNkhRck5PQlY1T1djb2dqRzdFT3VIUGJ6eHlDYkFIbUQ3aGZmUFBKOWczeHk4WWhYUFJfNkVPanBnYmtBMC1LUTF2ckdaUHMta0VVYVZFQ0laNFlzbGlsbkpZa1RZaEVYRm4; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:25 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447140256.Z0FBQUFBQmFrT3hrMGItM0lmWkN1SzR1M0hVTTdMY3JvUHF1d2dzeFU4Ylk2b0tyOTJwVjVlVVJHLTc4WjNEZ1lWT3R3UXBHemJ3U29MMDBZdlk2RE44WXN1cXY1ZTl2OGtzZ2ZkNFktZXdHNklmX2JLam1BZllrV3FjZ3dFdjNfc0ZhNko3cng1MGE; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:00 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "547.0",
-          "x-ratelimit-reset": "515",
-          "x-ratelimit-used": "53",
+          "x-ratelimit-remaining": "557.0",
+          "x-ratelimit-reset": "60",
+          "x-ratelimit-used": "43",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -2275,7 +2275,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:25",
+      "recorded_at": "2018-02-24T04:39:00",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -2288,7 +2288,7 @@
           "Connection": "keep-alive",
           "Content-Length": "62",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444885629.Z0FBQUFBQmFrT09WTkdJTWN1VDVDR3NzWmZJeUY3d3BqSU4wSkZwR3pCNkhRck5PQlY1T1djb2dqRzdFT3VIUGJ6eHlDYkFIbUQ3aGZmUFBKOWczeHk4WWhYUFJfNkVPanBnYmtBMC1LUTF2ckdaUHMta0VVYVZFQ0laNFlzbGlsbkpZa1RZaEVYRm4",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447140256.Z0FBQUFBQmFrT3hrMGItM0lmWkN1SzR1M0hVTTdMY3JvUHF1d2dzeFU4Ylk2b0tyOTJwVjVlVVJHLTc4WjNEZ1lWT3R3UXBHemJ3U29MMDBZdlk2RE44WXN1cXY1ZTl2OGtzZ2ZkNFktZXdHNklmX2JLam1BZllrV3FjZ3dFdjNfc0ZhNko3cng1MGE",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -2297,14 +2297,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": true, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": true, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1682",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:25 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:00 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -2312,16 +2312,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444886.721032,VS0,VE102",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447140.349522,VS0,VE107",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444885753.Z0FBQUFBQmFrT09WYnhXOGpBSTAyU3NGSklkVjhfMlNaRWJkNHJncFZKb1UzSUYwT3l1VlpPcGdVMGx5WEh1QkJvSVZJNmFNS2RWbGo4UTM2enlNSldMYnBYb29jdWY3TW5oZW9WSnRmSnNLNVJrZGhBWVAzc0RjeTFLUDBlSmxmZ3h1bUhfQlYzbVE; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:25 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447140384.Z0FBQUFBQmFrT3hrTEE5bVFzcHk2UzctMG5sNXF0SGp3b0hjYVc5WS1hdU9IdW1iT1NtUW5oRHFmaFc2WThvdHh0YWZHOW5rcDRIc2J5R0Q5MUh1cE1Vazl2bWJlWGJydFl4UGJ3ck96Q1JkV1VIYzJySUotSE5IakwzTWk4cWkwNENTZmd5Y3pNcEo; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:00 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "546.0",
-          "x-ratelimit-reset": "515",
-          "x-ratelimit-used": "54",
+          "x-ratelimit-remaining": "556.0",
+          "x-ratelimit-reset": "60",
+          "x-ratelimit-used": "44",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -2332,7 +2332,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:25",
+      "recorded_at": "2018-02-24T04:39:00",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -2345,7 +2345,7 @@
           "Connection": "keep-alive",
           "Content-Length": "63",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444885753.Z0FBQUFBQmFrT09WYnhXOGpBSTAyU3NGSklkVjhfMlNaRWJkNHJncFZKb1UzSUYwT3l1VlpPcGdVMGx5WEh1QkJvSVZJNmFNS2RWbGo4UTM2enlNSldMYnBYb29jdWY3TW5oZW9WSnRmSnNLNVJrZGhBWVAzc0RjeTFLUDBlSmxmZ3h1bUhfQlYzbVE",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447140384.Z0FBQUFBQmFrT3hrTEE5bVFzcHk2UzctMG5sNXF0SGp3b0hjYVc5WS1hdU9IdW1iT1NtUW5oRHFmaFc2WThvdHh0YWZHOW5rcDRIc2J5R0Q5MUh1cE1Vazl2bWJlWGJydFl4UGJ3ck96Q1JkV1VIYzJySUotSE5IakwzTWk4cWkwNENTZmd5Y3pNcEo",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -2354,14 +2354,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:25 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:00 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -2369,16 +2369,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444886.853315,VS0,VE106",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447140.481407,VS0,VE97",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444885905.Z0FBQUFBQmFrT09WZWl5bEdTU3FQaER3QWM5SVJYeEhrZ2lrN3RXLTdXMlJ0Mk9SWGdJM3o4RWRqMzg3MHdEejQyWmFnV0tzd2hzdEozUlZoMFpab0pTejFvWTdfcmhkalZuTlg3cEc2WUkyRVNRWkhKcnAyZUxkdkxLY1N1WGhFUHp2RTM4T29uTGw; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:25 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447140519.Z0FBQUFBQmFrT3hrVkVhQ0VhdDNTRkJYRUF1ZHdDNnQzNHhZRTRzblNjVlZIeGFaQ3NFQVJ3VG0wektUc1BndXNyNTYtcV9TclF4SGVsNVljZDJOaFFXbXUwd014YUtUbE82aVpUcWdldUw4cmktQWdpeGpjX0ZmQmRyMnRzYk1SUDJIdnVwUjE4VkU; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:00 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "545.0",
-          "x-ratelimit-reset": "515",
-          "x-ratelimit-used": "55",
+          "x-ratelimit-remaining": "555.0",
+          "x-ratelimit-reset": "60",
+          "x-ratelimit-used": "45",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -2389,7 +2389,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:26",
+      "recorded_at": "2018-02-24T04:39:00",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -2402,7 +2402,7 @@
           "Connection": "keep-alive",
           "Content-Length": "61",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444885905.Z0FBQUFBQmFrT09WZWl5bEdTU3FQaER3QWM5SVJYeEhrZ2lrN3RXLTdXMlJ0Mk9SWGdJM3o4RWRqMzg3MHdEejQyWmFnV0tzd2hzdEozUlZoMFpab0pTejFvWTdfcmhkalZuTlg3cEc2WUkyRVNRWkhKcnAyZUxkdkxLY1N1WGhFUHp2RTM4T29uTGw",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447140519.Z0FBQUFBQmFrT3hrVkVhQ0VhdDNTRkJYRUF1ZHdDNnQzNHhZRTRzblNjVlZIeGFaQ3NFQVJ3VG0wektUc1BndXNyNTYtcV9TclF4SGVsNVljZDJOaFFXbXUwd014YUtUbE82aVpUcWdldUw4cmktQWdpeGpjX0ZmQmRyMnRzYk1SUDJIdnVwUjE4VkU",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -2411,14 +2411,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": true, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": true, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1682",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:26 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:00 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -2426,16 +2426,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444886.994060,VS0,VE95",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447141.605213,VS0,VE104",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444886030.Z0FBQUFBQmFrT09XN0IxMTZDblFnRHRHVGhUU1lvVXYyWU5hckpsZEEyVkFIa2JXaGpnTWJqaVNPcTdIQ2pzX010NGRYSG5ULWF2RmZFRXJieXp3SjRqckl6NHBNWWJGcElLVFV4a3Q5SWEzc1FGcUlCT05qSFNPZ3ZWZDRtaTJJRkc1eXVUS2NtbGQ; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:26 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447140641.Z0FBQUFBQmFrT3hrcW9FcXdpRG5VXzViM2tzTi0tRThXeWNkMlo4cG9NdGt3R0xJaTdhRHN6SkZ4TkhYb1N4Q2IwOUtGMFd2aHdJa3BRQzBHeUpUeTJZcHN6YWNQQ0JkbG5Qb0h6bHNGVG5ESlZXbVpxLUdQU2hJazJGX3FaSG5NY2RaamE4UnpSa3A; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:00 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "544.0",
-          "x-ratelimit-reset": "514",
-          "x-ratelimit-used": "56",
+          "x-ratelimit-remaining": "554.0",
+          "x-ratelimit-reset": "60",
+          "x-ratelimit-used": "46",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -2446,7 +2446,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:26",
+      "recorded_at": "2018-02-24T04:39:00",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -2459,7 +2459,7 @@
           "Connection": "keep-alive",
           "Content-Length": "62",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444886030.Z0FBQUFBQmFrT09XN0IxMTZDblFnRHRHVGhUU1lvVXYyWU5hckpsZEEyVkFIa2JXaGpnTWJqaVNPcTdIQ2pzX010NGRYSG5ULWF2RmZFRXJieXp3SjRqckl6NHBNWWJGcElLVFV4a3Q5SWEzc1FGcUlCT05qSFNPZ3ZWZDRtaTJJRkc1eXVUS2NtbGQ",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447140641.Z0FBQUFBQmFrT3hrcW9FcXdpRG5VXzViM2tzTi0tRThXeWNkMlo4cG9NdGt3R0xJaTdhRHN6SkZ4TkhYb1N4Q2IwOUtGMFd2aHdJa3BRQzBHeUpUeTJZcHN6YWNQQ0JkbG5Qb0h6bHNGVG5ESlZXbVpxLUdQU2hJazJGX3FaSG5NY2RaamE4UnpSa3A",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -2468,14 +2468,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:26 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:00 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -2483,16 +2483,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444886.127470,VS0,VE97",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447141.734473,VS0,VE244",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444886159.Z0FBQUFBQmFrT09XYTMtbkVCN1JPWDk0OXNQNzVPUWZKWDBYWTdXY21neGFVUUxyY1MyZkhaanRROWp1SVcyMDVNcjNEYkRzOGtsVHpSVjN2OUZRaHNDcVJBQ2lXdzdRRmpuWXRmUmlpanhtREhTaFQwOVB1RDJ1cV9rbnlDMHk0UVR2MUZuN1RHeEw; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:26 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447140770.Z0FBQUFBQmFrT3hrX0JiVHJrYlZwSS1VWl9RRTYxRGhuU1VKRHVGblhLa0pScXNJOTVyNW1pZEtuejBQdTY4emQyaUEydW0weXUxWm9fbGl3SEVYODYtRGxfeS14LVRsMUZRQzBlZUFBRWI3R1QxSTF3RnZlazdRODJ3MEU3eEFxOU5rVzVTWDYyMTM; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:00 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "543.0",
-          "x-ratelimit-reset": "514",
-          "x-ratelimit-used": "57",
+          "x-ratelimit-remaining": "553.0",
+          "x-ratelimit-reset": "60",
+          "x-ratelimit-used": "47",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -2503,7 +2503,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:26",
+      "recorded_at": "2018-02-24T04:39:01",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -2516,7 +2516,7 @@
           "Connection": "keep-alive",
           "Content-Length": "60",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444886159.Z0FBQUFBQmFrT09XYTMtbkVCN1JPWDk0OXNQNzVPUWZKWDBYWTdXY21neGFVUUxyY1MyZkhaanRROWp1SVcyMDVNcjNEYkRzOGtsVHpSVjN2OUZRaHNDcVJBQ2lXdzdRRmpuWXRmUmlpanhtREhTaFQwOVB1RDJ1cV9rbnlDMHk0UVR2MUZuN1RHeEw",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447140770.Z0FBQUFBQmFrT3hrX0JiVHJrYlZwSS1VWl9RRTYxRGhuU1VKRHVGblhLa0pScXNJOTVyNW1pZEtuejBQdTY4emQyaUEydW0weXUxWm9fbGl3SEVYODYtRGxfeS14LVRsMUZRQzBlZUFBRWI3R1QxSTF3RnZlazdRODJ3MEU3eEFxOU5rVzVTWDYyMTM",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -2525,14 +2525,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": true, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": true, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1682",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:26 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:01 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -2540,16 +2540,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444886.263970,VS0,VE105",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447141.005291,VS0,VE97",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444886299.Z0FBQUFBQmFrT09XSVl0el9FU3lQSnNrMEdLZFVsaUE2RFBkSW1GQi1oU0dzRm5WdlRhS0I5cjIxVkJ3bmNlMkhYRWRkTjNZZXlfMmJleERBRUc4YlFuWVoxQUx4ZUdtbEUzR0pqT09hal9XVWVLaHF1THkxc1Y5cXpCalA1emIzNGJSRmF1V0dZV1o; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:26 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447141039.Z0FBQUFBQmFrT3hsMWhMQkt0ZXNVa0hMUkJqbGRxdTJZcGlFTVJfQW1qbjZNSEhCaFZoLVdoTEhvYmpBa2ExVHRObWozdU8xOTN6VTE0VndZZ3poVUoyS09PblhYZHowOExRYXZkb1lWUlVRblVEcElCUF9DcXluOV8tZTNwTERzOGMtZWE3ei1YQ04; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:01 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "542.0",
-          "x-ratelimit-reset": "514",
-          "x-ratelimit-used": "58",
+          "x-ratelimit-remaining": "552.0",
+          "x-ratelimit-reset": "59",
+          "x-ratelimit-used": "48",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -2560,7 +2560,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:26",
+      "recorded_at": "2018-02-24T04:39:01",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -2573,7 +2573,7 @@
           "Connection": "keep-alive",
           "Content-Length": "61",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444886299.Z0FBQUFBQmFrT09XSVl0el9FU3lQSnNrMEdLZFVsaUE2RFBkSW1GQi1oU0dzRm5WdlRhS0I5cjIxVkJ3bmNlMkhYRWRkTjNZZXlfMmJleERBRUc4YlFuWVoxQUx4ZUdtbEUzR0pqT09hal9XVWVLaHF1THkxc1Y5cXpCalA1emIzNGJSRmF1V0dZV1o",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447141039.Z0FBQUFBQmFrT3hsMWhMQkt0ZXNVa0hMUkJqbGRxdTJZcGlFTVJfQW1qbjZNSEhCaFZoLVdoTEhvYmpBa2ExVHRObWozdU8xOTN6VTE0VndZZ3poVUoyS09PblhYZHowOExRYXZkb1lWUlVRblVEcElCUF9DcXluOV8tZTNwTERzOGMtZWE3ei1YQ04",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -2582,14 +2582,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:26 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:01 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -2597,16 +2597,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444886.395308,VS0,VE105",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447141.138078,VS0,VE104",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444886431.Z0FBQUFBQmFrT09XRkxaM1FlVWhEWnFYcnd2bFYtbE96VHE1ZGhKcWZRTGFTQVE0NHhIOHVTRFNvbzRTTk5UVl9GYXFWOVQxdktTcDJGOXd6dThWNWU3bFVxQnBITmxpUjliT1dZb3R4bm9qQTdvRlFMMFRjTWNkSlhUZERCX1psbWx4RHNKSjRnc2U; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:26 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447141175.Z0FBQUFBQmFrT3hsZVhYVnFReFdUNUd0YUJKY19fZEFZaXNQTlh2V2ItcGRQcmFtWHdKeEp3aEVWa1VOTFlPVDRrdFRzclZhWUJ3TU5zVDM4U0o5T1NSMFBMREtoaWthNlN1WW9GWG51a0VPWTdIVVdHZldlY182WWl6UE1hd3hiMEgxZUx3X3VwWG4; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:01 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "541.0",
-          "x-ratelimit-reset": "514",
-          "x-ratelimit-used": "59",
+          "x-ratelimit-remaining": "551.0",
+          "x-ratelimit-reset": "59",
+          "x-ratelimit-used": "49",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -2617,7 +2617,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:26",
+      "recorded_at": "2018-02-24T04:39:01",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -2630,7 +2630,7 @@
           "Connection": "keep-alive",
           "Content-Length": "52",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444886431.Z0FBQUFBQmFrT09XRkxaM1FlVWhEWnFYcnd2bFYtbE96VHE1ZGhKcWZRTGFTQVE0NHhIOHVTRFNvbzRTTk5UVl9GYXFWOVQxdktTcDJGOXd6dThWNWU3bFVxQnBITmxpUjliT1dZb3R4bm9qQTdvRlFMMFRjTWNkSlhUZERCX1psbWx4RHNKSjRnc2U",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447141175.Z0FBQUFBQmFrT3hsZVhYVnFReFdUNUd0YUJKY19fZEFZaXNQTlh2V2ItcGRQcmFtWHdKeEp3aEVWa1VOTFlPVDRrdFRzclZhWUJ3TU5zVDM4U0o5T1NSMFBMREtoaWthNlN1WW9GWG51a0VPWTdIVVdHZldlY182WWl6UE1hd3hiMEgxZUx3X3VwWG4",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -2639,14 +2639,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": true, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": true, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1682",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:26 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:01 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -2654,16 +2654,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444887.525271,VS0,VE104",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447141.269664,VS0,VE172",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444886577.Z0FBQUFBQmFrT09XSmxraG5oUFNSMUF0eXh1eXp5U2ZLUkRSU2pNaUJKUDZxQWdLV1JtRktqS1Z0Mjc0MGNHdWt2R2kxcjVqTURoQkd6SFMwTTRlLVRiSVFUUmdjLWF0Znc4X01EakF3cm8wYlFzNUhTVlIzRmhmZFBCV3R1UXIzUXBSZ0JGN0tQXzE; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:26 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447141307.Z0FBQUFBQmFrT3hsQWw4bzNMOVBBTUZCcFYyd1g4NEtfYXJEMUJHalRoaWtnaTFHUm5zekFSVl9ic3ItaEd2ZDlNUmRlS2VpNUpfclY2b2llb2QyaXZZNVJ1c05GY01fb0pWNU9Id1Vsa1hzaTZ1aEpPZTY1Y2ZBeFRCWlB3Vk1GMEFNUmlVbGNrWXM; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:01 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "540.0",
-          "x-ratelimit-reset": "514",
-          "x-ratelimit-used": "60",
+          "x-ratelimit-remaining": "550.0",
+          "x-ratelimit-reset": "59",
+          "x-ratelimit-used": "50",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -2674,7 +2674,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:26",
+      "recorded_at": "2018-02-24T04:39:01",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -2687,7 +2687,7 @@
           "Connection": "keep-alive",
           "Content-Length": "53",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444886577.Z0FBQUFBQmFrT09XSmxraG5oUFNSMUF0eXh1eXp5U2ZLUkRSU2pNaUJKUDZxQWdLV1JtRktqS1Z0Mjc0MGNHdWt2R2kxcjVqTURoQkd6SFMwTTRlLVRiSVFUUmdjLWF0Znc4X01EakF3cm8wYlFzNUhTVlIzRmhmZFBCV3R1UXIzUXBSZ0JGN0tQXzE",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447141307.Z0FBQUFBQmFrT3hsQWw4bzNMOVBBTUZCcFYyd1g4NEtfYXJEMUJHalRoaWtnaTFHUm5zekFSVl9ic3ItaEd2ZDlNUmRlS2VpNUpfclY2b2llb2QyaXZZNVJ1c05GY01fb0pWNU9Id1Vsa1hzaTZ1aEpPZTY1Y2ZBeFRCWlB3Vk1GMEFNUmlVbGNrWXM",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -2696,14 +2696,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:26 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:01 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -2711,16 +2711,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444887.655194,VS0,VE95",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447141.468443,VS0,VE103",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444886691.Z0FBQUFBQmFrT09XOExOWUhUd3c2NExGRWg1WmxTMHdZVzBPeXA4dHR2QTNaT09ETVhGUFBXUHZiYmtMblhxMEVsQ0lCR0dBN2dRVHJOd1VfQ0p5X3NDY1J5WjMteGN2YWhUd0xibkg1Y2pnaVNpMHlQdjJfdk9RcjJad01iMzE0U2JyWDBLc0JUU0M; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:26 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447141492.Z0FBQUFBQmFrT3hsYzdKT2xxeHVuZW9vcGxWQnRPcWFfWGloZjVITUtGN3VCc1hRaTlQMl9sVnZDZWhRUGJXdkczX09IenlRSHh1REtTZlczVnBqRXI1eWdDSXBKQldKTk52TUozakdOQmtXRmdJLVM0cEEyUzVscFBCSm9HSHNFaGhWVEdCV000am0; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:01 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "539.0",
-          "x-ratelimit-reset": "514",
-          "x-ratelimit-used": "61",
+          "x-ratelimit-remaining": "549.0",
+          "x-ratelimit-reset": "59",
+          "x-ratelimit-used": "51",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -2731,7 +2731,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:26",
+      "recorded_at": "2018-02-24T04:39:01",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -2744,7 +2744,7 @@
           "Connection": "keep-alive",
           "Content-Length": "54",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444886691.Z0FBQUFBQmFrT09XOExOWUhUd3c2NExGRWg1WmxTMHdZVzBPeXA4dHR2QTNaT09ETVhGUFBXUHZiYmtMblhxMEVsQ0lCR0dBN2dRVHJOd1VfQ0p5X3NDY1J5WjMteGN2YWhUd0xibkg1Y2pnaVNpMHlQdjJfdk9RcjJad01iMzE0U2JyWDBLc0JUU0M",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447141492.Z0FBQUFBQmFrT3hsYzdKT2xxeHVuZW9vcGxWQnRPcWFfWGloZjVITUtGN3VCc1hRaTlQMl9sVnZDZWhRUGJXdkczX09IenlRSHh1REtTZlczVnBqRXI1eWdDSXBKQldKTk52TUozakdOQmtXRmdJLVM0cEEyUzVscFBCSm9HSHNFaGhWVEdCV000am0",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -2753,14 +2753,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": true, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": true, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1682",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:26 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:01 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -2768,16 +2768,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444887.777098,VS0,VE106",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447142.598231,VS0,VE97",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444886812.Z0FBQUFBQmFrT09XWVJYVEZHNWZUWlR2d01zNzc2T1dsSU5INlFpUTBxZFB2VU94TENEZ0wyckNMSWY3MWNFYV93Y0NWRVp0MzR4ZFhxZXptTlpnUW1xdWY5Rkp4dnpYRDBnbVZFSkQtWFBvUmpJNXpzWEk0cVVtWUJFSW1GWC1fVkV0Q00zZk92S2k; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:26 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447141633.Z0FBQUFBQmFrT3hsbk1GRFU5UkY3VDdMYVJwZlhfNjZwZHBQUTRCTEwyc0x1b1dpSnhvNjMxX2tQb1g4WkM1QVFkclBpcEJvc1ZrQmFSWjUyODVBOXFIa0o5V3JHQjVHc0FXUWtLTEVTcFRqYURaMW9XNmhYbkdqNEZId3JsaUZzVjNkNldKMVV6dE4; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:01 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "538.0",
-          "x-ratelimit-reset": "514",
-          "x-ratelimit-used": "62",
+          "x-ratelimit-remaining": "548.0",
+          "x-ratelimit-reset": "59",
+          "x-ratelimit-used": "52",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -2788,7 +2788,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:27",
+      "recorded_at": "2018-02-24T04:39:01",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -2801,7 +2801,7 @@
           "Connection": "keep-alive",
           "Content-Length": "55",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444886812.Z0FBQUFBQmFrT09XWVJYVEZHNWZUWlR2d01zNzc2T1dsSU5INlFpUTBxZFB2VU94TENEZ0wyckNMSWY3MWNFYV93Y0NWRVp0MzR4ZFhxZXptTlpnUW1xdWY5Rkp4dnpYRDBnbVZFSkQtWFBvUmpJNXpzWEk0cVVtWUJFSW1GWC1fVkV0Q00zZk92S2k",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447141633.Z0FBQUFBQmFrT3hsbk1GRFU5UkY3VDdMYVJwZlhfNjZwZHBQUTRCTEwyc0x1b1dpSnhvNjMxX2tQb1g4WkM1QVFkclBpcEJvc1ZrQmFSWjUyODVBOXFIa0o5V3JHQjVHc0FXUWtLTEVTcFRqYURaMW9XNmhYbkdqNEZId3JsaUZzVjNkNldKMVV6dE4",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -2810,14 +2810,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:27 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:01 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -2825,16 +2825,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444887.909330,VS0,VE352",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447142.721580,VS0,VE100",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444887193.Z0FBQUFBQmFrT09YTXBXV05HSnhHU3V0QkJYWm5CTjhBR0ZDWHN5ejVmUndnN2VHS0hDbEFYRFUxYlM2elNTOXFLUHJaX3J1aHlnWC1ZQ1dqVUFwc1VsRkE5YmdvTy1yRjYxQmg0SndaTlZuMnJhWmdHbndXY0pjQlJfeWs5cXRlOHViN0h6dzZXRU8; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:27 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447141752.Z0FBQUFBQmFrT3hsYTl4VVdJdldCQk9CbnVSTVU0YVdMYzZ3YW9LVGRlbkhTMURiQ1BpaTdsMlpiVnpha3VJdENWOGN6a19peVktbGY2Zmc4V1hSdTNrSjgwSXljS3VlSE10amYtYjJ6bnRfcmU5SWd1ZmtIdF9pRUxpZjRScG1oWGJBd3JUeEhLdVo; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:01 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "537.0",
-          "x-ratelimit-reset": "513",
-          "x-ratelimit-used": "63",
+          "x-ratelimit-remaining": "547.0",
+          "x-ratelimit-reset": "59",
+          "x-ratelimit-used": "53",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -2845,7 +2845,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:27",
+      "recorded_at": "2018-02-24T04:39:01",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -2858,7 +2858,7 @@
           "Connection": "keep-alive",
           "Content-Length": "57",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444887193.Z0FBQUFBQmFrT09YTXBXV05HSnhHU3V0QkJYWm5CTjhBR0ZDWHN5ejVmUndnN2VHS0hDbEFYRFUxYlM2elNTOXFLUHJaX3J1aHlnWC1ZQ1dqVUFwc1VsRkE5YmdvTy1yRjYxQmg0SndaTlZuMnJhWmdHbndXY0pjQlJfeWs5cXRlOHViN0h6dzZXRU8",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447141752.Z0FBQUFBQmFrT3hsYTl4VVdJdldCQk9CbnVSTVU0YVdMYzZ3YW9LVGRlbkhTMURiQ1BpaTdsMlpiVnpha3VJdENWOGN6a19peVktbGY2Zmc4V1hSdTNrSjgwSXljS3VlSE10amYtYjJ6bnRfcmU5SWd1ZmtIdF9pRUxpZjRScG1oWGJBd3JUeEhLdVo",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -2867,14 +2867,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": true, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": true, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1682",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:27 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:01 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -2882,16 +2882,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444887.312412,VS0,VE102",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447142.845866,VS0,VE94",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444887345.Z0FBQUFBQmFrT09YSzQxNGdLclZabTlHeUxJUWtMeC1uOG1kWWN5RjdjTlJKWENoaWV2clRrTHJLeXpNQmtWcENRTV9RV3hnam1jRTRRcHdCNk5sWEc1WXk4dnBuWFA1MllNd3VscFZ0S0JLbTduSlBINE1GcUM5V2ZEZV9oZFBXYlBidUhKREhFUzA; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:27 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447141879.Z0FBQUFBQmFrT3hsblZRaFBDV3FIOTVCbnBNMmxlbno3NmxjZ3RIOUVOdHhjT0JHRnZ6WjZzSkZSeXVqa0dxTWlENVFQRWpNeWQ0UUxiMnllUGU4cUlicVpEUlFuQi1qRUZFNXB3SkNqXzhjOG1fdnVoaHFsMHdiVktDcll0Z3E3MTJENmlRTF95UUI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:01 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "536.0",
-          "x-ratelimit-reset": "513",
-          "x-ratelimit-used": "64",
+          "x-ratelimit-remaining": "546.0",
+          "x-ratelimit-reset": "59",
+          "x-ratelimit-used": "54",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -2902,7 +2902,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:27",
+      "recorded_at": "2018-02-24T04:39:02",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -2915,7 +2915,7 @@
           "Connection": "keep-alive",
           "Content-Length": "58",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444887345.Z0FBQUFBQmFrT09YSzQxNGdLclZabTlHeUxJUWtMeC1uOG1kWWN5RjdjTlJKWENoaWV2clRrTHJLeXpNQmtWcENRTV9RV3hnam1jRTRRcHdCNk5sWEc1WXk4dnBuWFA1MllNd3VscFZ0S0JLbTduSlBINE1GcUM5V2ZEZV9oZFBXYlBidUhKREhFUzA",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447141879.Z0FBQUFBQmFrT3hsblZRaFBDV3FIOTVCbnBNMmxlbno3NmxjZ3RIOUVOdHhjT0JHRnZ6WjZzSkZSeXVqa0dxTWlENVFQRWpNeWQ0UUxiMnllUGU4cUlicVpEUlFuQi1qRUZFNXB3SkNqXzhjOG1fdnVoaHFsMHdiVktDcll0Z3E3MTJENmlRTF95UUI",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -2924,14 +2924,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:27 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:02 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -2939,16 +2939,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444887.441115,VS0,VE177",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447142.964981,VS0,VE99",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444887478.Z0FBQUFBQmFrT09YZ25HcV84VjhLNjZWTFdGeWVjVklHQ3A4d3dMT2FxejREeXlSVFRPYXNkR0VnazZKSDlIMnEzd1l5MkZGR2hqUGNydFV1MVp0U21xTnpjM0lSMk1DWWtLSWxyZVFLdGlfbEpqbW05eXEyTnpfQmNsQ25yaE5FX1FXUm1qQWtRbUI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:27 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447142001.Z0FBQUFBQmFrT3htVWk4OWs1aUN4X0xNTDhWZzVxYU1xOUo0YTFSZWFUaFVTZVo2QXRSVkRVT0FqbWRBR3A5WXREWG5XMWIzc2VGajJKd1V3UGFuRlJDLW1hZWY2dWdwUjJyQlFFWjg0OXRnNW5oSFROaW12bTFYeWRPcjJkVVE0OXR3V2ZwN1hsU2g; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:02 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "535.0",
-          "x-ratelimit-reset": "513",
-          "x-ratelimit-used": "65",
+          "x-ratelimit-remaining": "545.0",
+          "x-ratelimit-reset": "58",
+          "x-ratelimit-used": "55",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -2959,7 +2959,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:27",
+      "recorded_at": "2018-02-24T04:39:02",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -2972,7 +2972,7 @@
           "Connection": "keep-alive",
           "Content-Length": "55",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444887478.Z0FBQUFBQmFrT09YZ25HcV84VjhLNjZWTFdGeWVjVklHQ3A4d3dMT2FxejREeXlSVFRPYXNkR0VnazZKSDlIMnEzd1l5MkZGR2hqUGNydFV1MVp0U21xTnpjM0lSMk1DWWtLSWxyZVFLdGlfbEpqbW05eXEyTnpfQmNsQ25yaE5FX1FXUm1qQWtRbUI",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447142001.Z0FBQUFBQmFrT3htVWk4OWs1aUN4X0xNTDhWZzVxYU1xOUo0YTFSZWFUaFVTZVo2QXRSVkRVT0FqbWRBR3A5WXREWG5XMWIzc2VGajJKd1V3UGFuRlJDLW1hZWY2dWdwUjJyQlFFWjg0OXRnNW5oSFROaW12bTFYeWRPcjJkVVE0OXR3V2ZwN1hsU2g",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -2981,14 +2981,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": true, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": true, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1682",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:27 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:02 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -2996,16 +2996,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444888.645159,VS0,VE109",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447142.089292,VS0,VE96",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444887681.Z0FBQUFBQmFrT09YakNIYnNnMHR0T3BNQXlvZzE3RkdsX0dQV2lrWGNGU1FXNW9tSGpyRkhtd0Z5clEzWURnTnJiMUNGV25qaGRsYnlKUVFWTWxtbnNXU3NXSTVmVGV2RnBwUEZYYVdnVHV0SWlpekVvREF5bDN5QUZSbmZ2bXNVMEhNUXdwZ3l4N20; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:27 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447142124.Z0FBQUFBQmFrT3htaVlYWDNsNXBTeU9TNjRVbVc2V3k2QTRrem5VYW1RQy1yaEFCRmVyYi1rWDA2YU9TV1pUM0o4VFZvZTBYaFRUVk0zazJDU0lCRUFud2xmUWFPWFJRQkczN2NGSVB1VEdLZFk3Y3JaZkJXRkZ3REk2UTdfRnJTb0ZhdEpjWE9fSXQ; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:02 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "534.0",
-          "x-ratelimit-reset": "513",
-          "x-ratelimit-used": "66",
+          "x-ratelimit-remaining": "544.0",
+          "x-ratelimit-reset": "58",
+          "x-ratelimit-used": "56",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -3016,7 +3016,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:27",
+      "recorded_at": "2018-02-24T04:39:02",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -3029,7 +3029,7 @@
           "Connection": "keep-alive",
           "Content-Length": "56",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444887681.Z0FBQUFBQmFrT09YakNIYnNnMHR0T3BNQXlvZzE3RkdsX0dQV2lrWGNGU1FXNW9tSGpyRkhtd0Z5clEzWURnTnJiMUNGV25qaGRsYnlKUVFWTWxtbnNXU3NXSTVmVGV2RnBwUEZYYVdnVHV0SWlpekVvREF5bDN5QUZSbmZ2bXNVMEhNUXdwZ3l4N20",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447142124.Z0FBQUFBQmFrT3htaVlYWDNsNXBTeU9TNjRVbVc2V3k2QTRrem5VYW1RQy1yaEFCRmVyYi1rWDA2YU9TV1pUM0o4VFZvZTBYaFRUVk0zazJDU0lCRUFud2xmUWFPWFJRQkczN2NGSVB1VEdLZFk3Y3JaZkJXRkZ3REk2UTdfRnJTb0ZhdEpjWE9fSXQ",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -3038,14 +3038,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:27 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:02 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -3053,16 +3053,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444888.779990,VS0,VE94",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447142.211926,VS0,VE109",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444887812.Z0FBQUFBQmFrT09YTDNKT3ZRbl9SNy0ta1FYWmt6bV9RMlZFX0c0cjl0R3hVMmQ5b3NwMVIyeThEUzUzRHB5aGNad1dCTlZiU0RZdVplV1hfMVBSOHRSR2V5eTZidjBGTU9ueDY1czQ3MVVFNHVPTnN3WDhZU2hiczh1X3VCWE5URGtyMnlTd1NDOXI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:27 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447142247.Z0FBQUFBQmFrT3htOXVvbDdiMHZCR1FfUGp2Nmc5MjhrQmtZSkpieUZJYXc1RzNHQk5CckQxY2t2Z2UwcnUwWVZlYVNpV0NIRXJZT1J0SVVzZmZXdUhSYlVQN2g2WHZWX29haUR6MTBNOVhDUG5KaHpuNGRzQ0VMWTZOYmhRLURmRXNZaEZSQ3VDbFo; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:02 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "533.0",
-          "x-ratelimit-reset": "513",
-          "x-ratelimit-used": "67",
+          "x-ratelimit-remaining": "543.0",
+          "x-ratelimit-reset": "58",
+          "x-ratelimit-used": "57",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -3073,7 +3073,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:28",
+      "recorded_at": "2018-02-24T04:39:02",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -3086,7 +3086,7 @@
           "Connection": "keep-alive",
           "Content-Length": "48",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444887812.Z0FBQUFBQmFrT09YTDNKT3ZRbl9SNy0ta1FYWmt6bV9RMlZFX0c0cjl0R3hVMmQ5b3NwMVIyeThEUzUzRHB5aGNad1dCTlZiU0RZdVplV1hfMVBSOHRSR2V5eTZidjBGTU9ueDY1czQ3MVVFNHVPTnN3WDhZU2hiczh1X3VCWE5URGtyMnlTd1NDOXI",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447142247.Z0FBQUFBQmFrT3htOXVvbDdiMHZCR1FfUGp2Nmc5MjhrQmtZSkpieUZJYXc1RzNHQk5CckQxY2t2Z2UwcnUwWVZlYVNpV0NIRXJZT1J0SVVzZmZXdUhSYlVQN2g2WHZWX29haUR6MTBNOVhDUG5KaHpuNGRzQ0VMWTZOYmhRLURmRXNZaEZSQ3VDbFo",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -3095,14 +3095,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": true, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": true, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1682",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:28 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:02 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -3110,16 +3110,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444888.901072,VS0,VE108",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447142.349000,VS0,VE96",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444887933.Z0FBQUFBQmFrT09YY3FKcVFwbmJiU0Uzb2JTOHJFVVlKSWw5X09ORmwtbnBEMzJXOGk4dE9kSmFIZnRnUzJQc290NXFJeHJWZkJxd0xVOG15OGUtdmRwRGZpM3ZEWGs3MC1YMHBoeWVjU0hnLUtNREl5WU40OGdBRWJLQWlPempnWDlZUmk5bnpWUjQ; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:27 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447142385.Z0FBQUFBQmFrT3htVXBJLUtOZ2lyeVB4ZmRNcHRiYXQyREQ2aEUxZ2xZRnhnRmRVcGpXSnN2a002c2JhWlhnMnNmRk1GdmF0WnB3d1NEUE9EclFBVWlJVklFam5GT2d2THFRU1p6cUpNeUlHbURSMW5LMzBqX2hQdWRpNzlab1c4WnNMZDZrMEI3NjU; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:02 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "532.0",
-          "x-ratelimit-reset": "513",
-          "x-ratelimit-used": "68",
+          "x-ratelimit-remaining": "542.0",
+          "x-ratelimit-reset": "58",
+          "x-ratelimit-used": "58",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -3130,7 +3130,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:28",
+      "recorded_at": "2018-02-24T04:39:02",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -3143,7 +3143,7 @@
           "Connection": "keep-alive",
           "Content-Length": "49",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444887933.Z0FBQUFBQmFrT09YY3FKcVFwbmJiU0Uzb2JTOHJFVVlKSWw5X09ORmwtbnBEMzJXOGk4dE9kSmFIZnRnUzJQc290NXFJeHJWZkJxd0xVOG15OGUtdmRwRGZpM3ZEWGs3MC1YMHBoeWVjU0hnLUtNREl5WU40OGdBRWJLQWlPempnWDlZUmk5bnpWUjQ",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447142385.Z0FBQUFBQmFrT3htVXBJLUtOZ2lyeVB4ZmRNcHRiYXQyREQ2aEUxZ2xZRnhnRmRVcGpXSnN2a002c2JhWlhnMnNmRk1GdmF0WnB3d1NEUE9EclFBVWlJVklFam5GT2d2THFRU1p6cUpNeUlHbURSMW5LMzBqX2hQdWRpNzlab1c4WnNMZDZrMEI3NjU",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -3152,14 +3152,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:28 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:02 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -3167,16 +3167,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444888.036693,VS0,VE106",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447142.469944,VS0,VE98",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444888073.Z0FBQUFBQmFrT09ZN0N6dGFUMEVTZXYwR3hBVkJHTXl0Z1BOcDNQUTR6cVZtZXBhRVN6a0lWLURDTHJRVWd4T0Ewd2lmektEYXlCYWI4YjBrLUVaVmY1c1Vmd0RZWFlnV1pqYzlnVGc0Z0tER2FuNHdJc0JqTU9EY0VKU2hUcVBpSER1V1RnWnlFZjI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:28 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447142507.Z0FBQUFBQmFrT3htbFk4NEVJWndmWXBNNGxCc0tSSlcxdUtNaDhFMmZ5UU9KVUhTUWR6ZjZWdHhnWkdHNVI4UGhRRFNJNng2V2RkNkpKdWFhU1A4UjY5TDUzeG5xOWFuX3R0NElUUm1pQzBMbzViX0w2Q0tLdlNtTEFEZ1hQQjUwSUI4bDRMRWhOSkY; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:02 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "531.0",
-          "x-ratelimit-reset": "512",
-          "x-ratelimit-used": "69",
+          "x-ratelimit-remaining": "541.0",
+          "x-ratelimit-reset": "58",
+          "x-ratelimit-used": "59",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -3187,7 +3187,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:28",
+      "recorded_at": "2018-02-24T04:39:02",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -3200,7 +3200,7 @@
           "Connection": "keep-alive",
           "Content-Length": "56",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444888073.Z0FBQUFBQmFrT09ZN0N6dGFUMEVTZXYwR3hBVkJHTXl0Z1BOcDNQUTR6cVZtZXBhRVN6a0lWLURDTHJRVWd4T0Ewd2lmektEYXlCYWI4YjBrLUVaVmY1c1Vmd0RZWFlnV1pqYzlnVGc0Z0tER2FuNHdJc0JqTU9EY0VKU2hUcVBpSER1V1RnWnlFZjI",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447142507.Z0FBQUFBQmFrT3htbFk4NEVJWndmWXBNNGxCc0tSSlcxdUtNaDhFMmZ5UU9KVUhTUWR6ZjZWdHhnWkdHNVI4UGhRRFNJNng2V2RkNkpKdWFhU1A4UjY5TDUzeG5xOWFuX3R0NElUUm1pQzBMbzViX0w2Q0tLdlNtTEFEZ1hQQjUwSUI4bDRMRWhOSkY",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -3209,14 +3209,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": true, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": true, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1682",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:28 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:02 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -3224,16 +3224,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444888.179533,VS0,VE106",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447143.592715,VS0,VE98",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444888215.Z0FBQUFBQmFrT09ZcnM0bTFJekRGbWdQU0prZnJkeXRpQ1h4amZiNUNQMlRfaXRRcUM4SjZFUDVnblhVNFhFcW11OTZkdnBWa185VTQtbXdvU3NwRVYteDdzZlpCN09maXBWYlVmRXdIUDZCS3hRb25pZkczYVdWM19MdlpYSkpuX3hpMXNWRkhUWGg; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:28 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447142628.Z0FBQUFBQmFrT3htSDc1cGkyWm5MQmE4azFKcjhDZElVS3BGcnlIcVNwNTNWVVR6Z1dfUXVNMENhNTRCMWNrWmJRc3N6YkpsZGFwV3ZxS2Z6LTRlVmZjai1ITzhsOTdNbUxlNlE1cVBSR01YSGcwMEdScG5lVm8xWENXYTkzc1UwUVdCQ2pPVmprWGw; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:02 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "530.0",
-          "x-ratelimit-reset": "512",
-          "x-ratelimit-used": "70",
+          "x-ratelimit-remaining": "540.0",
+          "x-ratelimit-reset": "58",
+          "x-ratelimit-used": "60",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -3244,7 +3244,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:28",
+      "recorded_at": "2018-02-24T04:39:02",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -3257,7 +3257,7 @@
           "Connection": "keep-alive",
           "Content-Length": "57",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444888215.Z0FBQUFBQmFrT09ZcnM0bTFJekRGbWdQU0prZnJkeXRpQ1h4amZiNUNQMlRfaXRRcUM4SjZFUDVnblhVNFhFcW11OTZkdnBWa185VTQtbXdvU3NwRVYteDdzZlpCN09maXBWYlVmRXdIUDZCS3hRb25pZkczYVdWM19MdlpYSkpuX3hpMXNWRkhUWGg",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447142628.Z0FBQUFBQmFrT3htSDc1cGkyWm5MQmE4azFKcjhDZElVS3BGcnlIcVNwNTNWVVR6Z1dfUXVNMENhNTRCMWNrWmJRc3N6YkpsZGFwV3ZxS2Z6LTRlVmZjai1ITzhsOTdNbUxlNlE1cVBSR01YSGcwMEdScG5lVm8xWENXYTkzc1UwUVdCQ2pPVmprWGw",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -3266,14 +3266,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:28 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:02 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -3281,16 +3281,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444888.312115,VS0,VE327",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447143.716517,VS0,VE100",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444888344.Z0FBQUFBQmFrT09ZQnh1R0VBYzhWSG91Z2trMFpZZ1ZNQmpJeEJTcUkwcnNIVXJOSEhfRXc0VmdHa1h1YWVzMHBkUmhoWE40Rjc2ZGM2U3JXaWduMFIzWjNkYVhNSjI5dHdzRjg2ek1iUVdQVFg0QktoUTJpbExWNTJPVFBPWkQybWcyZWlOQWJzU3k; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:28 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447142751.Z0FBQUFBQmFrT3hteGg0eVpfeVVFa2ZWTllPNDZxZEtZQ2J2MUdpSG1peXVwaC1yanNRd0JFZmwwbWlqZUl6aEJFdjE3S1FISktYVUZHUzVBc0RjclNMdzdrT1U1ZWZ3M2k0RThFa09EcEtYNnpvZjY1MUluR003aEJwVFRsLU5DRHZJXzkzcWFRLVo; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:02 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "529.0",
-          "x-ratelimit-reset": "512",
-          "x-ratelimit-used": "71",
+          "x-ratelimit-remaining": "539.0",
+          "x-ratelimit-reset": "58",
+          "x-ratelimit-used": "61",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -3301,7 +3301,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:28",
+      "recorded_at": "2018-02-24T04:39:02",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -3314,7 +3314,7 @@
           "Connection": "keep-alive",
           "Content-Length": "46",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444888344.Z0FBQUFBQmFrT09ZQnh1R0VBYzhWSG91Z2trMFpZZ1ZNQmpJeEJTcUkwcnNIVXJOSEhfRXc0VmdHa1h1YWVzMHBkUmhoWE40Rjc2ZGM2U3JXaWduMFIzWjNkYVhNSjI5dHdzRjg2ek1iUVdQVFg0QktoUTJpbExWNTJPVFBPWkQybWcyZWlOQWJzU3k",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447142751.Z0FBQUFBQmFrT3hteGg0eVpfeVVFa2ZWTllPNDZxZEtZQ2J2MUdpSG1peXVwaC1yanNRd0JFZmwwbWlqZUl6aEJFdjE3S1FISktYVUZHUzVBc0RjclNMdzdrT1U1ZWZ3M2k0RThFa09EcEtYNnpvZjY1MUluR003aEJwVFRsLU5DRHZJXzkzcWFRLVo",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -3323,14 +3323,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": true, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": true, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1682",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:28 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:02 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -3338,16 +3338,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444889.665437,VS0,VE104",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447143.842039,VS0,VE97",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444888703.Z0FBQUFBQmFrT09ZRzFmaDFXRFc0Q0YycHFHQUNDUVhWSGM3aWZrMnF1YkhBQnh1eGJseXduWjg3ZXpRekFVRkE2OXQ0UEJjQkktOVE3bE1DTWJacnFsa2N0SFpRWmgxZHhqOTV5bkFmeWktREhIOXFYLU50cUI0U3VnZHk0R01kMWdyN09EYWhlZUI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:28 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447142878.Z0FBQUFBQmFrT3htZFNyaUdTM0JRX0dXYXJXOFFhSlp6UXpEd1d1cTh2WjZDQUNRLXFSc1JQaU5SY1hjSTdaZFNKdWxrUUpRN2hRZ0VXaEtiaUp5QUNHUVR3dXFqMzg4RkhiNlFZQlk0VFNHeTM0MXp3M0pLeFJ0X0cwYVNVcUFsdE1hT0NTbkJxMmk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:02 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "528.0",
-          "x-ratelimit-reset": "512",
-          "x-ratelimit-used": "72",
+          "x-ratelimit-remaining": "538.0",
+          "x-ratelimit-reset": "58",
+          "x-ratelimit-used": "62",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -3358,7 +3358,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:28",
+      "recorded_at": "2018-02-24T04:39:03",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -3371,7 +3371,7 @@
           "Connection": "keep-alive",
           "Content-Length": "47",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444888703.Z0FBQUFBQmFrT09ZRzFmaDFXRFc0Q0YycHFHQUNDUVhWSGM3aWZrMnF1YkhBQnh1eGJseXduWjg3ZXpRekFVRkE2OXQ0UEJjQkktOVE3bE1DTWJacnFsa2N0SFpRWmgxZHhqOTV5bkFmeWktREhIOXFYLU50cUI0U3VnZHk0R01kMWdyN09EYWhlZUI",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447142878.Z0FBQUFBQmFrT3htZFNyaUdTM0JRX0dXYXJXOFFhSlp6UXpEd1d1cTh2WjZDQUNRLXFSc1JQaU5SY1hjSTdaZFNKdWxrUUpRN2hRZ0VXaEtiaUp5QUNHUVR3dXFqMzg4RkhiNlFZQlk0VFNHeTM0MXp3M0pLeFJ0X0cwYVNVcUFsdE1hT0NTbkJxMmk",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -3380,14 +3380,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:28 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:03 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -3395,16 +3395,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444889.797091,VS0,VE103",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447143.964103,VS0,VE101",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444888831.Z0FBQUFBQmFrT09ZY0NuckxQbkh0OHhHS2l3NnZCUmZJLU5QOGwxemFtbjZuMHJqUmRkT0Q1cDFYZF85a3ZVUmRobmtGWnJGWFE0eG5DQU8yX2Zid21EeGROaFFKczdsYmFuTXdlRmtiLUhZTHBjSjh2bUhQbnRSRF9HWkhKbEZ6Wmg5VFhLb2VudXo; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:28 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447143007.Z0FBQUFBQmFrT3huRVhCU2gySnplLXM0dnl0VGsyWFUwYmd2NVhySkQxWmpsN1NldlAyQks5TnVhS3BhZkJDb2U2MVJHSFdsNzFyMlhYYlhkcndUNTFHZXNlcll0ZTlrLWRuWHRMWHJhcWtPVHZleXVQYjNldUoxcGVEeW9JVm1lSVktOUlsTlZ0YWE; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:03 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "527.0",
-          "x-ratelimit-reset": "512",
-          "x-ratelimit-used": "73",
+          "x-ratelimit-remaining": "537.0",
+          "x-ratelimit-reset": "57",
+          "x-ratelimit-used": "63",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -3415,7 +3415,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:29",
+      "recorded_at": "2018-02-24T04:39:03",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -3428,7 +3428,7 @@
           "Connection": "keep-alive",
           "Content-Length": "46",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444888831.Z0FBQUFBQmFrT09ZY0NuckxQbkh0OHhHS2l3NnZCUmZJLU5QOGwxemFtbjZuMHJqUmRkT0Q1cDFYZF85a3ZVUmRobmtGWnJGWFE0eG5DQU8yX2Zid21EeGROaFFKczdsYmFuTXdlRmtiLUhZTHBjSjh2bUhQbnRSRF9HWkhKbEZ6Wmg5VFhLb2VudXo",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447143007.Z0FBQUFBQmFrT3huRVhCU2gySnplLXM0dnl0VGsyWFUwYmd2NVhySkQxWmpsN1NldlAyQks5TnVhS3BhZkJDb2U2MVJHSFdsNzFyMlhYYlhkcndUNTFHZXNlcll0ZTlrLWRuWHRMWHJhcWtPVHZleXVQYjNldUoxcGVEeW9JVm1lSVktOUlsTlZ0YWE",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -3437,14 +3437,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:29 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:03 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -3452,16 +3452,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444889.925765,VS0,VE168",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447143.090222,VS0,VE107",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444888952.Z0FBQUFBQmFrT09ad1d1YXlReWlORmxtd3Z5V3FqZWVPTDFEVjNwc0s0V0otNUxwNjM5YXY1a3pEb0c1am4wNEZQN0hGZnJjZW1aWVdqMThSc0hWYndQT0NyMjVEeFIxdWVUYk1fc1FOTlZjbXZ1blh2djl2YWZWNXA2Q3B6VzJGblZGWkpzUFhkQkk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:29 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447143126.Z0FBQUFBQmFrT3huSU9aVzZyZUlKWFM2a1ZlY3JERVZZbGZ0eDZDT0FnQ3cwVWNkOGpTRUY2b2pBaC1ITV9sZnh2am4xTzZaazd3VXNUMlBjblFaRWEtQ0dKdmgxcEFTNWx2N2k0R0J2endyaVRGUnAyRTNtdHFXdXh4T3JxakthaVBTbTZNNnB3bkk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:03 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "526.0",
-          "x-ratelimit-reset": "511",
-          "x-ratelimit-used": "74",
+          "x-ratelimit-remaining": "536.0",
+          "x-ratelimit-reset": "57",
+          "x-ratelimit-used": "64",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -3472,7 +3472,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:29",
+      "recorded_at": "2018-02-24T04:39:03",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -3485,7 +3485,7 @@
           "Connection": "keep-alive",
           "Content-Length": "47",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444888952.Z0FBQUFBQmFrT09ad1d1YXlReWlORmxtd3Z5V3FqZWVPTDFEVjNwc0s0V0otNUxwNjM5YXY1a3pEb0c1am4wNEZQN0hGZnJjZW1aWVdqMThSc0hWYndQT0NyMjVEeFIxdWVUYk1fc1FOTlZjbXZ1blh2djl2YWZWNXA2Q3B6VzJGblZGWkpzUFhkQkk",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447143126.Z0FBQUFBQmFrT3huSU9aVzZyZUlKWFM2a1ZlY3JERVZZbGZ0eDZDT0FnQ3cwVWNkOGpTRUY2b2pBaC1ITV9sZnh2am4xTzZaazd3VXNUMlBjblFaRWEtQ0dKdmgxcEFTNWx2N2k0R0J2endyaVRGUnAyRTNtdHFXdXh4T3JxakthaVBTbTZNNnB3bkk",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -3494,14 +3494,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1684",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:29 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:03 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -3509,16 +3509,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444889.120449,VS0,VE109",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447143.231873,VS0,VE105",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444889163.Z0FBQUFBQmFrT09aWDVseHFQNTZEMnZNbjBqRlctWDl3X3FKd2Y3WHJOVzRfSG9jancwS2VabU5wbUcxRm5iNmYtemhYQTBHbThkOGh6R1V5TGkwRzc3b3hTaldESy1mTjJxcTZLb1paMWF1SHBVc3pyTkFvYXExWXptVEF5ZDkyaUpZX1JnM2ppYXA; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:29 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447143274.Z0FBQUFBQmFrT3huaFBZaHVOY2kweG1EU2NzZHUxdVZod1hWbldmNzRzSlB2UVdvVzItRm9PMmREM09BY0hGaUVDSDU1aDNGZzVtckcyQU16OTRQUHNsZWJJQmlMNGd5cTRNSjFPV2NVS1VuRGRiSC0wTHBjUGp6Q2tSM3JYUGp0SDFPNnI2TFZpOEs; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:03 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "525.0",
-          "x-ratelimit-reset": "511",
-          "x-ratelimit-used": "75",
+          "x-ratelimit-remaining": "535.0",
+          "x-ratelimit-reset": "57",
+          "x-ratelimit-used": "65",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -3529,7 +3529,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:29",
+      "recorded_at": "2018-02-24T04:39:03",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -3542,7 +3542,7 @@
           "Connection": "keep-alive",
           "Content-Length": "52",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444889163.Z0FBQUFBQmFrT09aWDVseHFQNTZEMnZNbjBqRlctWDl3X3FKd2Y3WHJOVzRfSG9jancwS2VabU5wbUcxRm5iNmYtemhYQTBHbThkOGh6R1V5TGkwRzc3b3hTaldESy1mTjJxcTZLb1paMWF1SHBVc3pyTkFvYXExWXptVEF5ZDkyaUpZX1JnM2ppYXA",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447143274.Z0FBQUFBQmFrT3huaFBZaHVOY2kweG1EU2NzZHUxdVZod1hWbldmNzRzSlB2UVdvVzItRm9PMmREM09BY0hGaUVDSDU1aDNGZzVtckcyQU16OTRQUHNsZWJJQmlMNGd5cTRNSjFPV2NVS1VuRGRiSC0wTHBjUGp6Q2tSM3JYUGp0SDFPNnI2TFZpOEs",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -3551,14 +3551,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": true, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": true, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:29 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:03 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -3566,16 +3566,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444889.256707,VS0,VE102",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447143.362548,VS0,VE101",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444889299.Z0FBQUFBQmFrT09aNGpLSW5VWGZ2Y1FpYUlUd2duRW9HbnJZRk95S2hGMzVlakxDRDViTXZ2SGVfbk94UFFIczg0R0N1R19CMDRhaG5USmkyQ05IVkh3bnlBSXRLekVWR01kWm1vYVlmekdvOFVfM1owWGZXQ2pIZ19tRTlwYW1EVTVxWUlwa0tlQUw; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:29 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447143401.Z0FBQUFBQmFrT3hubXp0b0dNWjY0UnlVaUxyUTNTeHNhM2M0THltMHdyVHB6Rml5Njc4OVFvUEFQSTdGakJDcUpDZkhENEIxdFg0cHFHLU5YVVJrUEZqbjZOOHN4QmNFUDE3ZXFpWHZKN1FreUJacnFfSzRwcHNISDNoRlpRT29KSmlESnNUT0tnX1A; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:03 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "524.0",
-          "x-ratelimit-reset": "511",
-          "x-ratelimit-used": "76",
+          "x-ratelimit-remaining": "534.0",
+          "x-ratelimit-reset": "57",
+          "x-ratelimit-used": "66",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -3586,7 +3586,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:29",
+      "recorded_at": "2018-02-24T04:39:03",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -3599,7 +3599,7 @@
           "Connection": "keep-alive",
           "Content-Length": "53",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444889299.Z0FBQUFBQmFrT09aNGpLSW5VWGZ2Y1FpYUlUd2duRW9HbnJZRk95S2hGMzVlakxDRDViTXZ2SGVfbk94UFFIczg0R0N1R19CMDRhaG5USmkyQ05IVkh3bnlBSXRLekVWR01kWm1vYVlmekdvOFVfM1owWGZXQ2pIZ19tRTlwYW1EVTVxWUlwa0tlQUw",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447143401.Z0FBQUFBQmFrT3hubXp0b0dNWjY0UnlVaUxyUTNTeHNhM2M0THltMHdyVHB6Rml5Njc4OVFvUEFQSTdGakJDcUpDZkhENEIxdFg0cHFHLU5YVVJrUEZqbjZOOHN4QmNFUDE3ZXFpWHZKN1FreUJacnFfSzRwcHNISDNoRlpRT29KSmlESnNUT0tnX1A",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -3608,14 +3608,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1684",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:29 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:03 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -3623,16 +3623,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444889.384893,VS0,VE106",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447143.490207,VS0,VE141",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444889414.Z0FBQUFBQmFrT09aZUkwcHNPVG50N0tuamZFRGNrV1YyYWJaUzhSY0YyWjBLOXpVQi0ydkFnejBnaVBtMGJOWWlVUkM3NkNMYzJXVVBqUjIyamswOU1OY0dra0hTV1k4R21vbkMyLS1mWE9TQW1NOGs5aWtxbDlvQVQ1VDZNN2MxZkNKU3BvWU1GNXo; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:29 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447143527.Z0FBQUFBQmFrT3hucmwxb2djZnR3b1BjSklXaWlVT0lwNlJNcXcyNElmZTdOYjBJcWhQUHgxLTg4R3RIVmd6UlRkNVNZeUl5WlZyZHNVSmx2Znc0YUpTTjFmOWMzbDZXNUtfLVkzR3hDZGVmb2JMRVZWdk42Wm9mVnQ0dlRfS2FHWHlVRktpSXlXZ2g; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:03 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "523.0",
-          "x-ratelimit-reset": "511",
-          "x-ratelimit-used": "77",
+          "x-ratelimit-remaining": "533.0",
+          "x-ratelimit-reset": "57",
+          "x-ratelimit-used": "67",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -3643,7 +3643,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:29",
+      "recorded_at": "2018-02-24T04:39:03",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -3656,7 +3656,7 @@
           "Connection": "keep-alive",
           "Content-Length": "54",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444889414.Z0FBQUFBQmFrT09aZUkwcHNPVG50N0tuamZFRGNrV1YyYWJaUzhSY0YyWjBLOXpVQi0ydkFnejBnaVBtMGJOWWlVUkM3NkNMYzJXVVBqUjIyamswOU1OY0dra0hTV1k4R21vbkMyLS1mWE9TQW1NOGs5aWtxbDlvQVQ1VDZNN2MxZkNKU3BvWU1GNXo",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447143527.Z0FBQUFBQmFrT3hucmwxb2djZnR3b1BjSklXaWlVT0lwNlJNcXcyNElmZTdOYjBJcWhQUHgxLTg4R3RIVmd6UlRkNVNZeUl5WlZyZHNVSmx2Znc0YUpTTjFmOWMzbDZXNUtfLVkzR3hDZGVmb2JMRVZWdk42Wm9mVnQ0dlRfS2FHWHlVRktpSXlXZ2g",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -3665,14 +3665,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": true, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": true, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:29 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:03 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -3680,16 +3680,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444890.518216,VS0,VE107",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447144.659204,VS0,VE100",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444889555.Z0FBQUFBQmFrT09aSDFwWDVFVURHWldZOU52MDZKYW92c0FETUlYblNLWVFHTXZSdF9xMUFwNTUzUU1jRDhyX2NKbDNxN2xwZHp4c0ZLSDFWcFZ4UFo3aFhadWhxcjA0T0RtTmd1Y2licXpUX0dQQnA2RDVCNkdybkJTT2tYLWxOcFliVEctSU1XLUc; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:29 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447143704.Z0FBQUFBQmFrT3hucnJsOXRBN3luY3dOTmJ0TjUtYnVBTmRDQUNFSjAyLU1VVENIcy1PTE1XcnJtczl5SlNoVEI1VDRmMGpDR2JQRDdJekd0QUtCaU9uTGNjdjJUcjN4NWRsQWxDbksxai1WcFJDV1RoYVdTX3RlblRCZWpOYktDclo5N0FacDhmRlE; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:03 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "522.0",
-          "x-ratelimit-reset": "511",
-          "x-ratelimit-used": "78",
+          "x-ratelimit-remaining": "532.0",
+          "x-ratelimit-reset": "57",
+          "x-ratelimit-used": "68",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -3700,7 +3700,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:29",
+      "recorded_at": "2018-02-24T04:39:03",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -3713,7 +3713,7 @@
           "Connection": "keep-alive",
           "Content-Length": "55",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444889555.Z0FBQUFBQmFrT09aSDFwWDVFVURHWldZOU52MDZKYW92c0FETUlYblNLWVFHTXZSdF9xMUFwNTUzUU1jRDhyX2NKbDNxN2xwZHp4c0ZLSDFWcFZ4UFo3aFhadWhxcjA0T0RtTmd1Y2licXpUX0dQQnA2RDVCNkdybkJTT2tYLWxOcFliVEctSU1XLUc",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447143704.Z0FBQUFBQmFrT3hucnJsOXRBN3luY3dOTmJ0TjUtYnVBTmRDQUNFSjAyLU1VVENIcy1PTE1XcnJtczl5SlNoVEI1VDRmMGpDR2JQRDdJekd0QUtCaU9uTGNjdjJUcjN4NWRsQWxDbksxai1WcFJDV1RoYVdTX3RlblRCZWpOYktDclo5N0FacDhmRlE",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -3722,14 +3722,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1684",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:29 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:03 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -3737,16 +3737,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444890.650852,VS0,VE158",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447144.785481,VS0,VE98",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444889683.Z0FBQUFBQmFrT09aZWZrWXVFYmJVSTdFNlYzelRCUGJUVWR5MUFvVEZic09LaDE2c3RuX0JmZm94eXAtUG9xRnp0QjRKSUdzU2hSQjlBY2FTam1CSTIyNi1BTWNOeVpHWGdrTEZUTzh2TXNUZGpBeHdlNExjWnBLcktaNktuT1lQYXp5WVZOYkZTWFA; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:29 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447143822.Z0FBQUFBQmFrT3huMzBFNDhXSXZmMU1vclR0bjlqNGpMeGVUNzgwVmJNUk9sRTgtalV3anVUdFNzZHR5RHRsczk1aFVMWTN6LTA0N2NZb0dLTHdkZ0VsZEM3a3FKZVd2ZTFxRUtEOTRMV3NJYjFpcDFKSmd6bVdWNmpOQ1dNNXNNMWVaRElhWkR5UGE; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:03 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "521.0",
-          "x-ratelimit-reset": "511",
-          "x-ratelimit-used": "79",
+          "x-ratelimit-remaining": "531.0",
+          "x-ratelimit-reset": "57",
+          "x-ratelimit-used": "69",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -3757,7 +3757,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:29",
+      "recorded_at": "2018-02-24T04:39:04",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -3770,7 +3770,7 @@
           "Connection": "keep-alive",
           "Content-Length": "51",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444889683.Z0FBQUFBQmFrT09aZWZrWXVFYmJVSTdFNlYzelRCUGJUVWR5MUFvVEZic09LaDE2c3RuX0JmZm94eXAtUG9xRnp0QjRKSUdzU2hSQjlBY2FTam1CSTIyNi1BTWNOeVpHWGdrTEZUTzh2TXNUZGpBeHdlNExjWnBLcktaNktuT1lQYXp5WVZOYkZTWFA",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447143822.Z0FBQUFBQmFrT3huMzBFNDhXSXZmMU1vclR0bjlqNGpMeGVUNzgwVmJNUk9sRTgtalV3anVUdFNzZHR5RHRsczk1aFVMWTN6LTA0N2NZb0dLTHdkZ0VsZEM3a3FKZVd2ZTFxRUtEOTRMV3NJYjFpcDFKSmd6bVdWNmpOQ1dNNXNNMWVaRElhWkR5UGE",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -3779,14 +3779,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": true, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": true, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:29 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:04 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -3794,16 +3794,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444890.836400,VS0,VE104",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447144.909271,VS0,VE104",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444889873.Z0FBQUFBQmFrT09aZDVCV2VQM0tDYUY1OEtBZG9keGVfVXI5MzUtLXdjMGdfcS1vdjBpV18xYTNkTThsNnF5c0FyUDFhMnZKWUVXNVFDZjFLUVhXeHlhS2VsM1J3YXpVUUJCcGtjaW8tMklmTHNoUWpYS1BLU3Utd3NXU3NiUnFZd3VocklqcTRIbUc; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:29 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447143943.Z0FBQUFBQmFrT3hubWl1TzhkY28zczVkUkRxWHNncGZmSVU4R1dDaXptYy1fVXExakV6MEVGVUt5X1dRM1Jxa1RPd3pyaDBvSFlxWk1nbnNZbXgtTWo4djRSbTRRbFZiYy0teWVyb3c5SGY2T1E1ZFh5Yjk5eklQRDQ3eHVqNXJlcHZlVTZZakRNc3I; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:03 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "520.0",
-          "x-ratelimit-reset": "511",
-          "x-ratelimit-used": "80",
+          "x-ratelimit-remaining": "530.0",
+          "x-ratelimit-reset": "57",
+          "x-ratelimit-used": "70",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -3814,7 +3814,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:30",
+      "recorded_at": "2018-02-24T04:39:04",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -3827,7 +3827,7 @@
           "Connection": "keep-alive",
           "Content-Length": "52",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444889873.Z0FBQUFBQmFrT09aZDVCV2VQM0tDYUY1OEtBZG9keGVfVXI5MzUtLXdjMGdfcS1vdjBpV18xYTNkTThsNnF5c0FyUDFhMnZKWUVXNVFDZjFLUVhXeHlhS2VsM1J3YXpVUUJCcGtjaW8tMklmTHNoUWpYS1BLU3Utd3NXU3NiUnFZd3VocklqcTRIbUc",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447143943.Z0FBQUFBQmFrT3hubWl1TzhkY28zczVkUkRxWHNncGZmSVU4R1dDaXptYy1fVXExakV6MEVGVUt5X1dRM1Jxa1RPd3pyaDBvSFlxWk1nbnNZbXgtTWo4djRSbTRRbFZiYy0teWVyb3c5SGY2T1E1ZFh5Yjk5eklQRDQ3eHVqNXJlcHZlVTZZakRNc3I",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -3836,14 +3836,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1684",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:30 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:04 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -3851,16 +3851,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444890.966871,VS0,VE100",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447144.039696,VS0,VE94",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444890005.Z0FBQUFBQmFrT09hdmhuZnVVeno2bG1fcnRveTB6NzB0OXhfVDdEcEJfekowZkdnNWNHT3Z3VmpfeElCSGpYbVRyalV6ZVotem9iaFhLS1dyV0MtT1JlaVRnTVpDYmRDcGZVZ1ZoUF9SaGV2TnBGRk9xLTA3UWJwaGlOWmplbzdLSkpLZ2MwNURYajI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:30 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447144077.Z0FBQUFBQmFrT3hvQXhfOTJLXzJ6czhXMVA1eFFNZ3RCWDVFWUZWTWREanpoYVFGWldfU1ZpRTlmcUNPQ21hVmE2a0JaUXFuVkhDdmNBVXJtdkpmZTZZbW1LR2xVazFjd2NNTHdrWWE5SzZldmd3ZGcwaTZGUmpqM3lYcjRMbGJ4aFVkRUtHMDhCMzU; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:04 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "519.0",
-          "x-ratelimit-reset": "510",
-          "x-ratelimit-used": "81",
+          "x-ratelimit-remaining": "529.0",
+          "x-ratelimit-reset": "56",
+          "x-ratelimit-used": "71",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -3871,7 +3871,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:30",
+      "recorded_at": "2018-02-24T04:39:04",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -3884,7 +3884,7 @@
           "Connection": "keep-alive",
           "Content-Length": "47",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444890005.Z0FBQUFBQmFrT09hdmhuZnVVeno2bG1fcnRveTB6NzB0OXhfVDdEcEJfekowZkdnNWNHT3Z3VmpfeElCSGpYbVRyalV6ZVotem9iaFhLS1dyV0MtT1JlaVRnTVpDYmRDcGZVZ1ZoUF9SaGV2TnBGRk9xLTA3UWJwaGlOWmplbzdLSkpLZ2MwNURYajI",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447144077.Z0FBQUFBQmFrT3hvQXhfOTJLXzJ6czhXMVA1eFFNZ3RCWDVFWUZWTWREanpoYVFGWldfU1ZpRTlmcUNPQ21hVmE2a0JaUXFuVkhDdmNBVXJtdkpmZTZZbW1LR2xVazFjd2NNTHdrWWE5SzZldmd3ZGcwaTZGUmpqM3lYcjRMbGJ4aFVkRUtHMDhCMzU",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -3893,14 +3893,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": true, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": true, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:30 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:04 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -3908,16 +3908,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444890.094159,VS0,VE300",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447144.158653,VS0,VE112",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444890130.Z0FBQUFBQmFrT09hekFSdU1mM3N0aHpPSExYUWRpcGVmd2lUQTBNM3p2enBZSjRONzBuOTBpZzlxc2FCYm5yX3poSk9MazJzLWRmZjREWWdZWW1KR2lYZU54aHRicVgxdWRqdW52SnIweEZCWTBDdVgwTjk1MG9JOTl5YmFQeXdodFl5ZDljZm9yd3g; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:30 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447144198.Z0FBQUFBQmFrT3hvbHlZWHZxYjZweDczOVlSY2h2aURjMzFpUG96ZXUwZW1JSGFoc0NmLVA1RGtwa2NVU3htWFdsSGRWT3NXdEFHdkVvMUt3anVqNW1oYzZPMUZRMUtKak5BT2NPbkdZSEUtbF9RcW41VkMtWjZncWxQQzJfa1I3cDBNQ0JUaWtRdjc; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:04 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "518.0",
-          "x-ratelimit-reset": "510",
-          "x-ratelimit-used": "82",
+          "x-ratelimit-remaining": "528.0",
+          "x-ratelimit-reset": "56",
+          "x-ratelimit-used": "72",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -3928,7 +3928,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:30",
+      "recorded_at": "2018-02-24T04:39:04",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -3941,7 +3941,7 @@
           "Connection": "keep-alive",
           "Content-Length": "48",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444890130.Z0FBQUFBQmFrT09hekFSdU1mM3N0aHpPSExYUWRpcGVmd2lUQTBNM3p2enBZSjRONzBuOTBpZzlxc2FCYm5yX3poSk9MazJzLWRmZjREWWdZWW1KR2lYZU54aHRicVgxdWRqdW52SnIweEZCWTBDdVgwTjk1MG9JOTl5YmFQeXdodFl5ZDljZm9yd3g",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447144198.Z0FBQUFBQmFrT3hvbHlZWHZxYjZweDczOVlSY2h2aURjMzFpUG96ZXUwZW1JSGFoc0NmLVA1RGtwa2NVU3htWFdsSGRWT3NXdEFHdkVvMUt3anVqNW1oYzZPMUZRMUtKak5BT2NPbkdZSEUtbF9RcW41VkMtWjZncWxQQzJfa1I3cDBNQ0JUaWtRdjc",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -3950,14 +3950,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1684",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:30 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:04 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -3965,16 +3965,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444890.487331,VS0,VE122",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447144.295355,VS0,VE246",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444890523.Z0FBQUFBQmFrT09hcnJYZTFYWE9KY0NuMWx0RFd0MVlNNW5qbnZhVWZ5eEZlNVFsZ21pYUF0dnZoaWtXaEk3cGhXcXdIZmQwRkJidGowQ3Flb3JXanVlX2lmRG12b2FZQWFSTVJlM0dDR1F6ZlZIQ0d4OVhEMlVQZU9qMG5sVWlfWTBLZlIxQmVmcVA; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:30 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447144330.Z0FBQUFBQmFrT3hvdXpYd1d2Xy12LThGRzJPY2wxc3ZodGQyRHpOcDJINmUya1pqWU9oQkRVMlJXQWlOQXNsLWdwOXRid1lidlZZUWZfM1NiQURYdENvQWNjZExEMGdzdEpHd3FVUXZaZDY4TkFBbHNtWmEyeHRoZVNITFlWYS16MGdVZ1BZcUpvLUQ; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:04 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "517.0",
-          "x-ratelimit-reset": "510",
-          "x-ratelimit-used": "83",
+          "x-ratelimit-remaining": "527.0",
+          "x-ratelimit-reset": "56",
+          "x-ratelimit-used": "73",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -3985,7 +3985,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:30",
+      "recorded_at": "2018-02-24T04:39:04",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -3998,7 +3998,7 @@
           "Connection": "keep-alive",
           "Content-Length": "61",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444890523.Z0FBQUFBQmFrT09hcnJYZTFYWE9KY0NuMWx0RFd0MVlNNW5qbnZhVWZ5eEZlNVFsZ21pYUF0dnZoaWtXaEk3cGhXcXdIZmQwRkJidGowQ3Flb3JXanVlX2lmRG12b2FZQWFSTVJlM0dDR1F6ZlZIQ0d4OVhEMlVQZU9qMG5sVWlfWTBLZlIxQmVmcVA",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447144330.Z0FBQUFBQmFrT3hvdXpYd1d2Xy12LThGRzJPY2wxc3ZodGQyRHpOcDJINmUya1pqWU9oQkRVMlJXQWlOQXNsLWdwOXRid1lidlZZUWZfM1NiQURYdENvQWNjZExEMGdzdEpHd3FVUXZaZDY4TkFBbHNtWmEyeHRoZVNITFlWYS16MGdVZ1BZcUpvLUQ",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -4007,14 +4007,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": true, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": true, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:30 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:04 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -4022,16 +4022,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444891.635121,VS0,VE103",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447145.642402,VS0,VE196",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444890668.Z0FBQUFBQmFrT09hMzBKa1B1M0w1ak9YdmpsZGxjcEFXcTBXV1dXSzZWRFV0emtyRTJaOGwwQWVOX0RrcFdkdW0wcGtZckxnMHN5c0J1RS00eldpMXd3WnlSdmctclJFRjlPXzg5N05Odk9JUHdHbVFFazVENW1JbkZjNVBLNGJzaFdtRGhIcXJUQm0; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:30 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447144678.Z0FBQUFBQmFrT3hvVV9FdllicEU4WmJLd1YzOFpfNEk0ZUU0R2FFWkU5QWZSb0pzcUFqdWI1VjZwRDAzMzBtT1dEdmdsdGtudEgtTHU3UVg4WUFqT0Y3SEotN1Q2Um1zcFNZVmx4cWN5cHB6cVQwbFMtQzJVX3RsZVdHR3NKaFhnVEhKdkhQSVphelo; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:04 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "516.0",
-          "x-ratelimit-reset": "510",
-          "x-ratelimit-used": "84",
+          "x-ratelimit-remaining": "526.0",
+          "x-ratelimit-reset": "56",
+          "x-ratelimit-used": "74",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -4042,7 +4042,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:30",
+      "recorded_at": "2018-02-24T04:39:04",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -4055,7 +4055,7 @@
           "Connection": "keep-alive",
           "Content-Length": "62",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444890668.Z0FBQUFBQmFrT09hMzBKa1B1M0w1ak9YdmpsZGxjcEFXcTBXV1dXSzZWRFV0emtyRTJaOGwwQWVOX0RrcFdkdW0wcGtZckxnMHN5c0J1RS00eldpMXd3WnlSdmctclJFRjlPXzg5N05Odk9JUHdHbVFFazVENW1JbkZjNVBLNGJzaFdtRGhIcXJUQm0",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447144678.Z0FBQUFBQmFrT3hvVV9FdllicEU4WmJLd1YzOFpfNEk0ZUU0R2FFWkU5QWZSb0pzcUFqdWI1VjZwRDAzMzBtT1dEdmdsdGtudEgtTHU3UVg4WUFqT0Y3SEotN1Q2Um1zcFNZVmx4cWN5cHB6cVQwbFMtQzJVX3RsZVdHR3NKaFhnVEhKdkhQSVphelo",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -4064,14 +4064,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1684",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:30 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:04 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -4079,16 +4079,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444891.765009,VS0,VE103",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447145.866531,VS0,VE102",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444890817.Z0FBQUFBQmFrT09hb2I4bHUtUGhyYlozT2RxSDVpR2FkaEVJMnRoMFFjX1JTcTlLSVZadG9XR3RrY2lMVXBYY1A0SFZlTlFWaWhnOEllYld1T2RXYWJqTUNsUGJfUDN5VlZBaDdrS3hlUWI3UkxNSllWd29Ta3cxZEk0RGxyUWdqU2J1cU1ld053bHA; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:30 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447144903.Z0FBQUFBQmFrT3hvVmwwbVB4WjJabEV0eFNKVm9zbkxLUUZtamNmd1VaNUhSMTJhUS1jLW10S2k1dFhuUFliTGh0bFpDT2phN1NoZU9BQ3pXZkVqNWtzWlNJUjlpZ0s2ZWppT2h3MGo3UncxcnlzQjBZa1QxLUIxNFZqZkY3dHFsWUxTQm4zcE5ieVo; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:04 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "515.0",
-          "x-ratelimit-reset": "510",
-          "x-ratelimit-used": "85",
+          "x-ratelimit-remaining": "525.0",
+          "x-ratelimit-reset": "56",
+          "x-ratelimit-used": "75",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -4099,7 +4099,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:30",
+      "recorded_at": "2018-02-24T04:39:05",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -4112,7 +4112,7 @@
           "Connection": "keep-alive",
           "Content-Length": "49",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444890817.Z0FBQUFBQmFrT09hb2I4bHUtUGhyYlozT2RxSDVpR2FkaEVJMnRoMFFjX1JTcTlLSVZadG9XR3RrY2lMVXBYY1A0SFZlTlFWaWhnOEllYld1T2RXYWJqTUNsUGJfUDN5VlZBaDdrS3hlUWI3UkxNSllWd29Ta3cxZEk0RGxyUWdqU2J1cU1ld053bHA",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447144903.Z0FBQUFBQmFrT3hvVmwwbVB4WjJabEV0eFNKVm9zbkxLUUZtamNmd1VaNUhSMTJhUS1jLW10S2k1dFhuUFliTGh0bFpDT2phN1NoZU9BQ3pXZkVqNWtzWlNJUjlpZ0s2ZWppT2h3MGo3UncxcnlzQjBZa1QxLUIxNFZqZkY3dHFsWUxTQm4zcE5ieVo",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -4121,14 +4121,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": true, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": true, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:30 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:05 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -4136,16 +4136,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444891.895543,VS0,VE97",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447145.998023,VS0,VE98",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444890932.Z0FBQUFBQmFrT09hSmdWZDIzeF9Ka2lsbzFmblNsYk1ZaHp1bVY1NmRRVUhzemNuUERXZXp0VnBKUEhsdlhISXotTnhhb05lRXlOTkNLalh6dWYtbjVjNGpqNWpYeTRtV2NzVHR2d2gyTkFDblpVRlMzcDlBcm45WUw4aTUtREZwOEN5U1JDQ1ZPRlM; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:30 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447145029.Z0FBQUFBQmFrT3hwR09Dd1JZZFJIVjBRLWlIOHg5WHY2QmhhVmdKdDg5WkRiZlBGa25hbDhITXpNM0ZOQlVQMlQ4M1N6MGVlWEJURGR0Mm9WMk9ZSHRfTU1IbFMwQnZ4cFlNY21WZ25mVHpUVzRjZ1U5VVJiNEtxOWxPcW9kRUpxUDJFc0p0T21OTUk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:05 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "514.0",
-          "x-ratelimit-reset": "510",
-          "x-ratelimit-used": "86",
+          "x-ratelimit-remaining": "524.0",
+          "x-ratelimit-reset": "55",
+          "x-ratelimit-used": "76",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -4156,7 +4156,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:31",
+      "recorded_at": "2018-02-24T04:39:05",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -4169,7 +4169,7 @@
           "Connection": "keep-alive",
           "Content-Length": "50",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444890932.Z0FBQUFBQmFrT09hSmdWZDIzeF9Ka2lsbzFmblNsYk1ZaHp1bVY1NmRRVUhzemNuUERXZXp0VnBKUEhsdlhISXotTnhhb05lRXlOTkNLalh6dWYtbjVjNGpqNWpYeTRtV2NzVHR2d2gyTkFDblpVRlMzcDlBcm45WUw4aTUtREZwOEN5U1JDQ1ZPRlM",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447145029.Z0FBQUFBQmFrT3hwR09Dd1JZZFJIVjBRLWlIOHg5WHY2QmhhVmdKdDg5WkRiZlBGa25hbDhITXpNM0ZOQlVQMlQ4M1N6MGVlWEJURGR0Mm9WMk9ZSHRfTU1IbFMwQnZ4cFlNY21WZ25mVHpUVzRjZ1U5VVJiNEtxOWxPcW9kRUpxUDJFc0p0T21OTUk",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -4178,14 +4178,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1684",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:31 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:05 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -4193,16 +4193,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444891.018223,VS0,VE105",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447145.122618,VS0,VE95",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444891050.Z0FBQUFBQmFrT09ialY4X0ZVb2pxS1FZSXVoRFFiY2hweXI2elI1WVl1bHBONnA0c2drWjQwbW4zSWIyTGRGRTNJZ0ZwVmoxcHhEdTV5b1llX29jdjFwU3NVWW5TdHR1STZwRTJzMXZiSXlyMXVQS2VWNUhjMmFQNk9zS1VNWjdJY1ZEbWF4WlpQdW4; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:31 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447145154.Z0FBQUFBQmFrT3hwaHdTUGpCaTl0UkxOVjdMT0dXSkJxOEx4MzhlUnVya0NEYm5FSGtjQ0VHWVcxUDVHWWt0dDlUN1l0NEpyV0NaVlJ2YS1vM3BGb2Zqckd2a2o5TDEzOFJvZk5MWmgzaEhUeUY1UEhaWTU3SEk2NFlaeW9Gb3lZczRoeGpLRTlMOHA; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:05 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "513.0",
-          "x-ratelimit-reset": "509",
-          "x-ratelimit-used": "87",
+          "x-ratelimit-remaining": "523.0",
+          "x-ratelimit-reset": "55",
+          "x-ratelimit-used": "77",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -4213,7 +4213,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:31",
+      "recorded_at": "2018-02-24T04:39:05",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -4226,7 +4226,7 @@
           "Connection": "keep-alive",
           "Content-Length": "54",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444891050.Z0FBQUFBQmFrT09ialY4X0ZVb2pxS1FZSXVoRFFiY2hweXI2elI1WVl1bHBONnA0c2drWjQwbW4zSWIyTGRGRTNJZ0ZwVmoxcHhEdTV5b1llX29jdjFwU3NVWW5TdHR1STZwRTJzMXZiSXlyMXVQS2VWNUhjMmFQNk9zS1VNWjdJY1ZEbWF4WlpQdW4",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447145154.Z0FBQUFBQmFrT3hwaHdTUGpCaTl0UkxOVjdMT0dXSkJxOEx4MzhlUnVya0NEYm5FSGtjQ0VHWVcxUDVHWWt0dDlUN1l0NEpyV0NaVlJ2YS1vM3BGb2Zqckd2a2o5TDEzOFJvZk5MWmgzaEhUeUY1UEhaWTU3SEk2NFlaeW9Gb3lZczRoeGpLRTlMOHA",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -4235,14 +4235,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": true, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": true, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:31 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:05 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -4250,16 +4250,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444891.150810,VS0,VE97",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447145.244767,VS0,VE103",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444891193.Z0FBQUFBQmFrT09iU1ZOYndKaFVObTE5cEFndXRlNHJCVXJlLUp2NFpvRk5EUDlBTmJsM0FsdzlZMFZXSmQ3bTQ1VmN3TTFhdEo5RHM2eXRaSlROb2RxaHFnc01TUDI4SzZWYXgxRWdkN2ZmY0NhUTJuVnlIQWV1QVo0R09kUWRFbDN2aWE0NV9oQlQ; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:31 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447145279.Z0FBQUFBQmFrT3hwV21fQkVYWmNGN3hqYnlpYlFoeURXeUhvMnpXY3R3aDNMY0JMWVJ0Rms0QTBleGhsM2lpTEtuVFVPRHlaT1JaSHUzQktUUndZNE5fN2dTR00xSGlpUHhNX3lSZXJycUd4TS1tWGlUYW45ZVo5TTNzQm5CNWlBUGJYb3FpZDZJVVE; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:05 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "512.0",
-          "x-ratelimit-reset": "509",
-          "x-ratelimit-used": "88",
+          "x-ratelimit-remaining": "522.0",
+          "x-ratelimit-reset": "55",
+          "x-ratelimit-used": "78",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -4270,7 +4270,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:31",
+      "recorded_at": "2018-02-24T04:39:05",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -4283,7 +4283,7 @@
           "Connection": "keep-alive",
           "Content-Length": "55",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444891193.Z0FBQUFBQmFrT09iU1ZOYndKaFVObTE5cEFndXRlNHJCVXJlLUp2NFpvRk5EUDlBTmJsM0FsdzlZMFZXSmQ3bTQ1VmN3TTFhdEo5RHM2eXRaSlROb2RxaHFnc01TUDI4SzZWYXgxRWdkN2ZmY0NhUTJuVnlIQWV1QVo0R09kUWRFbDN2aWE0NV9oQlQ",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447145279.Z0FBQUFBQmFrT3hwV21fQkVYWmNGN3hqYnlpYlFoeURXeUhvMnpXY3R3aDNMY0JMWVJ0Rms0QTBleGhsM2lpTEtuVFVPRHlaT1JaSHUzQktUUndZNE5fN2dTR00xSGlpUHhNX3lSZXJycUd4TS1tWGlUYW45ZVo5TTNzQm5CNWlBUGJYb3FpZDZJVVE",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -4292,14 +4292,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1684",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:31 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:05 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -4307,16 +4307,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444891.273992,VS0,VE97",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447145.373435,VS0,VE104",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444891309.Z0FBQUFBQmFrT09icXdvVDhiM0lucTVNWENrRVdnRVQtU3VEYktwTE4zM20yRTJrcm1CVzBnUXp3WDJFMVpIUkhXdGlpYjAxblZKU1RoZmNrWDNvWExkY2RzdHViWlZneXM0cGJHbzQ5QjBvMnlRVEd2cDZpQThwN01FZGZKRXBEY0tjZ2dGaHpLOTg; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:31 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447145409.Z0FBQUFBQmFrT3hwV1czZ0ZpUjJzdWUwZnBMaVFfYVdneDA2bHowSUlPaC1EMW04bFJ5UlF2Sk5VSlhsSFUtdENfZ1A1WkU1UXQ3MlRhQ0t2aE1TaFdTWTJGOHlIcVpaM2NCaDcySkZVWjd0QUNuYzlrTzYzSDktSEVPNUJLLVNvZFkzSkNuZlAyMks; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:05 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "511.0",
-          "x-ratelimit-reset": "509",
-          "x-ratelimit-used": "89",
+          "x-ratelimit-remaining": "521.0",
+          "x-ratelimit-reset": "55",
+          "x-ratelimit-used": "79",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -4327,7 +4327,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:31",
+      "recorded_at": "2018-02-24T04:39:05",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -4340,7 +4340,7 @@
           "Connection": "keep-alive",
           "Content-Length": "55",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444891309.Z0FBQUFBQmFrT09icXdvVDhiM0lucTVNWENrRVdnRVQtU3VEYktwTE4zM20yRTJrcm1CVzBnUXp3WDJFMVpIUkhXdGlpYjAxblZKU1RoZmNrWDNvWExkY2RzdHViWlZneXM0cGJHbzQ5QjBvMnlRVEd2cDZpQThwN01FZGZKRXBEY0tjZ2dGaHpLOTg",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447145409.Z0FBQUFBQmFrT3hwV1czZ0ZpUjJzdWUwZnBMaVFfYVdneDA2bHowSUlPaC1EMW04bFJ5UlF2Sk5VSlhsSFUtdENfZ1A1WkU1UXQ3MlRhQ0t2aE1TaFdTWTJGOHlIcVpaM2NCaDcySkZVWjd0QUNuYzlrTzYzSDktSEVPNUJLLVNvZFkzSkNuZlAyMks",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -4349,14 +4349,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": true, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": true, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:31 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:05 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -4364,16 +4364,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444891.399651,VS0,VE96",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447146.503700,VS0,VE109",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444891436.Z0FBQUFBQmFrT09iVU5IWU05MTB6TWZpeXB0YUFiLVBkNlNHeHh2d2hxOHllMkVvd3FmR3B3Mks3RzJEbWIyeGZYdjlFWUNrd1RkRFBKSF9UT1lWQWV1Qlhma0t1U0dqR1JMaWJFb0NGWlo5TGZSc0dnWnJRZUY0WWluNkhLY0xjLXVqcDBhYUdWVzI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:31 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447145542.Z0FBQUFBQmFrT3hwbmxBcFRYbHhoYVduX1JBVjJ2SkVwdkpybm5xX1FGMTVZSG9YbEw2NlRMMDFuRFdiX3plcjhlU25HaGlFVW4tUW02TVZTcVJpQXNoRnV4ZkxkZlZfSnBRcXk2WW04LVdpUFFDUmc0dTNUc1RQVzlGLTY1QkphQmlIZW1LNnl4NDk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:05 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "510.0",
-          "x-ratelimit-reset": "509",
-          "x-ratelimit-used": "90",
+          "x-ratelimit-remaining": "520.0",
+          "x-ratelimit-reset": "55",
+          "x-ratelimit-used": "80",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -4384,7 +4384,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:31",
+      "recorded_at": "2018-02-24T04:39:05",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -4397,7 +4397,7 @@
           "Connection": "keep-alive",
           "Content-Length": "56",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444891436.Z0FBQUFBQmFrT09iVU5IWU05MTB6TWZpeXB0YUFiLVBkNlNHeHh2d2hxOHllMkVvd3FmR3B3Mks3RzJEbWIyeGZYdjlFWUNrd1RkRFBKSF9UT1lWQWV1Qlhma0t1U0dqR1JMaWJFb0NGWlo5TGZSc0dnWnJRZUY0WWluNkhLY0xjLXVqcDBhYUdWVzI",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447145542.Z0FBQUFBQmFrT3hwbmxBcFRYbHhoYVduX1JBVjJ2SkVwdkpybm5xX1FGMTVZSG9YbEw2NlRMMDFuRFdiX3plcjhlU25HaGlFVW4tUW02TVZTcVJpQXNoRnV4ZkxkZlZfSnBRcXk2WW04LVdpUFFDUmc0dTNUc1RQVzlGLTY1QkphQmlIZW1LNnl4NDk",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -4406,14 +4406,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1684",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:31 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:05 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -4421,16 +4421,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444892.521772,VS0,VE96",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447146.662679,VS0,VE106",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444891555.Z0FBQUFBQmFrT09iYUhwLThmNzNVMTFmNS1vV1VjdWNPT29pem1VM1FHS3FqNVo0MEJnelJnSTdRdDNTLV9iQ05pZUdReWdwN0RxS1MxOHY0b2dqWThzTlZWM2RPTC0tZmxPZy1OaVk1V3lKX0hBZ1J0LUxWdE5ZNzktWEdRR1htTk9VSUpUMC1Tb1A; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:31 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447145700.Z0FBQUFBQmFrT3hwQjVSSVFVMURtUXlSNnVsdnlMTjFOUEZUdnVKdHlwUElUOXNDeG1xTkx1Y09XNHlPNGNDU2ZzTUxjX1JSamdWbEI1RGVJWDhxeHZqVnJ5d3BnRHcyNnFxSUNfek0xQ3BuaENETmVvVWtCazBYQUlsaXFhRmZwVnpBeXczWHNSQjE; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:05 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "509.0",
-          "x-ratelimit-reset": "509",
-          "x-ratelimit-used": "91",
+          "x-ratelimit-remaining": "519.0",
+          "x-ratelimit-reset": "55",
+          "x-ratelimit-used": "81",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -4441,7 +4441,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:31",
+      "recorded_at": "2018-02-24T04:39:05",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -4454,7 +4454,7 @@
           "Connection": "keep-alive",
           "Content-Length": "52",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444891555.Z0FBQUFBQmFrT09iYUhwLThmNzNVMTFmNS1vV1VjdWNPT29pem1VM1FHS3FqNVo0MEJnelJnSTdRdDNTLV9iQ05pZUdReWdwN0RxS1MxOHY0b2dqWThzTlZWM2RPTC0tZmxPZy1OaVk1V3lKX0hBZ1J0LUxWdE5ZNzktWEdRR1htTk9VSUpUMC1Tb1A",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447145700.Z0FBQUFBQmFrT3hwQjVSSVFVMURtUXlSNnVsdnlMTjFOUEZUdnVKdHlwUElUOXNDeG1xTkx1Y09XNHlPNGNDU2ZzTUxjX1JSamdWbEI1RGVJWDhxeHZqVnJ5d3BnRHcyNnFxSUNfek0xQ3BuaENETmVvVWtCazBYQUlsaXFhRmZwVnpBeXczWHNSQjE",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -4463,14 +4463,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": true, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": true, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:31 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:05 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -4478,16 +4478,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444892.644292,VS0,VE105",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447146.801381,VS0,VE104",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444891674.Z0FBQUFBQmFrT09iQUlWVzZzVG00aHpwR1pSeVRocEwxLWYyelE0U19oQ3A1ZjNPMzZsN1BaVFBkSTlzSWtQQWY0cUxGQ1pDOGFTYjBGZjJYVVBmTmNNLU1YWW1ETEVlX2hLaXlRRldnT3ZGYUpVNmpiX3QxN1RxeHdmem56bDZNa0JIX3JCTzBUZU0; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:31 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447145836.Z0FBQUFBQmFrT3hwb01aM1pGNTllMWxsZXZrU3BTWDFJZEVqeTlKcXVxbXQxTFRDSVFNX1pZbF9jbGZHSlp6Q0NROF9sSlltRzRLT3JsbWVRSXp6ajhnbG1QSkFRZk5IM0FZSWZ5V0FnOUM3SVRnY0oySE5DaktHTEtkV3NTQlRWY1lEZkc0aFVpUHA; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:05 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "508.0",
-          "x-ratelimit-reset": "509",
-          "x-ratelimit-used": "92",
+          "x-ratelimit-remaining": "518.0",
+          "x-ratelimit-reset": "55",
+          "x-ratelimit-used": "82",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -4498,7 +4498,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:31",
+      "recorded_at": "2018-02-24T04:39:06",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -4511,7 +4511,7 @@
           "Connection": "keep-alive",
           "Content-Length": "53",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444891674.Z0FBQUFBQmFrT09iQUlWVzZzVG00aHpwR1pSeVRocEwxLWYyelE0U19oQ3A1ZjNPMzZsN1BaVFBkSTlzSWtQQWY0cUxGQ1pDOGFTYjBGZjJYVVBmTmNNLU1YWW1ETEVlX2hLaXlRRldnT3ZGYUpVNmpiX3QxN1RxeHdmem56bDZNa0JIX3JCTzBUZU0",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447145836.Z0FBQUFBQmFrT3hwb01aM1pGNTllMWxsZXZrU3BTWDFJZEVqeTlKcXVxbXQxTFRDSVFNX1pZbF9jbGZHSlp6Q0NROF9sSlltRzRLT3JsbWVRSXp6ajhnbG1QSkFRZk5IM0FZSWZ5V0FnOUM3SVRnY0oySE5DaktHTEtkV3NTQlRWY1lEZkc0aFVpUHA",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -4520,14 +4520,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1684",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:31 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:06 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -4535,16 +4535,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444892.780936,VS0,VE107",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447146.930820,VS0,VE117",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444891817.Z0FBQUFBQmFrT09ia0Rzd2FUMGJfZnZkVC1mY1F2SUxSaHo5R1VhX3B2Z001VkdXa3BOOXpmODhJOUY0b2R0cWFxaGMyNUFyeUNsWmFOVzNBeDBIMm4zQmEwRXhVMlFYUGc5NHpuVUJEUHpsU1dGRG1kYXhDbGZKS2lfanNkWi1SWWlmY1Z1cVBxcEM; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:31 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447145967.Z0FBQUFBQmFrT3hxVGJJX3BjTkEtb2U5MkZHUGlyUDRSV3RaNjlUVk9SbGJUSVNhbC1UT2lrVV9CS05fZFoxMWtwd1U3MzRRRTFKWUVfNmZkZkwtRW9seFNjQk5WWkFpejlFZjhVeUQtaFJQb19QOE14LWlGd1I0a2NpR2lkbW1jeFpPLWtFTEFvUzE; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:06 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "507.0",
-          "x-ratelimit-reset": "509",
-          "x-ratelimit-used": "93",
+          "x-ratelimit-remaining": "517.0",
+          "x-ratelimit-reset": "55",
+          "x-ratelimit-used": "83",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -4555,7 +4555,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:32",
+      "recorded_at": "2018-02-24T04:39:06",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -4568,7 +4568,7 @@
           "Connection": "keep-alive",
           "Content-Length": "51",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444891817.Z0FBQUFBQmFrT09ia0Rzd2FUMGJfZnZkVC1mY1F2SUxSaHo5R1VhX3B2Z001VkdXa3BOOXpmODhJOUY0b2R0cWFxaGMyNUFyeUNsWmFOVzNBeDBIMm4zQmEwRXhVMlFYUGc5NHpuVUJEUHpsU1dGRG1kYXhDbGZKS2lfanNkWi1SWWlmY1Z1cVBxcEM",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447145967.Z0FBQUFBQmFrT3hxVGJJX3BjTkEtb2U5MkZHUGlyUDRSV3RaNjlUVk9SbGJUSVNhbC1UT2lrVV9CS05fZFoxMWtwd1U3MzRRRTFKWUVfNmZkZkwtRW9seFNjQk5WWkFpejlFZjhVeUQtaFJQb19QOE14LWlGd1I0a2NpR2lkbW1jeFpPLWtFTEFvUzE",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -4577,14 +4577,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": true, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": true, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:32 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:06 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -4592,16 +4592,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444892.915626,VS0,VE112",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447146.086359,VS0,VE103",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444891951.Z0FBQUFBQmFrT09iY2lwSTBqSkVuMGk4eDIyZURsdzdEdUJTYlp0cmJnUm1jMUtuSDJJeTdUU184MUxFVXpGTWVzOTRTYnFUQ3hjN01UWm9sSlMybFFqdTlJZjNRZWpRWjJKVnFyT3ozTkkzNzNNTXZ0d1k1dXZGX19nQ3RHb1E4SjEyZ1JFSzR3OG0; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:31 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447146120.Z0FBQUFBQmFrT3hxcGloNXAtajdwTGRhMTNEeEEwN0JzaTB2V2lyd1pFTmVrN1ZQVGxoS25mWVZtSTltbUNEa2lQeFB4NzBYdEFiQmdmdW0xN3FBZzNCX2NBNU1EU1Vjc0RCUVZIc25JT0ZsRzJDQUZTWldvTGs2d1RQWGRTV2tSRWZGUlFSUlp6MWk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:06 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "506.0",
-          "x-ratelimit-reset": "509",
-          "x-ratelimit-used": "94",
+          "x-ratelimit-remaining": "516.0",
+          "x-ratelimit-reset": "54",
+          "x-ratelimit-used": "84",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -4612,7 +4612,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:32",
+      "recorded_at": "2018-02-24T04:39:06",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -4625,7 +4625,7 @@
           "Connection": "keep-alive",
           "Content-Length": "52",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444891951.Z0FBQUFBQmFrT09iY2lwSTBqSkVuMGk4eDIyZURsdzdEdUJTYlp0cmJnUm1jMUtuSDJJeTdUU184MUxFVXpGTWVzOTRTYnFUQ3hjN01UWm9sSlMybFFqdTlJZjNRZWpRWjJKVnFyT3ozTkkzNzNNTXZ0d1k1dXZGX19nQ3RHb1E4SjEyZ1JFSzR3OG0",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447146120.Z0FBQUFBQmFrT3hxcGloNXAtajdwTGRhMTNEeEEwN0JzaTB2V2lyd1pFTmVrN1ZQVGxoS25mWVZtSTltbUNEa2lQeFB4NzBYdEFiQmdmdW0xN3FBZzNCX2NBNU1EU1Vjc0RCUVZIc25JT0ZsRzJDQUZTWldvTGs2d1RQWGRTV2tSRWZGUlFSUlp6MWk",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -4634,14 +4634,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1684",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:32 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:06 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -4649,16 +4649,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444892.054463,VS0,VE104",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447146.217241,VS0,VE101",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444892088.Z0FBQUFBQmFrT09jeFdLaTB1NVNvUV9Rb1VXMXpLUzdxU1ppU1c4YlR1RWdkZTBueHBocXpuUkhxRS0xOHRaWHowbFVqdzl4OVF6anZXcjQ2aW0zQVVIaEpGS2FqRUp0SGsxcDVZR2cyaXRyYXRrVk9Lb1Y5NklZb3hKS3FNWlR3bmp3aGN2TmhRQlQ; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:32 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447146253.Z0FBQUFBQmFrT3hxd3ZnY0R4SVFrbTQxMkoyZUp6MENicU9HZWk5SzJRVXFOeUFIbFhTZE1vREtKT0JORjM0ZGtSYXFoQkdqdGFQWU8tVkJzSzN0UVRiZWQ1UndCN1BoNDdZaThNdDN3ZlNxU1FXbDB5SEx5eXh4b21jN2hDRXdMaFVkZDFWcC1WOTA; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:06 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "505.0",
-          "x-ratelimit-reset": "508",
-          "x-ratelimit-used": "95",
+          "x-ratelimit-remaining": "515.0",
+          "x-ratelimit-reset": "54",
+          "x-ratelimit-used": "85",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -4669,7 +4669,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:32",
+      "recorded_at": "2018-02-24T04:39:06",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -4682,7 +4682,7 @@
           "Connection": "keep-alive",
           "Content-Length": "56",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444892088.Z0FBQUFBQmFrT09jeFdLaTB1NVNvUV9Rb1VXMXpLUzdxU1ppU1c4YlR1RWdkZTBueHBocXpuUkhxRS0xOHRaWHowbFVqdzl4OVF6anZXcjQ2aW0zQVVIaEpGS2FqRUp0SGsxcDVZR2cyaXRyYXRrVk9Lb1Y5NklZb3hKS3FNWlR3bmp3aGN2TmhRQlQ",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447146253.Z0FBQUFBQmFrT3hxd3ZnY0R4SVFrbTQxMkoyZUp6MENicU9HZWk5SzJRVXFOeUFIbFhTZE1vREtKT0JORjM0ZGtSYXFoQkdqdGFQWU8tVkJzSzN0UVRiZWQ1UndCN1BoNDdZaThNdDN3ZlNxU1FXbDB5SEx5eXh4b21jN2hDRXdMaFVkZDFWcC1WOTA",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -4691,14 +4691,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": true, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": true, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:32 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:06 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -4706,16 +4706,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444892.185180,VS0,VE95",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447146.353514,VS0,VE107",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444892208.Z0FBQUFBQmFrT09jRVRWWF9JbWpOcmJ5QmtuWllXX0djaTk4WTZoMUc3UkpDYzJxbDlrR2RycXg1dDJXUC1rZF9ISGpoNUNqd0wydDVlZmc2V3lWZjZieHdEOUQ4WWxZSjEwYUc4NWJkdGxfRGx0blV6b2lXcFZvVkVKdHJYdlpVNUlTeks1ZkJTaUc; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:32 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447146382.Z0FBQUFBQmFrT3hxZ0RCNzFqM2NMV01ubldZajJocVQxY2xYdWJvQk9VRElsMThjRXNLekkxXzk3VlZkZUJIekVLa2hiaFZxZWJpTkF3emtEUzljYVBqaHdYdnJmUmFySnZxbmFhaEdTc0dDZkZ4LVBzbHd3VWlCcE9Ua0REU09ucWZGaHRHSlpsSGg; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:06 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "504.0",
-          "x-ratelimit-reset": "508",
-          "x-ratelimit-used": "96",
+          "x-ratelimit-remaining": "514.0",
+          "x-ratelimit-reset": "54",
+          "x-ratelimit-used": "86",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -4726,7 +4726,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:32",
+      "recorded_at": "2018-02-24T04:39:06",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -4739,7 +4739,7 @@
           "Connection": "keep-alive",
           "Content-Length": "57",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444892208.Z0FBQUFBQmFrT09jRVRWWF9JbWpOcmJ5QmtuWllXX0djaTk4WTZoMUc3UkpDYzJxbDlrR2RycXg1dDJXUC1rZF9ISGpoNUNqd0wydDVlZmc2V3lWZjZieHdEOUQ4WWxZSjEwYUc4NWJkdGxfRGx0blV6b2lXcFZvVkVKdHJYdlpVNUlTeks1ZkJTaUc",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447146382.Z0FBQUFBQmFrT3hxZ0RCNzFqM2NMV01ubldZajJocVQxY2xYdWJvQk9VRElsMThjRXNLekkxXzk3VlZkZUJIekVLa2hiaFZxZWJpTkF3emtEUzljYVBqaHdYdnJmUmFySnZxbmFhaEdTc0dDZkZ4LVBzbHd3VWlCcE9Ua0REU09ucWZGaHRHSlpsSGg",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -4748,14 +4748,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1684",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:32 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:06 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -4763,16 +4763,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444892.306782,VS0,VE477",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447147.511559,VS0,VE99",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444892344.Z0FBQUFBQmFrT09jLVRocHQtUEEwVnZERVNHUGZOSzVXU0JxTjEybFdBYm9Xd0tiNG84T045c2xCQWtaU0dBc0t6X3FZOGdhWFNQUjZqR0lZNW1CdmNabHJ4OEgxREhUNHN3dEZkV0FKZDk4TDNTR3JwTEpyOWRYRU1NOTUxUGF5TVpTRjNMbnE3Z08; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:32 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447146584.Z0FBQUFBQmFrT3hxc2ZKVTkydmVEUE90UTdxS2dFX1hZaUFoam5ibEFURjd6aUNkMVRrSnlrVTV4Qk1OS2tHTzJCZjBzcE1laTB4Qmk3alZhWDhOTEhXU29PX1VuYnNFMUJubklfRG1pSldMLU5ZaEUxdmFiak5xV1ZLeGJJQWFqSU1BSUpEQzFCcE0; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:06 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "503.0",
-          "x-ratelimit-reset": "508",
-          "x-ratelimit-used": "97",
+          "x-ratelimit-remaining": "513.0",
+          "x-ratelimit-reset": "54",
+          "x-ratelimit-used": "87",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -4783,7 +4783,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:32",
+      "recorded_at": "2018-02-24T04:39:06",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -4796,7 +4796,7 @@
           "Connection": "keep-alive",
           "Content-Length": "55",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444892344.Z0FBQUFBQmFrT09jLVRocHQtUEEwVnZERVNHUGZOSzVXU0JxTjEybFdBYm9Xd0tiNG84T045c2xCQWtaU0dBc0t6X3FZOGdhWFNQUjZqR0lZNW1CdmNabHJ4OEgxREhUNHN3dEZkV0FKZDk4TDNTR3JwTEpyOWRYRU1NOTUxUGF5TVpTRjNMbnE3Z08",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447146584.Z0FBQUFBQmFrT3hxc2ZKVTkydmVEUE90UTdxS2dFX1hZaUFoam5ibEFURjd6aUNkMVRrSnlrVTV4Qk1OS2tHTzJCZjBzcE1laTB4Qmk3alZhWDhOTEhXU29PX1VuYnNFMUJubklfRG1pSldMLU5ZaEUxdmFiak5xV1ZLeGJJQWFqSU1BSUpEQzFCcE0",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -4805,14 +4805,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": true, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": true, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:32 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:06 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -4820,16 +4820,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444893.842406,VS0,VE108",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447147.654669,VS0,VE98",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444892883.Z0FBQUFBQmFrT09jSkxRUUd4OFZGVUFLRkpha3lTQTlaMDl4SnBTYXRxNzZTOTN2UjVKZHNfZVIxMlZzVzVFMmN5X0xFWWgySXBSS3ViTmVpTk9PQVpMZFlKa1Y5dC1oY3RjRm5VLVptWXVocW8tSWRTeDRDOVpCUHpZbEZSSzhuZ0p1aDhuNVk5OGY; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:32 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447146680.Z0FBQUFBQmFrT3hxWTU4dmk3SmZiR3RObllQZnRRQTRQZEJMcnVYd3RqTkdzZ2tHQXNNbHVoZ3F4ZDVSTTZ1Rnc0Q05JcHljNWpUOXhheGMxQTlQWGpzbkRoQzc0dFU4a0ptZmZHa0ctNWc0a0NxT3Y1SmN4a1FHY2FvSXJ5dUpYUVRCc0ZXN1NtbU0; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:06 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "502.0",
-          "x-ratelimit-reset": "508",
-          "x-ratelimit-used": "98",
+          "x-ratelimit-remaining": "512.0",
+          "x-ratelimit-reset": "54",
+          "x-ratelimit-used": "88",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -4840,7 +4840,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:33",
+      "recorded_at": "2018-02-24T04:39:06",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -4853,7 +4853,7 @@
           "Connection": "keep-alive",
           "Content-Length": "56",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444892883.Z0FBQUFBQmFrT09jSkxRUUd4OFZGVUFLRkpha3lTQTlaMDl4SnBTYXRxNzZTOTN2UjVKZHNfZVIxMlZzVzVFMmN5X0xFWWgySXBSS3ViTmVpTk9PQVpMZFlKa1Y5dC1oY3RjRm5VLVptWXVocW8tSWRTeDRDOVpCUHpZbEZSSzhuZ0p1aDhuNVk5OGY",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447146680.Z0FBQUFBQmFrT3hxWTU4dmk3SmZiR3RObllQZnRRQTRQZEJMcnVYd3RqTkdzZ2tHQXNNbHVoZ3F4ZDVSTTZ1Rnc0Q05JcHljNWpUOXhheGMxQTlQWGpzbkRoQzc0dFU4a0ptZmZHa0ctNWc0a0NxT3Y1SmN4a1FHY2FvSXJ5dUpYUVRCc0ZXN1NtbU0",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -4862,14 +4862,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1684",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:33 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:06 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -4877,16 +4877,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444893.975238,VS0,VE101",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447147.793186,VS0,VE97",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444893011.Z0FBQUFBQmFrT09kR2hxQzhQa0Y4T0dqSnN4UUVxTGY3WFllMmxUTXdrcU5JTEJmNzR5T1FqYVg1REJ1TkhDWjNDczlxRHpIZ3dSd2N2U3dib2VyYy02TUZIVGtsVWFYNmlWRW1jNDBPNktaZTExaFdPUjdWQlE1ckw3NU1FZy1GWmFzOWU1OG12LS0; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:33 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447146831.Z0FBQUFBQmFrT3hxR0lnQzU3VGlsaEVRQ1cwbEd1RndSaDlXWkZpZ0hJNlI3dC1oaWZLOEZKOUpydS1CNllMLUFSdXQ5dmt1NXQ2RmllT3FHUTRob1d5LW02T25pbUtMRjdJX0RYWms5SHRFck1LYTB3bVBJRnZTXzBBZDdnR1UxcjlKMVhQMWNraFg; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:06 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "501.0",
-          "x-ratelimit-reset": "507",
-          "x-ratelimit-used": "99",
+          "x-ratelimit-remaining": "511.0",
+          "x-ratelimit-reset": "54",
+          "x-ratelimit-used": "89",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -4897,7 +4897,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:33",
+      "recorded_at": "2018-02-24T04:39:07",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -4910,7 +4910,7 @@
           "Connection": "keep-alive",
           "Content-Length": "59",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444893011.Z0FBQUFBQmFrT09kR2hxQzhQa0Y4T0dqSnN4UUVxTGY3WFllMmxUTXdrcU5JTEJmNzR5T1FqYVg1REJ1TkhDWjNDczlxRHpIZ3dSd2N2U3dib2VyYy02TUZIVGtsVWFYNmlWRW1jNDBPNktaZTExaFdPUjdWQlE1ckw3NU1FZy1GWmFzOWU1OG12LS0",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447146831.Z0FBQUFBQmFrT3hxR0lnQzU3VGlsaEVRQ1cwbEd1RndSaDlXWkZpZ0hJNlI3dC1oaWZLOEZKOUpydS1CNllMLUFSdXQ5dmt1NXQ2RmllT3FHUTRob1d5LW02T25pbUtMRjdJX0RYWms5SHRFck1LYTB3bVBJRnZTXzBBZDdnR1UxcjlKMVhQMWNraFg",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -4919,14 +4919,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": true, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": true, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:33 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:07 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -4934,16 +4934,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444893.102911,VS0,VE106",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447147.922044,VS0,VE101",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444893138.Z0FBQUFBQmFrT09kWklWZFZUX3JIZ21aVHoxdjJVM0x4Q01pZS1HWTM1eVZTSVhJbWZ3RlVYRG5sVlZ3Z1cyUzZLU2Q2Yk93cGRXVnVNMHNVdHZWMG5sVXBYWUtJUWNsX0JrV2Nib2lqTUQ4Mk1rSTY5YWM0d2ZHeHBhdDAydk54REhSN2o1a0lJOEc; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:33 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447146957.Z0FBQUFBQmFrT3hxYi05RXdMOUJLbzY1bEgzZDBQamxWZGNDdktPUWs4ZTBndlJQYU1waFVySnRmQnZ1eVVkQnJhTkZTZkRram4xR0xBRFdXa1prcGhoX3RiQlUwSzViNF9ZWTBCR0cxVUhwMlBzLUVUb3lKUWNvd0Y5cjBkM0o2dkYyY3pIb28xblE; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:06 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "500.0",
-          "x-ratelimit-reset": "507",
-          "x-ratelimit-used": "100",
+          "x-ratelimit-remaining": "510.0",
+          "x-ratelimit-reset": "54",
+          "x-ratelimit-used": "90",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -4954,7 +4954,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:33",
+      "recorded_at": "2018-02-24T04:39:07",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -4967,7 +4967,7 @@
           "Connection": "keep-alive",
           "Content-Length": "60",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444893138.Z0FBQUFBQmFrT09kWklWZFZUX3JIZ21aVHoxdjJVM0x4Q01pZS1HWTM1eVZTSVhJbWZ3RlVYRG5sVlZ3Z1cyUzZLU2Q2Yk93cGRXVnVNMHNVdHZWMG5sVXBYWUtJUWNsX0JrV2Nib2lqTUQ4Mk1rSTY5YWM0d2ZHeHBhdDAydk54REhSN2o1a0lJOEc",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447146957.Z0FBQUFBQmFrT3hxYi05RXdMOUJLbzY1bEgzZDBQamxWZGNDdktPUWs4ZTBndlJQYU1waFVySnRmQnZ1eVVkQnJhTkZTZkRram4xR0xBRFdXa1prcGhoX3RiQlUwSzViNF9ZWTBCR0cxVUhwMlBzLUVUb3lKUWNvd0Y5cjBkM0o2dkYyY3pIb28xblE",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -4976,14 +4976,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1684",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:33 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:07 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -4991,16 +4991,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444893.235533,VS0,VE105",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447147.048450,VS0,VE95",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444893270.Z0FBQUFBQmFrT09kem5ZZGFRZjhaR3ZUQkszeXBnMzN3VklRUjRUMzNvQXM4SElpcTNVY2VIRTFGZkNqS1VsN3RoR2hVS1RqU0lvYnItLW9PN3ItZW9pVjBjUHQybllZYlNOSGYzakMzZ3lsdUZMeHlSNWVsR1lDdGlJazRSVXFCNW5RRm9oUWJ1bjM; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:33 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447147081.Z0FBQUFBQmFrT3hyZWF4UDRRU2xicy1NTmYxR0VhbG5ia2Y4UWlBSEtydTRXZ01kS2hnQ0kxVTQtWmtSTWxWa3E3SUlJeW5KalBxYjJZQmJZR25jd2FIMy1lSHpHSklfYVpJWDFISkJ5cWRXMTlXTVBIUnRwRVFBcG5wVWNHMVFMd2pZVjVaWUF5elM; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:07 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "499.0",
-          "x-ratelimit-reset": "507",
-          "x-ratelimit-used": "101",
+          "x-ratelimit-remaining": "509.0",
+          "x-ratelimit-reset": "53",
+          "x-ratelimit-used": "91",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -5011,7 +5011,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:33",
+      "recorded_at": "2018-02-24T04:39:07",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -5024,7 +5024,7 @@
           "Connection": "keep-alive",
           "Content-Length": "58",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444893270.Z0FBQUFBQmFrT09kem5ZZGFRZjhaR3ZUQkszeXBnMzN3VklRUjRUMzNvQXM4SElpcTNVY2VIRTFGZkNqS1VsN3RoR2hVS1RqU0lvYnItLW9PN3ItZW9pVjBjUHQybllZYlNOSGYzakMzZ3lsdUZMeHlSNWVsR1lDdGlJazRSVXFCNW5RRm9oUWJ1bjM",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447147081.Z0FBQUFBQmFrT3hyZWF4UDRRU2xicy1NTmYxR0VhbG5ia2Y4UWlBSEtydTRXZ01kS2hnQ0kxVTQtWmtSTWxWa3E3SUlJeW5KalBxYjJZQmJZR25jd2FIMy1lSHpHSklfYVpJWDFISkJ5cWRXMTlXTVBIUnRwRVFBcG5wVWNHMVFMd2pZVjVaWUF5elM",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -5033,14 +5033,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": true, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": true, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:33 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:07 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -5048,16 +5048,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444893.367321,VS0,VE97",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447147.194469,VS0,VE104",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444893400.Z0FBQUFBQmFrT09kLXE2MWRYdEVFcXFvSjBOVHBjb1hxYXJZcXZFREx4SkI4Y1ZIUjdreXRvYTU4V20ycUNuQ3g4SVZleHJLR2FKV3NpZ0pNZ2tQN0d3OEx4MDdHenZEelQyQjZxZkRYbGZTWVhXY2hiLW14NXlscVc5MU91VFRXekkyNFhlZF9iR3A; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:33 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447147241.Z0FBQUFBQmFrT3hyMVdoTnFUTDFQR2dUcmd0RFFaaXdaRTAxeTliaUVkSkRQcGxETV9KMENOTHVoWnBpenczR0dEZzJtaEp0RVpTVG0ybDJuc2cxcjZkdVV5U21MdVppeWppX2djb2lqWnRnb002NWpNOGRfazNIZUp1SmZpRFI3M2dPcVFNMUM5M1M; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:07 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "498.0",
-          "x-ratelimit-reset": "507",
-          "x-ratelimit-used": "102",
+          "x-ratelimit-remaining": "508.0",
+          "x-ratelimit-reset": "53",
+          "x-ratelimit-used": "92",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -5068,7 +5068,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:33",
+      "recorded_at": "2018-02-24T04:39:07",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -5081,7 +5081,7 @@
           "Connection": "keep-alive",
           "Content-Length": "59",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444893400.Z0FBQUFBQmFrT09kLXE2MWRYdEVFcXFvSjBOVHBjb1hxYXJZcXZFREx4SkI4Y1ZIUjdreXRvYTU4V20ycUNuQ3g4SVZleHJLR2FKV3NpZ0pNZ2tQN0d3OEx4MDdHenZEelQyQjZxZkRYbGZTWVhXY2hiLW14NXlscVc5MU91VFRXekkyNFhlZF9iR3A",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447147241.Z0FBQUFBQmFrT3hyMVdoTnFUTDFQR2dUcmd0RFFaaXdaRTAxeTliaUVkSkRQcGxETV9KMENOTHVoWnBpenczR0dEZzJtaEp0RVpTVG0ybDJuc2cxcjZkdVV5U21MdVppeWppX2djb2lqWnRnb002NWpNOGRfazNIZUp1SmZpRFI3M2dPcVFNMUM5M1M",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -5090,14 +5090,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1684",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:33 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:07 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -5105,16 +5105,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444893.493788,VS0,VE101",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447147.323683,VS0,VE97",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444893526.Z0FBQUFBQmFrT09kTC10RzkxVG1MVjViQWk2Z2piMnRSck5GVGM2OTdnMkRzV01JcTNCcWw5R3RUNk93NlpHWkxMa0dOMVJHVlUyVjVWNEZDRGIxcGZESjRjWGxmUGM0NkhtSFlpVVdGWXcyQmNvSm1hWWVPUXlZVmZVbS1XVmVrX3VqaVpXRUhmcWM; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:33 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447147358.Z0FBQUFBQmFrT3hyRzBMRlRtQjVNUnJNR25mX2MwUHNSeHg5cE9wUjcycDhhVjJmN3ZQM0s1cGpldDhyUHJYZEM3elVHYkJLUkFVX0xOaHRKTDVhNEl0NmVIU0NnU1Vjc1JLUXI0VkQyQ2l2WkJGbkwwZnE2bWtGQjNBeHJZeDZEb2ZvZ1AyWWNXY2g; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:07 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "497.0",
-          "x-ratelimit-reset": "507",
-          "x-ratelimit-used": "103",
+          "x-ratelimit-remaining": "507.0",
+          "x-ratelimit-reset": "53",
+          "x-ratelimit-used": "93",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -5125,7 +5125,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:33",
+      "recorded_at": "2018-02-24T04:39:07",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -5138,7 +5138,7 @@
           "Connection": "keep-alive",
           "Content-Length": "71",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444893526.Z0FBQUFBQmFrT09kTC10RzkxVG1MVjViQWk2Z2piMnRSck5GVGM2OTdnMkRzV01JcTNCcWw5R3RUNk93NlpHWkxMa0dOMVJHVlUyVjVWNEZDRGIxcGZESjRjWGxmUGM0NkhtSFlpVVdGWXcyQmNvSm1hWWVPUXlZVmZVbS1XVmVrX3VqaVpXRUhmcWM",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447147358.Z0FBQUFBQmFrT3hyRzBMRlRtQjVNUnJNR25mX2MwUHNSeHg5cE9wUjcycDhhVjJmN3ZQM0s1cGpldDhyUHJYZEM3elVHYkJLUkFVX0xOaHRKTDVhNEl0NmVIU0NnU1Vjc1JLUXI0VkQyQ2l2WkJGbkwwZnE2bWtGQjNBeHJZeDZEb2ZvZ1AyWWNXY2g",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -5147,14 +5147,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"confidence\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"confidence\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1691",
+          "Content-Length": "1688",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:33 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:07 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -5162,16 +5162,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444894.620564,VS0,VE104",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447147.446581,VS0,VE97",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444893659.Z0FBQUFBQmFrT09kT3ZseG04MTJtZkNLS1kwYlduOHYxeEJDMW9NTERNQzl4VDBvc1NEc0hBRkIzWU9rYVZCRGF6bTNncnhyeDR2Sm9hVnRENnRzNHZiZTh5akFhdW1XcnpjZ3htMVhaOEpZZDJrTTA2czY3WFhDd2ExYWtQcGpIREYyalREdDlISGQ; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:33 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447147477.Z0FBQUFBQmFrT3hyXzdXZ2QtY0taMjNSMU1vRGFUaHdna2pLekZSa3FjbWV1T3ZqTUJKQ2F0TW1PeU84bDNLb0pZTWI2d3l5YW9oOW9TYXVHTk1Bby1QUmdjWXZ6cmFYOTctVjZrcjZ3T1VQcWhqU1c0MHRwdHA2NGZBMlZUWDQyVHlYNTMzMFpkQUk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:07 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "496.0",
-          "x-ratelimit-reset": "507",
-          "x-ratelimit-used": "104",
+          "x-ratelimit-remaining": "506.0",
+          "x-ratelimit-reset": "53",
+          "x-ratelimit-used": "94",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -5182,7 +5182,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:33",
+      "recorded_at": "2018-02-24T04:39:07",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -5195,7 +5195,7 @@
           "Connection": "keep-alive",
           "Content-Length": "64",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444893659.Z0FBQUFBQmFrT09kT3ZseG04MTJtZkNLS1kwYlduOHYxeEJDMW9NTERNQzl4VDBvc1NEc0hBRkIzWU9rYVZCRGF6bTNncnhyeDR2Sm9hVnRENnRzNHZiZTh5akFhdW1XcnpjZ3htMVhaOEpZZDJrTTA2czY3WFhDd2ExYWtQcGpIREYyalREdDlISGQ",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447147477.Z0FBQUFBQmFrT3hyXzdXZ2QtY0taMjNSMU1vRGFUaHdna2pLekZSa3FjbWV1T3ZqTUJKQ2F0TW1PeU84bDNLb0pZTWI2d3l5YW9oOW9TYXVHTk1Bby1QUmdjWXZ6cmFYOTctVjZrcjZ3T1VQcWhqU1c0MHRwdHA2NGZBMlZUWDQyVHlYNTMzMFpkQUk",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -5204,14 +5204,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1684",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:33 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:07 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -5219,16 +5219,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444894.751266,VS0,VE104",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447148.569708,VS0,VE108",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444893786.Z0FBQUFBQmFrT09kQUUwZ2djQmRIZTdCMDhEdlFORmV1VkJZazlwMzBUR3VVcW5ocTlEcS1zZUttV011Q291S3IySUVMelpkMjlVTGZQc3doeGlkZ3IwcjlET3VrNE9MVFEwMzFrTXplOVR5ZTFWQ0N0dmhucWNvWVVHZVlUMDM3bWZ0bmJWQURPVng; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:33 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447147607.Z0FBQUFBQmFrT3hydjhlakl3N1NtWVFvNG1FVDdlQTIyZmcxb2QwSHFtRzNScjU5T3FxSVE0NGI3d1V1YVNxWHBsVW9kRTJzRk5EZzFFZjFicktkLTdzV2MyX2VWVDJtY1c4d25UNHp1U0JGS1d5MlFEdFE1NDllVVJ5YnhsdVlFdEhXLUtxX3ZPRlE; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:07 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "495.0",
-          "x-ratelimit-reset": "507",
-          "x-ratelimit-used": "105",
+          "x-ratelimit-remaining": "505.0",
+          "x-ratelimit-reset": "53",
+          "x-ratelimit-used": "95",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -5239,7 +5239,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:33",
+      "recorded_at": "2018-02-24T04:39:07",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -5252,7 +5252,7 @@
           "Connection": "keep-alive",
           "Content-Length": "47",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444893786.Z0FBQUFBQmFrT09kQUUwZ2djQmRIZTdCMDhEdlFORmV1VkJZazlwMzBUR3VVcW5ocTlEcS1zZUttV011Q291S3IySUVMelpkMjlVTGZQc3doeGlkZ3IwcjlET3VrNE9MVFEwMzFrTXplOVR5ZTFWQ0N0dmhucWNvWVVHZVlUMDM3bWZ0bmJWQURPVng",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447147607.Z0FBQUFBQmFrT3hydjhlakl3N1NtWVFvNG1FVDdlQTIyZmcxb2QwSHFtRzNScjU5T3FxSVE0NGI3d1V1YVNxWHBsVW9kRTJzRk5EZzFFZjFicktkLTdzV2MyX2VWVDJtY1c4d25UNHp1U0JGS1d5MlFEdFE1NDllVVJ5YnhsdVlFdEhXLUtxX3ZPRlE",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -5261,14 +5261,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"es\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"es\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1684",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:33 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:07 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -5276,16 +5276,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444894.881484,VS0,VE105",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447148.702989,VS0,VE109",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444893915.Z0FBQUFBQmFrT09kS0pZTnAzN21zbDA5RUZicXh0cFMxMTMybm5aTlhKQWpEd2dGMEU2MldORjZCaEc2WDg5MXdIQkR0VHRVNTRFYm8yUEpXR0Q1U2VuSk9YU19hYzdJcE0zallSbi1TakJQR1JWdnVZeDM4ejg0S3Jqc1N2UHNqX2hIaWR1UktUdFI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:33 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447147743.Z0FBQUFBQmFrT3hyZGZ2UGhrekp5TGJWX3NDMUFvcVpsb0xVOVc3dWo1SGo3dlFvazVXSERBVGJSTDlrbjVxdDBXYmpzYUpmUWY0NXNyaFR1QzZuaXJvRC1UcnJ5ZUJva3JtY3BwOGdHRXZCaW9kZWY4SWNuY3hlcGxzUVo4djBTV0lKQWdyUmxDZ2Y; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:07 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "494.0",
-          "x-ratelimit-reset": "507",
-          "x-ratelimit-used": "106",
+          "x-ratelimit-remaining": "504.0",
+          "x-ratelimit-reset": "53",
+          "x-ratelimit-used": "96",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -5296,7 +5296,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:34",
+      "recorded_at": "2018-02-24T04:39:07",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -5309,7 +5309,7 @@
           "Connection": "keep-alive",
           "Content-Length": "47",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444893915.Z0FBQUFBQmFrT09kS0pZTnAzN21zbDA5RUZicXh0cFMxMTMybm5aTlhKQWpEd2dGMEU2MldORjZCaEc2WDg5MXdIQkR0VHRVNTRFYm8yUEpXR0Q1U2VuSk9YU19hYzdJcE0zallSbi1TakJQR1JWdnVZeDM4ejg0S3Jqc1N2UHNqX2hIaWR1UktUdFI",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447147743.Z0FBQUFBQmFrT3hyZGZ2UGhrekp5TGJWX3NDMUFvcVpsb0xVOVc3dWo1SGo3dlFvazVXSERBVGJSTDlrbjVxdDBXYmpzYUpmUWY0NXNyaFR1QzZuaXJvRC1UcnJ5ZUJva3JtY3BwOGdHRXZCaW9kZWY4SWNuY3hlcGxzUVo4djBTV0lKQWdyUmxDZ2Y",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -5318,14 +5318,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1684",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:34 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:07 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -5333,16 +5333,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444894.012446,VS0,VE195",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447148.840770,VS0,VE96",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444894046.Z0FBQUFBQmFrT09lZUNrTF9XdE9uS0R5LUhwZTlSem4wSFNfS2ZnZDR2YUJIRy13YWFMZVlCYW9YbHJJN1FXcWR0QmU1VDdoVlE4NWgwZldZaWpBdWtSbXRiWlp4UXIycmFBWDJzamliM2lrbVBPeHhVQmN5S2ZUUzQzZ0pYczg4VHlpaHl5RDJuNU0; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:34 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447147876.Z0FBQUFBQmFrT3hyNVIxWE5Ub0RPTWFOTmkxRklHRW40WlN6OURCMEJUV21JOUZiT1VTcWt6YzJWcFhScEp0UjhsODFaZVI0ZlczNmFSTlk2MjBSNGlZZDdQVWpJNi1rd1FSNm1GMmNCLTZJdnlvM2pPUHlLSkpzaUR1VkhJUno0MGNvZmM3XzdaYWk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:07 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "493.0",
-          "x-ratelimit-reset": "506",
-          "x-ratelimit-used": "107",
+          "x-ratelimit-remaining": "503.0",
+          "x-ratelimit-reset": "53",
+          "x-ratelimit-used": "97",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -5353,7 +5353,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:34",
+      "recorded_at": "2018-02-24T04:39:08",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -5366,7 +5366,7 @@
           "Connection": "keep-alive",
           "Content-Length": "48",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444894046.Z0FBQUFBQmFrT09lZUNrTF9XdE9uS0R5LUhwZTlSem4wSFNfS2ZnZDR2YUJIRy13YWFMZVlCYW9YbHJJN1FXcWR0QmU1VDdoVlE4NWgwZldZaWpBdWtSbXRiWlp4UXIycmFBWDJzamliM2lrbVBPeHhVQmN5S2ZUUzQzZ0pYczg4VHlpaHl5RDJuNU0",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447147876.Z0FBQUFBQmFrT3hyNVIxWE5Ub0RPTWFOTmkxRklHRW40WlN6OURCMEJUV21JOUZiT1VTcWt6YzJWcFhScEp0UjhsODFaZVI0ZlczNmFSTlk2MjBSNGlZZDdQVWpJNi1rd1FSNm1GMmNCLTZJdnlvM2pPUHlLSkpzaUR1VkhJUno0MGNvZmM3XzdaYWk",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -5375,14 +5375,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"on\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"on\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:34 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:08 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -5390,16 +5390,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444894.232977,VS0,VE169",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447148.962838,VS0,VE104",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444894274.Z0FBQUFBQmFrT09lTDc1X2tBS2k0LWljTm9fYUNpcVFJbEI0V3pEOGQxZk9mLWNpRzIzV3M3akhVTnhNWTFLRkpnNm9lRVhleFRSNkd2MjNxMThqOEVIR1JSdERzMjdsQ1ZjejJIcXdjUElXOW92eVBFYlo2bWFfM2lNRFZsWXFicVk5OU16VEVPX28; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:34 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447147999.Z0FBQUFBQmFrT3hzUF8zb1dZSDV5emJ3X19JZjBQM0dBeGZmX3F1Q1VKaHh2clVHUzItRXJyckZMTFRKc0ZlWFNINWEtemtwUXF1WkZoWU9zMFo1RS1CVmw0RTJRTVNENTNVUmdMODJ0MlJHMVVTb2phcWJTbVp6a2NuM3ZrTWpqenBXakpPREZRNkc; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:08 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "492.0",
-          "x-ratelimit-reset": "506",
-          "x-ratelimit-used": "108",
+          "x-ratelimit-remaining": "502.0",
+          "x-ratelimit-reset": "52",
+          "x-ratelimit-used": "98",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -5410,7 +5410,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:34",
+      "recorded_at": "2018-02-24T04:39:08",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -5423,7 +5423,7 @@
           "Connection": "keep-alive",
           "Content-Length": "49",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444894274.Z0FBQUFBQmFrT09lTDc1X2tBS2k0LWljTm9fYUNpcVFJbEI0V3pEOGQxZk9mLWNpRzIzV3M3akhVTnhNWTFLRkpnNm9lRVhleFRSNkd2MjNxMThqOEVIR1JSdERzMjdsQ1ZjejJIcXdjUElXOW92eVBFYlo2bWFfM2lNRFZsWXFicVk5OU16VEVPX28",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447147999.Z0FBQUFBQmFrT3hzUF8zb1dZSDV5emJ3X19JZjBQM0dBeGZmX3F1Q1VKaHh2clVHUzItRXJyckZMTFRKc0ZlWFNINWEtemtwUXF1WkZoWU9zMFo1RS1CVmw0RTJRTVNENTNVUmdMODJ0MlJHMVVTb2phcWJTbVp6a2NuM3ZrTWpqenBXakpPREZRNkc",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -5432,14 +5432,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1684",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:34 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:08 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -5447,16 +5447,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444894.430189,VS0,VE108",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447148.093454,VS0,VE105",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444894471.Z0FBQUFBQmFrT09lMmxJRGkwNmdONWd6WnR6Yk1HSDV6bmN1b21qbkZSUVhWVU90LXN4U3FSc2hvWVZ0TXM4cXluS2lsZUdVUHlYQW1mYm5oSmFSMzNuVkd3NnpKZXgyVmVmeTh6clY5VEZhd0pObkRqZS0yVXBfS3R0SG9vUno5c2FVcGhYQVotWjI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:34 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447148131.Z0FBQUFBQmFrT3hzZlM2Nkc3Rk1yRnRuMEdYcnZPSkk0R0tkNmtCZFR4TV8zemwtX0RkYXBPSEktUXJGWktPaTk5ck5nMTgtb0lLeG9NZ3RGSURXa3htZE1jdmR5T1dHTkFUTXptdkpyRVVuNUIwazZ2N2o0LXNXSzNzNXA5czRfeW5hZkpoRDFaalM; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:08 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "491.0",
-          "x-ratelimit-reset": "506",
-          "x-ratelimit-used": "109",
+          "x-ratelimit-remaining": "501.0",
+          "x-ratelimit-reset": "52",
+          "x-ratelimit-used": "99",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -5467,7 +5467,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:34",
+      "recorded_at": "2018-02-24T04:39:08",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -5480,7 +5480,7 @@
           "Connection": "keep-alive",
           "Content-Length": "56",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444894471.Z0FBQUFBQmFrT09lMmxJRGkwNmdONWd6WnR6Yk1HSDV6bmN1b21qbkZSUVhWVU90LXN4U3FSc2hvWVZ0TXM4cXluS2lsZUdVUHlYQW1mYm5oSmFSMzNuVkd3NnpKZXgyVmVmeTh6clY5VEZhd0pObkRqZS0yVXBfS3R0SG9vUno5c2FVcGhYQVotWjI",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447148131.Z0FBQUFBQmFrT3hzZlM2Nkc3Rk1yRnRuMEdYcnZPSkk0R0tkNmtCZFR4TV8zemwtX0RkYXBPSEktUXJGWktPaTk5ck5nMTgtb0lLeG9NZ3RGSURXa3htZE1jdmR5T1dHTkFUTXptdkpyRVVuNUIwazZ2N2o0LXNXSzNzNXA5czRfeW5hZkpoRDFaalM",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -5489,14 +5489,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"on\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"on\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1683",
+          "Content-Length": "1680",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:34 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:08 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -5504,16 +5504,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444895.566189,VS0,VE105",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447148.222888,VS0,VE127",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444894598.Z0FBQUFBQmFrT09lSUVXY2lQZ3hqRzRTVEkwbVY2ZEQwV3p3S2hGZko1YjZpd2pLYVFjV1drYlp3azdXcVVDRkQ5YjVxLUI0a2dTakFtbzQ2bjlqRTM5OUFKTURlVE5DVC1VZGxyVF8xR01qSHotUE1KTFFRLTBWYTZ0M1pWaDZ2b29PQ2pzTFNvTm4; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:34 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447148263.Z0FBQUFBQmFrT3hzVnVpWDhkSGl1cGx0Qk1PamZ0R3hveHpDYzVuX1dUMXByeGJGVmJWQlFSa2VMVVBYRFlUTHdDaTJnaGlKVmFXVXhmazk4WEhmUlpYaUprVEQyUmlNUkFvWE9JdlpyZzdZNDFLZmJ5WGdQempBTzFMc2hLVTlOX2hKaU80WWd5S1o; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:08 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "490.0",
-          "x-ratelimit-reset": "506",
-          "x-ratelimit-used": "110",
+          "x-ratelimit-remaining": "500.0",
+          "x-ratelimit-reset": "52",
+          "x-ratelimit-used": "100",
           "x-xss-protection": "1; mode=block"
         },
         "status": {
@@ -5524,7 +5524,7 @@
       }
     },
     {
-      "recorded_at": "2018-02-24T04:01:34",
+      "recorded_at": "2018-02-24T04:39:08",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -5537,7 +5537,7 @@
           "Connection": "keep-alive",
           "Content-Length": "57",
           "Content-Type": "application/x-www-form-urlencoded",
-          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444894598.Z0FBQUFBQmFrT09lSUVXY2lQZ3hqRzRTVEkwbVY2ZEQwV3p3S2hGZko1YjZpd2pLYVFjV1drYlp3azdXcVVDRkQ5YjVxLUI0a2dTakFtbzQ2bjlqRTM5OUFKTURlVE5DVC1VZGxyVF8xR01qSHotUE1KTFFRLTBWYTZ0M1pWaDZ2b29PQ2pzTFNvTm4",
+          "Cookie": "edgebucket=4Gp3CEh05pXRBbAt3l; session_tracker=gqPmk20RdUhCChbD3a.0.1519447148263.Z0FBQUFBQmFrT3hzVnVpWDhkSGl1cGx0Qk1PamZ0R3hveHpDYzVuX1dUMXByeGJGVmJWQlFSa2VMVVBYRFlUTHdDaTJnaGlKVmFXVXhmazk4WEhmUlpYaUprVEQyUmlNUkFvWE9JdlpyZzdZNDFLZmJ5WGdQempBTzFMc2hLVTlOX2hKaU80WWd5S1o",
           "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
         },
         "method": "PATCH",
@@ -5546,14 +5546,14 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
         },
         "headers": {
           "Accept-Ranges": "bytes",
           "Connection": "keep-alive",
-          "Content-Length": "1684",
+          "Content-Length": "1681",
           "Content-Type": "application/json; charset=UTF-8",
-          "Date": "Sat, 24 Feb 2018 04:01:34 GMT",
+          "Date": "Sat, 24 Feb 2018 04:39:08 GMT",
           "Server": "snooserv",
           "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
           "Vary": "accept-encoding",
@@ -5561,16 +5561,16 @@
           "X-Cache": "MISS",
           "X-Cache-Hits": "0",
           "X-Moose": "majestic",
-          "X-Served-By": "cache-sjc3131-SJC",
-          "X-Timer": "S1519444895.697380,VS0,VE104",
+          "X-Served-By": "cache-sjc3632-SJC",
+          "X-Timer": "S1519447148.377908,VS0,VE283",
           "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
           "expires": "-1",
-          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444894734.Z0FBQUFBQmFrT09lNEJINVcyWnF5VTdJTV9hem4wbEtObDlxRFBpbWJIeXB2YjNfUkliZlBUMlpSVDBhbnFsRDB3ZUxLZXkyZVl0MkpxZkJrTGtEUVVHanh2ODRKOUdlOHY5WE1qSTBBN211Q2gtMTduVEFUbDBqT0xPLWdjb1FMbk1KVTdtV2FxeVE; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:34 GMT; secure",
+          "set-cookie": "session_tracker=gqPmk20RdUhCChbD3a.0.1519447148598.Z0FBQUFBQmFrT3hzNFA0RGNZdHVWLUlNMmNGWnE1T0FJUFZkOEdSTG9vYU9YaUpJakZ2TW1ESjJ5NkNnTkY3amg1OXVmMnFhRkhpUV82djkxUTZxbmQxdk01NDloalN5Q29yZ2czQ1VOOFU0SXM4VEthSDJWUHB2YWtnVDN0NXdXVmhvbjZjbWYtUU8; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:39:08 GMT; secure",
           "x-content-type-options": "nosniff",
           "x-frame-options": "SAMEORIGIN",
-          "x-ratelimit-remaining": "489.0",
-          "x-ratelimit-reset": "506",
-          "x-ratelimit-used": "111",
+          "x-ratelimit-remaining": "499.0",
+          "x-ratelimit-reset": "52",
+          "x-ratelimit-used": "101",
           "x-xss-protection": "1; mode=block"
         },
         "status": {

--- a/tests/integration/cassettes/TestPreferences.test_update.json
+++ b/tests/integration/cassettes/TestPreferences.test_update.json
@@ -1,0 +1,5585 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-02-24T04:01:20",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "53",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:20 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3627-SJC",
+          "X-Timer": "S1519444880.739720,VS0,VE856",
+          "cache-control": "max-age=0, must-revalidate",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444879773.Z0FBQUFBQmFrT09RMzBqaDhYYk5rUS1SWV8zMG5vWHFVUHN6WUF1NjREb0c5cmtwdW5EMnJQRXpvQ0prYjVZam9QdlVKc0lzUjZMd2pzYWRPcUV1YnF4QkRZWngzX3pXQ0dEZTRjMjk5ZjUzRXJ5WE04a3lGanhPZmhCbDlUQXU1clNZZS1Nb3lqanQ; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:20 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:20",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "25",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444879773.Z0FBQUFBQmFrT09RMzBqaDhYYk5rUS1SWV8zMG5vWHFVUHN6WUF1NjREb0c5cmtwdW5EMnJQRXpvQ0prYjVZam9QdlVKc0lzUjZMd2pzYWRPcUV1YnF4QkRZWngzX3pXQ0dEZTRjMjk5ZjUzRXJ5WE04a3lGanhPZmhCbDlUQXU1clNZZS1Nb3lqanQ",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 50, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1684",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:20 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444881.720913,VS0,VE92",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444880756.Z0FBQUFBQmFrT09RZncwOVd5aG5FSkFvZUMzQmQ4ME9XaFc5S0EwUzBmdlpXb0RaN3ZtNFlPYTFuaDhudml0RGNOWVBHQlVVV2J0SDRucTNiby1qVUdER2dlanRXcUZwUnAzZGFnNUFyQW1Oa1ZQLVNlZXJmLUJhSnhRc01pc1VoYW5hNkh6ZEJ1VHg; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:20 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "585.0",
+          "x-ratelimit-reset": "520",
+          "x-ratelimit-used": "15",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:20",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22min_comment_score%22%3A+1%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "53",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444880756.Z0FBQUFBQmFrT09RZncwOVd5aG5FSkFvZUMzQmQ4ME9XaFc5S0EwUzBmdlpXb0RaN3ZtNFlPYTFuaDhudml0RGNOWVBHQlVVV2J0SDRucTNiby1qVUdER2dlanRXcUZwUnAzZGFnNUFyQW1Oa1ZQLVNlZXJmLUJhSnhRc01pc1VoYW5hNkh6ZEJ1VHg",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 1, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 50, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1684",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:20 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444881.838403,VS0,VE95",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444880880.Z0FBQUFBQmFrT09ROGstT1huNjl1Rl91SjNsU1dRaWRaTlFkQWxjbjktWmRGVzhyRlAyYTdac3F3X3pvd0VsdFpkMlhqYUszSmR6aFl2MG1GVVI5WGFRbjZaZGNEVlRnQjdpeVBudkRMeEFfT2NhelpxYUh2bldSOGk5RGlfUjIxMjgycDZZTlRldE8; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:20 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "584.0",
+          "x-ratelimit-reset": "520",
+          "x-ratelimit-used": "16",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:21",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22min_comment_score%22%3A+3%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "53",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444880880.Z0FBQUFBQmFrT09ROGstT1huNjl1Rl91SjNsU1dRaWRaTlFkQWxjbjktWmRGVzhyRlAyYTdac3F3X3pvd0VsdFpkMlhqYUszSmR6aFl2MG1GVVI5WGFRbjZaZGNEVlRnQjdpeVBudkRMeEFfT2NhelpxYUh2bldSOGk5RGlfUjIxMjgycDZZTlRldE8",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 50, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1684",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:21 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444881.959729,VS0,VE94",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444880996.Z0FBQUFBQmFrT09SdGtDTklacDlQTFZYVW54bE5iLVVnYXRjY21DM0kzX3ZhLVF1X08zRlkwTFA4Nm1MZUFhU3VlYlYyWTIzaVQzY1BHNzVZNWc0QjA3aHNVc0NRenZUbVNvNTZzblZIWG9mOE44bHdMWGcxajRkYmplWFJfTkF0ZlV6MWVpZmtkSDc; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:21 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "583.0",
+          "x-ratelimit-reset": "519",
+          "x-ratelimit-used": "17",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:21",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22min_link_score%22%3A+1%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "50",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444880996.Z0FBQUFBQmFrT09SdGtDTklacDlQTFZYVW54bE5iLVVnYXRjY21DM0kzX3ZhLVF1X08zRlkwTFA4Nm1MZUFhU3VlYlYyWTIzaVQzY1BHNzVZNWc0QjA3aHNVc0NRenZUbVNvNTZzblZIWG9mOE44bHdMWGcxajRkYmplWFJfTkF0ZlV6MWVpZmtkSDc",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 1, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 50, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1684",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:21 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444881.080191,VS0,VE106",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444881117.Z0FBQUFBQmFrT09SZTVRUWFNSy1MVm9QaWkzV0REbkpma3E5RmpXdzJfajNYVEFybVlzR2tuRzg1R05lWFZVU01yNWU0M2x4WVBKVEF0T2x0MWRXUmJLbk82Tm9vR0U4OE9oYTNRVGRWT3N3UldERGlBcktEVEtpbXpSemNxVlJKeGJBM21NZEtIQm0; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:21 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "582.0",
+          "x-ratelimit-reset": "519",
+          "x-ratelimit-used": "18",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:21",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22min_link_score%22%3A+3%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "50",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444881117.Z0FBQUFBQmFrT09SZTVRUWFNSy1MVm9QaWkzV0REbkpma3E5RmpXdzJfajNYVEFybVlzR2tuRzg1R05lWFZVU01yNWU0M2x4WVBKVEF0T2x0MWRXUmJLbk82Tm9vR0U4OE9oYTNRVGRWT3N3UldERGlBcktEVEtpbXpSemNxVlJKeGJBM21NZEtIQm0",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 50, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1684",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:21 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444881.212305,VS0,VE98",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444881247.Z0FBQUFBQmFrT09SVXU1M3FVc2E1ZmdnU1hVSXFGU3lrNUo1SzZRdjh0RW01ZVNuY2JOcnhCdDFjbDNPVWZ1Z3ZjeWNKbDBVZFNUR1Ewem9uQnB0SnI1VlJmdEFWR0FrbzlFZUM5RzRoZ0tTOGZjeTVVR3VMS0pTN25oRG8teU9aZFBCbF9XU3Z0RFg; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:21 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "581.0",
+          "x-ratelimit-reset": "519",
+          "x-ratelimit-used": "19",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:21",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22num_comments%22%3A+1%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "48",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444881247.Z0FBQUFBQmFrT09SVXU1M3FVc2E1ZmdnU1hVSXFGU3lrNUo1SzZRdjh0RW01ZVNuY2JOcnhCdDFjbDNPVWZ1Z3ZjeWNKbDBVZFNUR1Ewem9uQnB0SnI1VlJmdEFWR0FrbzlFZUM5RzRoZ0tTOGZjeTVVR3VMS0pTN25oRG8teU9aZFBCbF9XU3Z0RFg",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 1, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 50, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1684",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:21 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444881.339583,VS0,VE95",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444881378.Z0FBQUFBQmFrT09SUmx0LVdFeDNXMjFzcmQtY2NpdHhrQnFkOFdNLTZPbE5jTHduNHAtWDFPREJUNDJDN2lJb0syVzlkaFdqUmxIMlRlNjZuSU5WWllvSnp2blc4ckNObHduY1dRRFg0bzZFQkFHMDBiX1l6d1hUWDlLS2dpaE9JVFQwZG5jNTBkTUo; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:21 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "580.0",
+          "x-ratelimit-reset": "519",
+          "x-ratelimit-used": "20",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:21",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22num_comments%22%3A+3%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "48",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444881378.Z0FBQUFBQmFrT09SUmx0LVdFeDNXMjFzcmQtY2NpdHhrQnFkOFdNLTZPbE5jTHduNHAtWDFPREJUNDJDN2lJb0syVzlkaFdqUmxIMlRlNjZuSU5WWllvSnp2blc4ckNObHduY1dRRFg0bzZFQkFHMDBiX1l6d1hUWDlLS2dpaE9JVFQwZG5jNTBkTUo",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 50, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1684",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:21 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444881.461160,VS0,VE96",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444881496.Z0FBQUFBQmFrT09ScVpyalo2c2c0RU5UOW5XVm9vS0xzU1RMQ1hEYy1abUM3OEdraUdMUWwyVEtNc09pQngxZm1aTF9WYUVsT1Z2Nk5EeV9NeG02MVNLZ3dWX1FQVG1xNEN2Wm5FaGs3bzZOcVUxYl9wZzIwVGlTY1cycEtuR0o1MHpxVHRsbnZncFU; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:21 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "579.0",
+          "x-ratelimit-reset": "519",
+          "x-ratelimit-used": "21",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:21",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22numsites%22%3A+1%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "44",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444881496.Z0FBQUFBQmFrT09ScVpyalo2c2c0RU5UOW5XVm9vS0xzU1RMQ1hEYy1abUM3OEdraUdMUWwyVEtNc09pQngxZm1aTF9WYUVsT1Z2Nk5EeV9NeG02MVNLZ3dWX1FQVG1xNEN2Wm5FaGs3bzZOcVUxYl9wZzIwVGlTY1cycEtuR0o1MHpxVHRsbnZncFU",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 1, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:21 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444882.583366,VS0,VE106",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444881621.Z0FBQUFBQmFrT09Sd1Jfa3VzcU5kWmFVNy1Ed0dRaFJnUEVjVEs5WURaX196TmpGSF9qbHpPc0o1cldBSkNMMENWS0hLVWttWEV0aHVNRTF6VHkzcm5ldWFJc3hhdWVwU2JWamVVQWpyZmdOcXdHbGtqUm9ibm5NM18tcUxPWVRpSUZYS3JoSkFLdHM; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:21 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "578.0",
+          "x-ratelimit-reset": "519",
+          "x-ratelimit-used": "22",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:21",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22numsites%22%3A+3%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "44",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444881621.Z0FBQUFBQmFrT09Sd1Jfa3VzcU5kWmFVNy1Ed0dRaFJnUEVjVEs5WURaX196TmpGSF9qbHpPc0o1cldBSkNMMENWS0hLVWttWEV0aHVNRTF6VHkzcm5ldWFJc3hhdWVwU2JWamVVQWpyZmdOcXdHbGtqUm9ibm5NM18tcUxPWVRpSUZYS3JoSkFLdHM",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:21 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444882.716224,VS0,VE101",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444881744.Z0FBQUFBQmFrT09Sa1hvSm1ORHgxOFZLSnUzRjNiYTV3LU5fSjJIRWVPYlRrYzJxZmFpSTZpaWV2WXRQTXpRMjFJSGV2R2djWEd5WTJ6NnpYRkJ6NWVHaHF4NGdnWUlGUWVzandpYWpKRThmRGUtQWVsMXY3QXN3NUpxeHFienlaQlFHYjFaVGFFSWk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:21 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "577.0",
+          "x-ratelimit-reset": "519",
+          "x-ratelimit-used": "23",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:21",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22allow_clicktracking%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "58",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444881744.Z0FBQUFBQmFrT09Sa1hvSm1ORHgxOFZLSnUzRjNiYTV3LU5fSjJIRWVPYlRrYzJxZmFpSTZpaWV2WXRQTXpRMjFJSGV2R2djWEd5WTJ6NnpYRkJ6NWVHaHF4NGdnWUlGUWVzandpYWpKRThmRGUtQWVsMXY3QXN3NUpxeHFienlaQlFHYjFaVGFFSWk",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": true, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1682",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:21 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444882.845785,VS0,VE107",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444881881.Z0FBQUFBQmFrT09SdlVEYV9fMTZNRWJZVEtjaFYwMjROUm1WdGZUX2xPeEdZeTBkRFBQWHZmYmp4aC1UWjZlMHhyUnJMcjJZRHh4V0d0OFRPcTk5T2xTUHVaMW1zNk16dDRIUzFxenByWVhrVkhWWWxoWUMxWldMMkVfcHpNNnlya2NxRlhzaTN0WF8; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:21 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "576.0",
+          "x-ratelimit-reset": "519",
+          "x-ratelimit-used": "24",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:22",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22allow_clicktracking%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "59",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444881881.Z0FBQUFBQmFrT09SdlVEYV9fMTZNRWJZVEtjaFYwMjROUm1WdGZUX2xPeEdZeTBkRFBQWHZmYmp4aC1UWjZlMHhyUnJMcjJZRHh4V0d0OFRPcTk5T2xTUHVaMW1zNk16dDRIUzFxenByWVhrVkhWWWxoWUMxWldMMkVfcHpNNnlya2NxRlhzaTN0WF8",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:22 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444882.980047,VS0,VE105",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444882011.Z0FBQUFBQmFrT09TUzF0Y2JwMDA2X3dCTHExenNxOHJvWGI4cjBFUGZiWGpfWWU0MjBLaDNEZlM1Z3F6VWdsV1ZWUWNBN2pmWTNpMjVieEk5cFlYMlI2UXVRY1JkU0hwOF9QbWdsY1MwMjNqUjlteWdmTmRLclNOeGQ1MmlwcndmaXZxVGZCZGk3cmQ; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:22 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "575.0",
+          "x-ratelimit-reset": "518",
+          "x-ratelimit-used": "25",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:22",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22beta%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "43",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444882011.Z0FBQUFBQmFrT09TUzF0Y2JwMDA2X3dCTHExenNxOHJvWGI4cjBFUGZiWGpfWWU0MjBLaDNEZlM1Z3F6VWdsV1ZWUWNBN2pmWTNpMjVieEk5cFlYMlI2UXVRY1JkU0hwOF9QbWdsY1MwMjNqUjlteWdmTmRLclNOeGQ1MmlwcndmaXZxVGZCZGk3cmQ",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": true, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1682",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:22 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444882.112408,VS0,VE102",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444882151.Z0FBQUFBQmFrT09TcDJ3OHlKVV9mNFA1dHJLUTBYYWptR1cwZXZ5Y2JCQ0VuaTVROUNrRXdZaWlKbEFFMWVnSHVHOVN1dkhsaUFoTUNNVG9qRE1EYTJ3azMxaXNUTk5fVnVWM1RWVFRad3NBVTQxZmlzdnZHYVBUczI0RXNpSlFRZU1jRzVFTjVzRHM; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:22 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "574.0",
+          "x-ratelimit-reset": "518",
+          "x-ratelimit-used": "26",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:22",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22beta%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "44",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444882151.Z0FBQUFBQmFrT09TcDJ3OHlKVV9mNFA1dHJLUTBYYWptR1cwZXZ5Y2JCQ0VuaTVROUNrRXdZaWlKbEFFMWVnSHVHOVN1dkhsaUFoTUNNVG9qRE1EYTJ3azMxaXNUTk5fVnVWM1RWVFRad3NBVTQxZmlzdnZHYVBUczI0RXNpSlFRZU1jRzVFTjVzRHM",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:22 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444882.240647,VS0,VE95",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444882278.Z0FBQUFBQmFrT09TWTRJUWU1NjAyWElNVTRTMlVBTjRNY3VXbzFVM01zZk9vVUdNTWpLZ19Xell6dnNsdllVVUx1NlE3Ynk5dWxQYWxRM2taaTR2SnMxOVh2NzFMU2x5NGExdlJOMGNZZWszM1FyMG85RjBKbWxCbEFVMDFUcks2bVVUQ3Vfb29GV3Q; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:22 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "573.0",
+          "x-ratelimit-reset": "518",
+          "x-ratelimit-used": "27",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:22",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22clickgadget%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "50",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444882278.Z0FBQUFBQmFrT09TWTRJUWU1NjAyWElNVTRTMlVBTjRNY3VXbzFVM01zZk9vVUdNTWpLZ19Xell6dnNsdllVVUx1NlE3Ynk5dWxQYWxRM2taaTR2SnMxOVh2NzFMU2x5NGExdlJOMGNZZWszM1FyMG85RjBKbWxCbEFVMDFUcks2bVVUQ3Vfb29GV3Q",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": true, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1682",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:22 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444882.363650,VS0,VE107",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444882399.Z0FBQUFBQmFrT09TY3I3c3FTUlhZY2tfWTg1eDZhU2NFQTdDR1o2TW50bUhlUUplT1FZNFdBMWc3dE9wUTNvcGIwUGdNZ05OcEVfUkx4QVd4OHI2UGhTZXRIeHVHZTVuS0VIeGNLdlFLRTdOMGczeVVlYnFRU29DeGFldERHeFcxd3JuaWlza3dZems; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:22 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "572.0",
+          "x-ratelimit-reset": "518",
+          "x-ratelimit-used": "28",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:22",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22clickgadget%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "51",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444882399.Z0FBQUFBQmFrT09TY3I3c3FTUlhZY2tfWTg1eDZhU2NFQTdDR1o2TW50bUhlUUplT1FZNFdBMWc3dE9wUTNvcGIwUGdNZ05OcEVfUkx4QVd4OHI2UGhTZXRIeHVHZTVuS0VIeGNLdlFLRTdOMGczeVVlYnFRU29DeGFldERHeFcxd3JuaWlza3dZems",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:22 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444882.498520,VS0,VE103",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444882536.Z0FBQUFBQmFrT09TUXpWVDk5a05lazU4Z19EVFZWTTc0a0xCMHdaX3VfMnUtVmdkOFJ4c2hSdTczLUNGSWZXb2tfV0tIT3ZLMG5ISFJNb2kzdlMtR3Jsall2aUFtX2QteUtXY1V2VXJ2Umh4Uk5kNy0yZjZiaGlRNjEwanc3YmtDdWVuejVZaDBHcWQ; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:22 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "571.0",
+          "x-ratelimit-reset": "518",
+          "x-ratelimit-used": "29",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:22",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22collapse_read_messages%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "61",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444882536.Z0FBQUFBQmFrT09TUXpWVDk5a05lazU4Z19EVFZWTTc0a0xCMHdaX3VfMnUtVmdkOFJ4c2hSdTczLUNGSWZXb2tfV0tIT3ZLMG5ISFJNb2kzdlMtR3Jsall2aUFtX2QteUtXY1V2VXJ2Umh4Uk5kNy0yZjZiaGlRNjEwanc3YmtDdWVuejVZaDBHcWQ",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": true, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1682",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:22 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444883.629155,VS0,VE98",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444882666.Z0FBQUFBQmFrT09TbGlFS2R2RktldVl5SXpPOWNKSlQ4WkJsVHo5ZFNWc1gxNzJmdC0wRVQ4Sko2eXo5bFFnREF0d0xvbmYwcWVIZ1Rucmw2bVhMOXIzMXo2Z2xQd3N5UjVfZ0ZmcVBxeXM5ZmNucW1DOExsUlNnYklJeVNRYTV2Zkptb29YejJ2OXg; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:22 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "570.0",
+          "x-ratelimit-reset": "518",
+          "x-ratelimit-used": "30",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:22",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22collapse_read_messages%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "62",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444882666.Z0FBQUFBQmFrT09TbGlFS2R2RktldVl5SXpPOWNKSlQ4WkJsVHo5ZFNWc1gxNzJmdC0wRVQ4Sko2eXo5bFFnREF0d0xvbmYwcWVIZ1Rucmw2bVhMOXIzMXo2Z2xQd3N5UjVfZ0ZmcVBxeXM5ZmNucW1DOExsUlNnYklJeVNRYTV2Zkptb29YejJ2OXg",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:22 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444883.753228,VS0,VE100",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444882791.Z0FBQUFBQmFrT09TY0EwREZKVkI4VG5ra29seFBBVGNDdGpkU01Kbm1ST3Z1SDdPZWZLX1BPYWRfYkllcWcyUzROQWRfeXc5VWFTenltb2tlMDN6eGJKRS1ibk1ZeXpIeGI2dk5hQktoemN5TGNmZ3dVdDZzUWctMm4tVEVtTjZVSm5SMFo2VFhRN2o; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:22 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "569.0",
+          "x-ratelimit-reset": "518",
+          "x-ratelimit-used": "31",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:22",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22compress%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "47",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444882791.Z0FBQUFBQmFrT09TY0EwREZKVkI4VG5ra29seFBBVGNDdGpkU01Kbm1ST3Z1SDdPZWZLX1BPYWRfYkllcWcyUzROQWRfeXc5VWFTenltb2tlMDN6eGJKRS1ibk1ZeXpIeGI2dk5hQktoemN5TGNmZ3dVdDZzUWctMm4tVEVtTjZVSm5SMFo2VFhRN2o",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": true, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1682",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:22 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444883.880230,VS0,VE102",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444882917.Z0FBQUFBQmFrT09TVXJYU3h2cFlnMkZXMVRkb0NOaUZVSW1Dck9FRzRPQ1kydENZMTNKTHlQeGFMU1Z1d3R3b0VFQ0NSY3BFQ0Zmam9aNHB2R2xnVkQwQ09wTnRWOURaM1VtOWZxLVNYV3A5SWNXdllpOXdQUlF1MXBWbFhqbVBpX2VtRkdEaW1PN3Q; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:22 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "568.0",
+          "x-ratelimit-reset": "518",
+          "x-ratelimit-used": "32",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22compress%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "48",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444882917.Z0FBQUFBQmFrT09TVXJYU3h2cFlnMkZXMVRkb0NOaUZVSW1Dck9FRzRPQ1kydENZMTNKTHlQeGFMU1Z1d3R3b0VFQ0NSY3BFQ0Zmam9aNHB2R2xnVkQwQ09wTnRWOURaM1VtOWZxLVNYV3A5SWNXdllpOXdQUlF1MXBWbFhqbVBpX2VtRkdEaW1PN3Q",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:23 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444883.008112,VS0,VE102",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444883042.Z0FBQUFBQmFrT09UeWRXNlhpZXhyZ3pCQmpzdXg1MW9DUUkxWWd3UDQyWmhPVTQ5ZWNfYWVnQTV6R0NSX3NYWG4ydXpTOGt3RklhMFJ2a0JwOFpDUEFJczVfcTAxWUoxNjlSTHJiVHJIQWZWTHBVWUpuSTVRcWRhMkFRUWVKVDBIcGpkZUhwRnl2T2c; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:23 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "567.0",
+          "x-ratelimit-reset": "517",
+          "x-ratelimit-used": "33",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22creddit_autorenew%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "56",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444883042.Z0FBQUFBQmFrT09UeWRXNlhpZXhyZ3pCQmpzdXg1MW9DUUkxWWd3UDQyWmhPVTQ5ZWNfYWVnQTV6R0NSX3NYWG4ydXpTOGt3RklhMFJ2a0JwOFpDUEFJczVfcTAxWUoxNjlSTHJiVHJIQWZWTHBVWUpuSTVRcWRhMkFRUWVKVDBIcGpkZUhwRnl2T2c",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": true, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1682",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:23 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444883.137259,VS0,VE105",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444883174.Z0FBQUFBQmFrT09UVHV5VkY3c0hEQTk2RU5MUjlxTlRYbVZTYnplT09tUy1nY21teHIzYmlobV9aT0owaXY4d01Qb1YwcmFQZTZ2blNrT2V2VGN0NlJneHBRRE5xS3pzLWNZbHRWMm9fYzNwYmpxRy0zUF93ZExCNmtjQU5teC1sNWlBT3RmNXpNYUE; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:23 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "566.0",
+          "x-ratelimit-reset": "517",
+          "x-ratelimit-used": "34",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22creddit_autorenew%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "57",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444883174.Z0FBQUFBQmFrT09UVHV5VkY3c0hEQTk2RU5MUjlxTlRYbVZTYnplT09tUy1nY21teHIzYmlobV9aT0owaXY4d01Qb1YwcmFQZTZ2blNrT2V2VGN0NlJneHBRRE5xS3pzLWNZbHRWMm9fYzNwYmpxRy0zUF93ZExCNmtjQU5teC1sNWlBT3RmNXpNYUE",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:23 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444883.267698,VS0,VE105",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444883301.Z0FBQUFBQmFrT09UYloxSHV5Mi1UekJaUDhMNmJzZTJNVnhyZkp3R2p3VG5aZXVIZnN2ZWM3aThzcW1GMG54TkMzN2E2ZElpbEZ3eUR4RDNfNFNuWVZPMXpzMldqUmFKd2lvbVBMSWE1OW9sZ1ZIZWdyeExoV3VJbXhmTTU5NU1wVVZsWV9uUm1fQ1U; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:23 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "565.0",
+          "x-ratelimit-reset": "517",
+          "x-ratelimit-used": "35",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22domain_details%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "53",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444883301.Z0FBQUFBQmFrT09UYloxSHV5Mi1UekJaUDhMNmJzZTJNVnhyZkp3R2p3VG5aZXVIZnN2ZWM3aThzcW1GMG54TkMzN2E2ZElpbEZ3eUR4RDNfNFNuWVZPMXpzMldqUmFKd2lvbVBMSWE1OW9sZ1ZIZWdyeExoV3VJbXhmTTU5NU1wVVZsWV9uUm1fQ1U",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": true, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1682",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:23 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444883.398894,VS0,VE104",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444883441.Z0FBQUFBQmFrT09UQmhxRzRDNUV4b2trREdUaV81N2loTmRiNExNTGxyWnhrSkhmdktLbF9wazV2TTlGUU5qLVNhUnU3bmNVRHJOUE16N3IyTnBuYXZSaVZMZWV0NjdlRkRuQ3JXakxpZUFNVTk0em56OWdXZlR2Nm5IZUYxblk5YWw3VmYtUkNhNDI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:23 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "564.0",
+          "x-ratelimit-reset": "517",
+          "x-ratelimit-used": "36",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22domain_details%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "54",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444883441.Z0FBQUFBQmFrT09UQmhxRzRDNUV4b2trREdUaV81N2loTmRiNExNTGxyWnhrSkhmdktLbF9wazV2TTlGUU5qLVNhUnU3bmNVRHJOUE16N3IyTnBuYXZSaVZMZWV0NjdlRkRuQ3JXakxpZUFNVTk0em56OWdXZlR2Nm5IZUYxblk5YWw3VmYtUkNhNDI",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:23 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444884.529530,VS0,VE101",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444883566.Z0FBQUFBQmFrT09USjZWd2EyRTc1bml1SHBlTmI3RTRRME1JeU44M19PdVBNU3doUVp5d0ZLNVZjdHBUeUNqa2s3ZTdBSnZ6dUllZG9SaldXTkJQS1hudEMwVWpoOUNPcTYweXctbzRGdEFVSUFPU25yQkN5cURWQlpWWFYwX28xNWNRbWRPYkhVeGw; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:23 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "563.0",
+          "x-ratelimit-reset": "517",
+          "x-ratelimit-used": "37",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22email_digests%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "52",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444883566.Z0FBQUFBQmFrT09USjZWd2EyRTc1bml1SHBlTmI3RTRRME1JeU44M19PdVBNU3doUVp5d0ZLNVZjdHBUeUNqa2s3ZTdBSnZ6dUllZG9SaldXTkJQS1hudEMwVWpoOUNPcTYweXctbzRGdEFVSUFPU25yQkN5cURWQlpWWFYwX28xNWNRbWRPYkhVeGw",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": true, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1682",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:23 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444884.657142,VS0,VE103",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444883719.Z0FBQUFBQmFrT09Ub043MmFXNFZlZ1FzeGZLSGtaOGhCVUY2RDRybF92NHFocmo4eHNybnpQRzNJcG9JekphSm0zY21CNkVybEFEYlhsRC01NS16cjYwWTVlZHVSbjJwbUxMdnNVcWQ1Z0FqSlJNYmQ3anZyamZCdTdmTGRRZ2RxTnA2VFJucHJTajA; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:23 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "562.0",
+          "x-ratelimit-reset": "517",
+          "x-ratelimit-used": "38",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22email_digests%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "53",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444883719.Z0FBQUFBQmFrT09Ub043MmFXNFZlZ1FzeGZLSGtaOGhCVUY2RDRybF92NHFocmo4eHNybnpQRzNJcG9JekphSm0zY21CNkVybEFEYlhsRC01NS16cjYwWTVlZHVSbjJwbUxMdnNVcWQ1Z0FqSlJNYmQ3anZyamZCdTdmTGRRZ2RxTnA2VFJucHJTajA",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:23 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444884.785260,VS0,VE90",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444883823.Z0FBQUFBQmFrT09UVWdKYnJoUXJucnpXQVB5QXVBRDJfYTJGU01SUWJCcjFBb2lIT1BaWmFhQkNYLUdRTmRTTUcwNWpmOVBiNUJ1c2hHai1yMFY3MWx3Ny1iNzdlSDRlcy1rUm8tcWJvSE5MLWZJaXRRRWU5R2ROYk1jUjhJMVBPMTFwM0U0TG5xMFg; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:23 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "561.0",
+          "x-ratelimit-reset": "517",
+          "x-ratelimit-used": "39",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:24",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22email_messages%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "53",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444883823.Z0FBQUFBQmFrT09UVWdKYnJoUXJucnpXQVB5QXVBRDJfYTJGU01SUWJCcjFBb2lIT1BaWmFhQkNYLUdRTmRTTUcwNWpmOVBiNUJ1c2hHai1yMFY3MWx3Ny1iNzdlSDRlcy1rUm8tcWJvSE5MLWZJaXRRRWU5R2ROYk1jUjhJMVBPMTFwM0U0TG5xMFg",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": true, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1682",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:23 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444884.901101,VS0,VE94",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444883936.Z0FBQUFBQmFrT09UdVdaampHSXRkdnN5QTZaRmo0el9HTFdtUGJfSE9Ia1BPa3BTelZHVFRlWUdIV19CakpqVDZOSTgzS2FIZmlJSGtGTGdKZFpZUUg1NndnaVo4ZjNHa3RlcW9obXJJMjlfOE1lT1FlRktsalVpTkV4SHRNLVlNdDNvMkR2NkZVZ0M; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:23 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "560.0",
+          "x-ratelimit-reset": "517",
+          "x-ratelimit-used": "40",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:24",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22email_messages%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "54",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444883936.Z0FBQUFBQmFrT09UdVdaampHSXRkdnN5QTZaRmo0el9HTFdtUGJfSE9Ia1BPa3BTelZHVFRlWUdIV19CakpqVDZOSTgzS2FIZmlJSGtGTGdKZFpZUUg1NndnaVo4ZjNHa3RlcW9obXJJMjlfOE1lT1FlRktsalVpTkV4SHRNLVlNdDNvMkR2NkZVZ0M",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:24 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444884.022822,VS0,VE97",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444884058.Z0FBQUFBQmFrT09VbEdiX0dqNWI5R2xJdHZwTXpHSG5ZTnFLMHlPRkFaNXJrQWxnZUdKdHBYUl92Sk04NHlwRVN1UXNmdER0Nmw3WWIydExqZFJFYTVzdUZMMnlWaGRBaFpvZjVfX0pJSHA2RTRWVXhRSDJkc2lnVDJKWW0yMUJwaWhVUzZqcGVPWHA; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:24 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "559.0",
+          "x-ratelimit-reset": "516",
+          "x-ratelimit-used": "41",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:24",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22email_unsubscribe_all%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "60",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444884058.Z0FBQUFBQmFrT09VbEdiX0dqNWI5R2xJdHZwTXpHSG5ZTnFLMHlPRkFaNXJrQWxnZUdKdHBYUl92Sk04NHlwRVN1UXNmdER0Nmw3WWIydExqZFJFYTVzdUZMMnlWaGRBaFpvZjVfX0pJSHA2RTRWVXhRSDJkc2lnVDJKWW0yMUJwaWhVUzZqcGVPWHA",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": true, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1682",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:24 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444884.146600,VS0,VE100",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444884182.Z0FBQUFBQmFrT09VM0d0dFlYdmhJakREUWg3Z0w3T1YtVjlaM25xYWZkVDdJYjkycmV6SEhnRUR0d3BQejRfQVhQRks2T1gzWWJOYzhjWVBhY19valRNallkRDVXOUpPOHpWN2hoek1KMDZGNVo3Q2ZDTkxRZ28xeXdFQlVZWkxzTHZRNTE0MHliT2k; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:24 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "558.0",
+          "x-ratelimit-reset": "516",
+          "x-ratelimit-used": "42",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:24",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22email_unsubscribe_all%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "61",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444884182.Z0FBQUFBQmFrT09VM0d0dFlYdmhJakREUWg3Z0w3T1YtVjlaM25xYWZkVDdJYjkycmV6SEhnRUR0d3BQejRfQVhQRks2T1gzWWJOYzhjWVBhY19valRNallkRDVXOUpPOHpWN2hoek1KMDZGNVo3Q2ZDTkxRZ28xeXdFQlVZWkxzTHZRNTE0MHliT2k",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:24 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444884.272815,VS0,VE96",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444884307.Z0FBQUFBQmFrT09VZXBqQzBleV9WSWlTRXlyNGJtemxnQ0xvVmlJcDJ1N2h6WVRJMlF4NXRoVFJLNUNSbmJkODFwcFE0ZElwRFVLR0lxTFlwdm9hYmpUeERSRzZlUVFYRDBaeko4bkhuUDd3a1p6WHZnR2ZhcURYZW9TZ19tQVdnbUFpZlNxd3JxM1g; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:24 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "557.0",
+          "x-ratelimit-reset": "516",
+          "x-ratelimit-used": "43",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:24",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22enable_default_themes%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "60",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444884307.Z0FBQUFBQmFrT09VZXBqQzBleV9WSWlTRXlyNGJtemxnQ0xvVmlJcDJ1N2h6WVRJMlF4NXRoVFJLNUNSbmJkODFwcFE0ZElwRFVLR0lxTFlwdm9hYmpUeERSRzZlUVFYRDBaeko4bkhuUDd3a1p6WHZnR2ZhcURYZW9TZ19tQVdnbUFpZlNxd3JxM1g",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": true, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1682",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:24 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444884.395988,VS0,VE106",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444884437.Z0FBQUFBQmFrT09VWHNLZzBST0NOR3BWM1ZscU9YcnIwLW9zcWFSb2hGUlk4ZGFjdkMzQVNETzlKMXVNU3ExQzNOMDdyN2RYWlNBbE5Vd2lKOUlwZVFYVDNFT21oZkxsVXRPZFBuTko0TzFLM29rdFFHUVlWX3prYVI0Q05ONzV5NTNkNnNHZ0ExZ20; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:24 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "556.0",
+          "x-ratelimit-reset": "516",
+          "x-ratelimit-used": "44",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:24",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22enable_default_themes%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "61",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444884437.Z0FBQUFBQmFrT09VWHNLZzBST0NOR3BWM1ZscU9YcnIwLW9zcWFSb2hGUlk4ZGFjdkMzQVNETzlKMXVNU3ExQzNOMDdyN2RYWlNBbE5Vd2lKOUlwZVFYVDNFT21oZkxsVXRPZFBuTko0TzFLM29rdFFHUVlWX3prYVI0Q05ONzV5NTNkNnNHZ0ExZ20",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:24 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444885.527951,VS0,VE101",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444884569.Z0FBQUFBQmFrT09VTjIySnV3VGgyazFiV0hoaE1iNlBHMmFkVS1rMzJQVDNRT296VVdLU2lvMy01dHhtd3k5akd3aUtYZURERTVmd2RnMF9NV2xYREtmcU5qYWhPYktZeVVOYzhMNVkzR2VuS3J2czRybjZMaW1jVnVMTjhnVUh5LUkxYjVGQW1aR2w; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:24 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "555.0",
+          "x-ratelimit-reset": "516",
+          "x-ratelimit-used": "45",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:24",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22hide_downs%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "49",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444884569.Z0FBQUFBQmFrT09VTjIySnV3VGgyazFiV0hoaE1iNlBHMmFkVS1rMzJQVDNRT296VVdLU2lvMy01dHhtd3k5akd3aUtYZURERTVmd2RnMF9NV2xYREtmcU5qYWhPYktZeVVOYzhMNVkzR2VuS3J2czRybjZMaW1jVnVMTjhnVUh5LUkxYjVGQW1aR2w",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": true, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1682",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:24 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444885.655250,VS0,VE105",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444884692.Z0FBQUFBQmFrT09VWU9iMDAwNFQwd0JkbjJTRFZWd0tiaXh4ckRRaFVXWDZJRGwwOHJWSEFmbFVWWERGVy16RmMwZWo2a3lrQzBWck1sbkZMdTQyc0pnQ0ZRcVg5UkdoSmFHMlZ2b0JfMG9sRFZ0UW5DUXBXSU95Zlh5ZUw1SEU2eVBJbVY0QWx2dFo; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:24 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "554.0",
+          "x-ratelimit-reset": "516",
+          "x-ratelimit-used": "46",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:24",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22hide_downs%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "50",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444884692.Z0FBQUFBQmFrT09VWU9iMDAwNFQwd0JkbjJTRFZWd0tiaXh4ckRRaFVXWDZJRGwwOHJWSEFmbFVWWERGVy16RmMwZWo2a3lrQzBWck1sbkZMdTQyc0pnQ0ZRcVg5UkdoSmFHMlZ2b0JfMG9sRFZ0UW5DUXBXSU95Zlh5ZUw1SEU2eVBJbVY0QWx2dFo",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:24 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444885.785844,VS0,VE105",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444884817.Z0FBQUFBQmFrT09VSk5Cck1kOTdfaVQzLXViWi1XNGFjRUpRUEJ3R1JIbTRYNVFYMENZS2tnT0lDMXpvdHdXODJ0S2RqdElCeUVWbTFtQmRRTVBTR3N3U2lXdFk5Z21HUU9ocnBhc1R6MTFGZTJvNnUtZjY2cDVtcGliTU9hSFJZeTNBR0R2bzlGWVk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:24 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "553.0",
+          "x-ratelimit-reset": "516",
+          "x-ratelimit-used": "47",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:25",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22hide_from_robots%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "55",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444884817.Z0FBQUFBQmFrT09VSk5Cck1kOTdfaVQzLXViWi1XNGFjRUpRUEJ3R1JIbTRYNVFYMENZS2tnT0lDMXpvdHdXODJ0S2RqdElCeUVWbTFtQmRRTVBTR3N3U2lXdFk5Z21HUU9ocnBhc1R6MTFGZTJvNnUtZjY2cDVtcGliTU9hSFJZeTNBR0R2bzlGWVk",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": true, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1682",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:25 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444885.917578,VS0,VE104",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444884955.Z0FBQUFBQmFrT09VTzhEbzFnWTFMd04wTmtjYjJwXzNOZDgyTnYtbGE5U3VNelRqdlJ5R2Z5Z1JvMWxxaXFrT1h1Y0RlYk4xWnBFeURkOWFHME1nTjVWZV9sUmZtZUpwZ2NrLXh0RzQ5dy1NSkMyZkk4V0h1d0Z1dUQ1cVpuMjYtY2l6LTFRZ2pZQXc; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:24 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "552.0",
+          "x-ratelimit-reset": "516",
+          "x-ratelimit-used": "48",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:25",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22hide_from_robots%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "56",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444884955.Z0FBQUFBQmFrT09VTzhEbzFnWTFMd04wTmtjYjJwXzNOZDgyTnYtbGE5U3VNelRqdlJ5R2Z5Z1JvMWxxaXFrT1h1Y0RlYk4xWnBFeURkOWFHME1nTjVWZV9sUmZtZUpwZ2NrLXh0RzQ5dy1NSkMyZkk4V0h1d0Z1dUQ1cVpuMjYtY2l6LTFRZ2pZQXc",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:25 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444885.047710,VS0,VE102",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444885082.Z0FBQUFBQmFrT09WdGo1OXVieE1PalpYb3lPeURBQnBYRWFqbm5SUXc3cFB0VGo0aUc5RVh4YVJLcXNuUmlZQ211amotSlRUVlpMNlViQl9vRWpQTktvUWtOODl5M0ZldnB5bmc4dWR0MG5hZ2w2SDQtYjdVYmMyRDJHWVRWbVhYM2FRX1RWTGpycTE; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:25 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "551.0",
+          "x-ratelimit-reset": "515",
+          "x-ratelimit-used": "49",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:25",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22hide_locationbar%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "55",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444885082.Z0FBQUFBQmFrT09WdGo1OXVieE1PalpYb3lPeURBQnBYRWFqbm5SUXc3cFB0VGo0aUc5RVh4YVJLcXNuUmlZQ211amotSlRUVlpMNlViQl9vRWpQTktvUWtOODl5M0ZldnB5bmc4dWR0MG5hZ2w2SDQtYjdVYmMyRDJHWVRWbVhYM2FRX1RWTGpycTE",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": true, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1682",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:25 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444885.176718,VS0,VE97",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444885212.Z0FBQUFBQmFrT09WZ3JScnlHWk1YNkhuaWRWcjV2QjAtNGVpSGxhYzhmdjY2NHRCS1hEN0E2OTNQbWxZOTlIdFc2YnlGaEh4Q1E2S3FqcUhYZWN6dEo3bDBNX3BnRUZVV1hWYTBkakpzX0pjNmlla2lzOWJrcXhPU0FtQVdnSnczUTlNZDVRbjFjbXc; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:25 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "550.0",
+          "x-ratelimit-reset": "515",
+          "x-ratelimit-used": "50",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:25",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22hide_locationbar%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "56",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444885212.Z0FBQUFBQmFrT09WZ3JScnlHWk1YNkhuaWRWcjV2QjAtNGVpSGxhYzhmdjY2NHRCS1hEN0E2OTNQbWxZOTlIdFc2YnlGaEh4Q1E2S3FqcUhYZWN6dEo3bDBNX3BnRUZVV1hWYTBkakpzX0pjNmlla2lzOWJrcXhPU0FtQVdnSnczUTlNZDVRbjFjbXc",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:25 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444885.299637,VS0,VE102",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444885336.Z0FBQUFBQmFrT09WbHBBZTQ0ZWk1NGZOblJ0bFZ2RW1PU1g3cTI1ZDd6Y19fdDBMVmZ4WGpjc0ZHNlktU2RseGE0bk91Z2hvcm9lR2FKQ2w3cFhHNHpPVXBfM2pULVJ2TjlfTzFQS2QxZkEwVTdsSWMxdElZRDFHdUE0Z0JxbE9saHBsMmIzc2hVNF8; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:25 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "549.0",
+          "x-ratelimit-reset": "515",
+          "x-ratelimit-used": "51",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:25",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22hide_ups%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "47",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444885336.Z0FBQUFBQmFrT09WbHBBZTQ0ZWk1NGZOblJ0bFZ2RW1PU1g3cTI1ZDd6Y19fdDBMVmZ4WGpjc0ZHNlktU2RseGE0bk91Z2hvcm9lR2FKQ2w3cFhHNHpPVXBfM2pULVJ2TjlfTzFQS2QxZkEwVTdsSWMxdElZRDFHdUE0Z0JxbE9saHBsMmIzc2hVNF8",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": true, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1682",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:25 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444885.428635,VS0,VE138",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444885461.Z0FBQUFBQmFrT09WWURpaDVSbWtyOS1kN0ZHMFBYYnkyYmE2dU5ERHZqajJrMFpUaTk1UFM1UDJVWUhfaF9GV05WLVFZQW5GZW53T24yX0V1eW10SHAtZFJ4VEpETF9WRUVoM1NpdFZ0TTNiTGJBeUcxS3NOTndmd1RCZlc5RFV3dzJZalpmS2l3Q1g; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:25 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "548.0",
+          "x-ratelimit-reset": "515",
+          "x-ratelimit-used": "52",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:25",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22hide_ups%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "48",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444885461.Z0FBQUFBQmFrT09WWURpaDVSbWtyOS1kN0ZHMFBYYnkyYmE2dU5ERHZqajJrMFpUaTk1UFM1UDJVWUhfaF9GV05WLVFZQW5GZW53T24yX0V1eW10SHAtZFJ4VEpETF9WRUVoM1NpdFZ0TTNiTGJBeUcxS3NOTndmd1RCZlc5RFV3dzJZalpmS2l3Q1g",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:25 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444886.592838,VS0,VE101",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444885629.Z0FBQUFBQmFrT09WTkdJTWN1VDVDR3NzWmZJeUY3d3BqSU4wSkZwR3pCNkhRck5PQlY1T1djb2dqRzdFT3VIUGJ6eHlDYkFIbUQ3aGZmUFBKOWczeHk4WWhYUFJfNkVPanBnYmtBMC1LUTF2ckdaUHMta0VVYVZFQ0laNFlzbGlsbkpZa1RZaEVYRm4; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:25 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "547.0",
+          "x-ratelimit-reset": "515",
+          "x-ratelimit-used": "53",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:25",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22highlight_controversial%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "62",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444885629.Z0FBQUFBQmFrT09WTkdJTWN1VDVDR3NzWmZJeUY3d3BqSU4wSkZwR3pCNkhRck5PQlY1T1djb2dqRzdFT3VIUGJ6eHlDYkFIbUQ3aGZmUFBKOWczeHk4WWhYUFJfNkVPanBnYmtBMC1LUTF2ckdaUHMta0VVYVZFQ0laNFlzbGlsbkpZa1RZaEVYRm4",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": true, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1682",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:25 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444886.721032,VS0,VE102",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444885753.Z0FBQUFBQmFrT09WYnhXOGpBSTAyU3NGSklkVjhfMlNaRWJkNHJncFZKb1UzSUYwT3l1VlpPcGdVMGx5WEh1QkJvSVZJNmFNS2RWbGo4UTM2enlNSldMYnBYb29jdWY3TW5oZW9WSnRmSnNLNVJrZGhBWVAzc0RjeTFLUDBlSmxmZ3h1bUhfQlYzbVE; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:25 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "546.0",
+          "x-ratelimit-reset": "515",
+          "x-ratelimit-used": "54",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:25",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22highlight_controversial%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "63",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444885753.Z0FBQUFBQmFrT09WYnhXOGpBSTAyU3NGSklkVjhfMlNaRWJkNHJncFZKb1UzSUYwT3l1VlpPcGdVMGx5WEh1QkJvSVZJNmFNS2RWbGo4UTM2enlNSldMYnBYb29jdWY3TW5oZW9WSnRmSnNLNVJrZGhBWVAzc0RjeTFLUDBlSmxmZ3h1bUhfQlYzbVE",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:25 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444886.853315,VS0,VE106",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444885905.Z0FBQUFBQmFrT09WZWl5bEdTU3FQaER3QWM5SVJYeEhrZ2lrN3RXLTdXMlJ0Mk9SWGdJM3o4RWRqMzg3MHdEejQyWmFnV0tzd2hzdEozUlZoMFpab0pTejFvWTdfcmhkalZuTlg3cEc2WUkyRVNRWkhKcnAyZUxkdkxLY1N1WGhFUHp2RTM4T29uTGw; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:25 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "545.0",
+          "x-ratelimit-reset": "515",
+          "x-ratelimit-used": "55",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:26",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22highlight_new_comments%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "61",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444885905.Z0FBQUFBQmFrT09WZWl5bEdTU3FQaER3QWM5SVJYeEhrZ2lrN3RXLTdXMlJ0Mk9SWGdJM3o4RWRqMzg3MHdEejQyWmFnV0tzd2hzdEozUlZoMFpab0pTejFvWTdfcmhkalZuTlg3cEc2WUkyRVNRWkhKcnAyZUxkdkxLY1N1WGhFUHp2RTM4T29uTGw",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": true, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1682",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:26 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444886.994060,VS0,VE95",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444886030.Z0FBQUFBQmFrT09XN0IxMTZDblFnRHRHVGhUU1lvVXYyWU5hckpsZEEyVkFIa2JXaGpnTWJqaVNPcTdIQ2pzX010NGRYSG5ULWF2RmZFRXJieXp3SjRqckl6NHBNWWJGcElLVFV4a3Q5SWEzc1FGcUlCT05qSFNPZ3ZWZDRtaTJJRkc1eXVUS2NtbGQ; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:26 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "544.0",
+          "x-ratelimit-reset": "514",
+          "x-ratelimit-used": "56",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:26",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22highlight_new_comments%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "62",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444886030.Z0FBQUFBQmFrT09XN0IxMTZDblFnRHRHVGhUU1lvVXYyWU5hckpsZEEyVkFIa2JXaGpnTWJqaVNPcTdIQ2pzX010NGRYSG5ULWF2RmZFRXJieXp3SjRqckl6NHBNWWJGcElLVFV4a3Q5SWEzc1FGcUlCT05qSFNPZ3ZWZDRtaTJJRkc1eXVUS2NtbGQ",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:26 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444886.127470,VS0,VE97",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444886159.Z0FBQUFBQmFrT09XYTMtbkVCN1JPWDk0OXNQNzVPUWZKWDBYWTdXY21neGFVUUxyY1MyZkhaanRROWp1SVcyMDVNcjNEYkRzOGtsVHpSVjN2OUZRaHNDcVJBQ2lXdzdRRmpuWXRmUmlpanhtREhTaFQwOVB1RDJ1cV9rbnlDMHk0UVR2MUZuN1RHeEw; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:26 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "543.0",
+          "x-ratelimit-reset": "514",
+          "x-ratelimit-used": "57",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:26",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22ignore_suggested_sort%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "60",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444886159.Z0FBQUFBQmFrT09XYTMtbkVCN1JPWDk0OXNQNzVPUWZKWDBYWTdXY21neGFVUUxyY1MyZkhaanRROWp1SVcyMDVNcjNEYkRzOGtsVHpSVjN2OUZRaHNDcVJBQ2lXdzdRRmpuWXRmUmlpanhtREhTaFQwOVB1RDJ1cV9rbnlDMHk0UVR2MUZuN1RHeEw",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": true, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1682",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:26 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444886.263970,VS0,VE105",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444886299.Z0FBQUFBQmFrT09XSVl0el9FU3lQSnNrMEdLZFVsaUE2RFBkSW1GQi1oU0dzRm5WdlRhS0I5cjIxVkJ3bmNlMkhYRWRkTjNZZXlfMmJleERBRUc4YlFuWVoxQUx4ZUdtbEUzR0pqT09hal9XVWVLaHF1THkxc1Y5cXpCalA1emIzNGJSRmF1V0dZV1o; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:26 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "542.0",
+          "x-ratelimit-reset": "514",
+          "x-ratelimit-used": "58",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:26",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22ignore_suggested_sort%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "61",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444886299.Z0FBQUFBQmFrT09XSVl0el9FU3lQSnNrMEdLZFVsaUE2RFBkSW1GQi1oU0dzRm5WdlRhS0I5cjIxVkJ3bmNlMkhYRWRkTjNZZXlfMmJleERBRUc4YlFuWVoxQUx4ZUdtbEUzR0pqT09hal9XVWVLaHF1THkxc1Y5cXpCalA1emIzNGJSRmF1V0dZV1o",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:26 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444886.395308,VS0,VE105",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444886431.Z0FBQUFBQmFrT09XRkxaM1FlVWhEWnFYcnd2bFYtbE96VHE1ZGhKcWZRTGFTQVE0NHhIOHVTRFNvbzRTTk5UVl9GYXFWOVQxdktTcDJGOXd6dThWNWU3bFVxQnBITmxpUjliT1dZb3R4bm9qQTdvRlFMMFRjTWNkSlhUZERCX1psbWx4RHNKSjRnc2U; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:26 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "541.0",
+          "x-ratelimit-reset": "514",
+          "x-ratelimit-used": "59",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:26",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22legacy_search%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "52",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444886431.Z0FBQUFBQmFrT09XRkxaM1FlVWhEWnFYcnd2bFYtbE96VHE1ZGhKcWZRTGFTQVE0NHhIOHVTRFNvbzRTTk5UVl9GYXFWOVQxdktTcDJGOXd6dThWNWU3bFVxQnBITmxpUjliT1dZb3R4bm9qQTdvRlFMMFRjTWNkSlhUZERCX1psbWx4RHNKSjRnc2U",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": true, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1682",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:26 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444887.525271,VS0,VE104",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444886577.Z0FBQUFBQmFrT09XSmxraG5oUFNSMUF0eXh1eXp5U2ZLUkRSU2pNaUJKUDZxQWdLV1JtRktqS1Z0Mjc0MGNHdWt2R2kxcjVqTURoQkd6SFMwTTRlLVRiSVFUUmdjLWF0Znc4X01EakF3cm8wYlFzNUhTVlIzRmhmZFBCV3R1UXIzUXBSZ0JGN0tQXzE; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:26 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "540.0",
+          "x-ratelimit-reset": "514",
+          "x-ratelimit-used": "60",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:26",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22legacy_search%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "53",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444886577.Z0FBQUFBQmFrT09XSmxraG5oUFNSMUF0eXh1eXp5U2ZLUkRSU2pNaUJKUDZxQWdLV1JtRktqS1Z0Mjc0MGNHdWt2R2kxcjVqTURoQkd6SFMwTTRlLVRiSVFUUmdjLWF0Znc4X01EakF3cm8wYlFzNUhTVlIzRmhmZFBCV3R1UXIzUXBSZ0JGN0tQXzE",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:26 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444887.655194,VS0,VE95",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444886691.Z0FBQUFBQmFrT09XOExOWUhUd3c2NExGRWg1WmxTMHdZVzBPeXA4dHR2QTNaT09ETVhGUFBXUHZiYmtMblhxMEVsQ0lCR0dBN2dRVHJOd1VfQ0p5X3NDY1J5WjMteGN2YWhUd0xibkg1Y2pnaVNpMHlQdjJfdk9RcjJad01iMzE0U2JyWDBLc0JUU0M; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:26 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "539.0",
+          "x-ratelimit-reset": "514",
+          "x-ratelimit-used": "61",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:26",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22live_orangereds%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "54",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444886691.Z0FBQUFBQmFrT09XOExOWUhUd3c2NExGRWg1WmxTMHdZVzBPeXA4dHR2QTNaT09ETVhGUFBXUHZiYmtMblhxMEVsQ0lCR0dBN2dRVHJOd1VfQ0p5X3NDY1J5WjMteGN2YWhUd0xibkg1Y2pnaVNpMHlQdjJfdk9RcjJad01iMzE0U2JyWDBLc0JUU0M",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": true, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1682",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:26 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444887.777098,VS0,VE106",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444886812.Z0FBQUFBQmFrT09XWVJYVEZHNWZUWlR2d01zNzc2T1dsSU5INlFpUTBxZFB2VU94TENEZ0wyckNMSWY3MWNFYV93Y0NWRVp0MzR4ZFhxZXptTlpnUW1xdWY5Rkp4dnpYRDBnbVZFSkQtWFBvUmpJNXpzWEk0cVVtWUJFSW1GWC1fVkV0Q00zZk92S2k; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:26 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "538.0",
+          "x-ratelimit-reset": "514",
+          "x-ratelimit-used": "62",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:27",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22live_orangereds%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "55",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444886812.Z0FBQUFBQmFrT09XWVJYVEZHNWZUWlR2d01zNzc2T1dsSU5INlFpUTBxZFB2VU94TENEZ0wyckNMSWY3MWNFYV93Y0NWRVp0MzR4ZFhxZXptTlpnUW1xdWY5Rkp4dnpYRDBnbVZFSkQtWFBvUmpJNXpzWEk0cVVtWUJFSW1GWC1fVkV0Q00zZk92S2k",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:27 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444887.909330,VS0,VE352",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444887193.Z0FBQUFBQmFrT09YTXBXV05HSnhHU3V0QkJYWm5CTjhBR0ZDWHN5ejVmUndnN2VHS0hDbEFYRFUxYlM2elNTOXFLUHJaX3J1aHlnWC1ZQ1dqVUFwc1VsRkE5YmdvTy1yRjYxQmg0SndaTlZuMnJhWmdHbndXY0pjQlJfeWs5cXRlOHViN0h6dzZXRU8; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:27 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "537.0",
+          "x-ratelimit-reset": "513",
+          "x-ratelimit-used": "63",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:27",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22mark_messages_read%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "57",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444887193.Z0FBQUFBQmFrT09YTXBXV05HSnhHU3V0QkJYWm5CTjhBR0ZDWHN5ejVmUndnN2VHS0hDbEFYRFUxYlM2elNTOXFLUHJaX3J1aHlnWC1ZQ1dqVUFwc1VsRkE5YmdvTy1yRjYxQmg0SndaTlZuMnJhWmdHbndXY0pjQlJfeWs5cXRlOHViN0h6dzZXRU8",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": true, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1682",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:27 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444887.312412,VS0,VE102",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444887345.Z0FBQUFBQmFrT09YSzQxNGdLclZabTlHeUxJUWtMeC1uOG1kWWN5RjdjTlJKWENoaWV2clRrTHJLeXpNQmtWcENRTV9RV3hnam1jRTRRcHdCNk5sWEc1WXk4dnBuWFA1MllNd3VscFZ0S0JLbTduSlBINE1GcUM5V2ZEZV9oZFBXYlBidUhKREhFUzA; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:27 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "536.0",
+          "x-ratelimit-reset": "513",
+          "x-ratelimit-used": "64",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:27",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22mark_messages_read%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "58",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444887345.Z0FBQUFBQmFrT09YSzQxNGdLclZabTlHeUxJUWtMeC1uOG1kWWN5RjdjTlJKWENoaWV2clRrTHJLeXpNQmtWcENRTV9RV3hnam1jRTRRcHdCNk5sWEc1WXk4dnBuWFA1MllNd3VscFZ0S0JLbTduSlBINE1GcUM5V2ZEZV9oZFBXYlBidUhKREhFUzA",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:27 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444887.441115,VS0,VE177",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444887478.Z0FBQUFBQmFrT09YZ25HcV84VjhLNjZWTFdGeWVjVklHQ3A4d3dMT2FxejREeXlSVFRPYXNkR0VnazZKSDlIMnEzd1l5MkZGR2hqUGNydFV1MVp0U21xTnpjM0lSMk1DWWtLSWxyZVFLdGlfbEpqbW05eXEyTnpfQmNsQ25yaE5FX1FXUm1qQWtRbUI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:27 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "535.0",
+          "x-ratelimit-reset": "513",
+          "x-ratelimit-used": "65",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:27",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22monitor_mentions%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "55",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444887478.Z0FBQUFBQmFrT09YZ25HcV84VjhLNjZWTFdGeWVjVklHQ3A4d3dMT2FxejREeXlSVFRPYXNkR0VnazZKSDlIMnEzd1l5MkZGR2hqUGNydFV1MVp0U21xTnpjM0lSMk1DWWtLSWxyZVFLdGlfbEpqbW05eXEyTnpfQmNsQ25yaE5FX1FXUm1qQWtRbUI",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": true, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1682",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:27 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444888.645159,VS0,VE109",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444887681.Z0FBQUFBQmFrT09YakNIYnNnMHR0T3BNQXlvZzE3RkdsX0dQV2lrWGNGU1FXNW9tSGpyRkhtd0Z5clEzWURnTnJiMUNGV25qaGRsYnlKUVFWTWxtbnNXU3NXSTVmVGV2RnBwUEZYYVdnVHV0SWlpekVvREF5bDN5QUZSbmZ2bXNVMEhNUXdwZ3l4N20; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:27 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "534.0",
+          "x-ratelimit-reset": "513",
+          "x-ratelimit-used": "66",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:27",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22monitor_mentions%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "56",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444887681.Z0FBQUFBQmFrT09YakNIYnNnMHR0T3BNQXlvZzE3RkdsX0dQV2lrWGNGU1FXNW9tSGpyRkhtd0Z5clEzWURnTnJiMUNGV25qaGRsYnlKUVFWTWxtbnNXU3NXSTVmVGV2RnBwUEZYYVdnVHV0SWlpekVvREF5bDN5QUZSbmZ2bXNVMEhNUXdwZ3l4N20",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:27 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444888.779990,VS0,VE94",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444887812.Z0FBQUFBQmFrT09YTDNKT3ZRbl9SNy0ta1FYWmt6bV9RMlZFX0c0cjl0R3hVMmQ5b3NwMVIyeThEUzUzRHB5aGNad1dCTlZiU0RZdVplV1hfMVBSOHRSR2V5eTZidjBGTU9ueDY1czQ3MVVFNHVPTnN3WDhZU2hiczh1X3VCWE5URGtyMnlTd1NDOXI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:27 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "533.0",
+          "x-ratelimit-reset": "513",
+          "x-ratelimit-used": "67",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:28",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22newwindow%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "48",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444887812.Z0FBQUFBQmFrT09YTDNKT3ZRbl9SNy0ta1FYWmt6bV9RMlZFX0c0cjl0R3hVMmQ5b3NwMVIyeThEUzUzRHB5aGNad1dCTlZiU0RZdVplV1hfMVBSOHRSR2V5eTZidjBGTU9ueDY1czQ3MVVFNHVPTnN3WDhZU2hiczh1X3VCWE5URGtyMnlTd1NDOXI",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": true, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1682",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:28 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444888.901072,VS0,VE108",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444887933.Z0FBQUFBQmFrT09YY3FKcVFwbmJiU0Uzb2JTOHJFVVlKSWw5X09ORmwtbnBEMzJXOGk4dE9kSmFIZnRnUzJQc290NXFJeHJWZkJxd0xVOG15OGUtdmRwRGZpM3ZEWGs3MC1YMHBoeWVjU0hnLUtNREl5WU40OGdBRWJLQWlPempnWDlZUmk5bnpWUjQ; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:27 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "532.0",
+          "x-ratelimit-reset": "513",
+          "x-ratelimit-used": "68",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:28",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22newwindow%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "49",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444887933.Z0FBQUFBQmFrT09YY3FKcVFwbmJiU0Uzb2JTOHJFVVlKSWw5X09ORmwtbnBEMzJXOGk4dE9kSmFIZnRnUzJQc290NXFJeHJWZkJxd0xVOG15OGUtdmRwRGZpM3ZEWGs3MC1YMHBoeWVjU0hnLUtNREl5WU40OGdBRWJLQWlPempnWDlZUmk5bnpWUjQ",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:28 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444888.036693,VS0,VE106",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444888073.Z0FBQUFBQmFrT09ZN0N6dGFUMEVTZXYwR3hBVkJHTXl0Z1BOcDNQUTR6cVZtZXBhRVN6a0lWLURDTHJRVWd4T0Ewd2lmektEYXlCYWI4YjBrLUVaVmY1c1Vmd0RZWFlnV1pqYzlnVGc0Z0tER2FuNHdJc0JqTU9EY0VKU2hUcVBpSER1V1RnWnlFZjI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:28 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "531.0",
+          "x-ratelimit-reset": "512",
+          "x-ratelimit-used": "69",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:28",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22no_video_autoplay%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "56",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444888073.Z0FBQUFBQmFrT09ZN0N6dGFUMEVTZXYwR3hBVkJHTXl0Z1BOcDNQUTR6cVZtZXBhRVN6a0lWLURDTHJRVWd4T0Ewd2lmektEYXlCYWI4YjBrLUVaVmY1c1Vmd0RZWFlnV1pqYzlnVGc0Z0tER2FuNHdJc0JqTU9EY0VKU2hUcVBpSER1V1RnWnlFZjI",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": true, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1682",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:28 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444888.179533,VS0,VE106",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444888215.Z0FBQUFBQmFrT09ZcnM0bTFJekRGbWdQU0prZnJkeXRpQ1h4amZiNUNQMlRfaXRRcUM4SjZFUDVnblhVNFhFcW11OTZkdnBWa185VTQtbXdvU3NwRVYteDdzZlpCN09maXBWYlVmRXdIUDZCS3hRb25pZkczYVdWM19MdlpYSkpuX3hpMXNWRkhUWGg; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:28 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "530.0",
+          "x-ratelimit-reset": "512",
+          "x-ratelimit-used": "70",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:28",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22no_video_autoplay%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "57",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444888215.Z0FBQUFBQmFrT09ZcnM0bTFJekRGbWdQU0prZnJkeXRpQ1h4amZiNUNQMlRfaXRRcUM4SjZFUDVnblhVNFhFcW11OTZkdnBWa185VTQtbXdvU3NwRVYteDdzZlpCN09maXBWYlVmRXdIUDZCS3hRb25pZkczYVdWM19MdlpYSkpuX3hpMXNWRkhUWGg",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:28 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444888.312115,VS0,VE327",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444888344.Z0FBQUFBQmFrT09ZQnh1R0VBYzhWSG91Z2trMFpZZ1ZNQmpJeEJTcUkwcnNIVXJOSEhfRXc0VmdHa1h1YWVzMHBkUmhoWE40Rjc2ZGM2U3JXaWduMFIzWjNkYVhNSjI5dHdzRjg2ek1iUVdQVFg0QktoUTJpbExWNTJPVFBPWkQybWcyZWlOQWJzU3k; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:28 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "529.0",
+          "x-ratelimit-reset": "512",
+          "x-ratelimit-used": "71",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:28",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22organic%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "46",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444888344.Z0FBQUFBQmFrT09ZQnh1R0VBYzhWSG91Z2trMFpZZ1ZNQmpJeEJTcUkwcnNIVXJOSEhfRXc0VmdHa1h1YWVzMHBkUmhoWE40Rjc2ZGM2U3JXaWduMFIzWjNkYVhNSjI5dHdzRjg2ek1iUVdQVFg0QktoUTJpbExWNTJPVFBPWkQybWcyZWlOQWJzU3k",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": true, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1682",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:28 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444889.665437,VS0,VE104",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444888703.Z0FBQUFBQmFrT09ZRzFmaDFXRFc0Q0YycHFHQUNDUVhWSGM3aWZrMnF1YkhBQnh1eGJseXduWjg3ZXpRekFVRkE2OXQ0UEJjQkktOVE3bE1DTWJacnFsa2N0SFpRWmgxZHhqOTV5bkFmeWktREhIOXFYLU50cUI0U3VnZHk0R01kMWdyN09EYWhlZUI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:28 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "528.0",
+          "x-ratelimit-reset": "512",
+          "x-ratelimit-used": "72",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:28",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22organic%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "47",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444888703.Z0FBQUFBQmFrT09ZRzFmaDFXRFc0Q0YycHFHQUNDUVhWSGM3aWZrMnF1YkhBQnh1eGJseXduWjg3ZXpRekFVRkE2OXQ0UEJjQkktOVE3bE1DTWJacnFsa2N0SFpRWmgxZHhqOTV5bkFmeWktREhIOXFYLU50cUI0U3VnZHk0R01kMWdyN09EYWhlZUI",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:28 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444889.797091,VS0,VE103",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444888831.Z0FBQUFBQmFrT09ZY0NuckxQbkh0OHhHS2l3NnZCUmZJLU5QOGwxemFtbjZuMHJqUmRkT0Q1cDFYZF85a3ZVUmRobmtGWnJGWFE0eG5DQU8yX2Zid21EeGROaFFKczdsYmFuTXdlRmtiLUhZTHBjSjh2bUhQbnRSRF9HWkhKbEZ6Wmg5VFhLb2VudXo; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:28 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "527.0",
+          "x-ratelimit-reset": "512",
+          "x-ratelimit-used": "73",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:29",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22over_18%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "46",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444888831.Z0FBQUFBQmFrT09ZY0NuckxQbkh0OHhHS2l3NnZCUmZJLU5QOGwxemFtbjZuMHJqUmRkT0Q1cDFYZF85a3ZVUmRobmtGWnJGWFE0eG5DQU8yX2Zid21EeGROaFFKczdsYmFuTXdlRmtiLUhZTHBjSjh2bUhQbnRSRF9HWkhKbEZ6Wmg5VFhLb2VudXo",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:29 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444889.925765,VS0,VE168",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444888952.Z0FBQUFBQmFrT09ad1d1YXlReWlORmxtd3Z5V3FqZWVPTDFEVjNwc0s0V0otNUxwNjM5YXY1a3pEb0c1am4wNEZQN0hGZnJjZW1aWVdqMThSc0hWYndQT0NyMjVEeFIxdWVUYk1fc1FOTlZjbXZ1blh2djl2YWZWNXA2Q3B6VzJGblZGWkpzUFhkQkk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:29 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "526.0",
+          "x-ratelimit-reset": "511",
+          "x-ratelimit-used": "74",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:29",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22over_18%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "47",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444888952.Z0FBQUFBQmFrT09ad1d1YXlReWlORmxtd3Z5V3FqZWVPTDFEVjNwc0s0V0otNUxwNjM5YXY1a3pEb0c1am4wNEZQN0hGZnJjZW1aWVdqMThSc0hWYndQT0NyMjVEeFIxdWVUYk1fc1FOTlZjbXZ1blh2djl2YWZWNXA2Q3B6VzJGblZGWkpzUFhkQkk",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1684",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:29 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444889.120449,VS0,VE109",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444889163.Z0FBQUFBQmFrT09aWDVseHFQNTZEMnZNbjBqRlctWDl3X3FKd2Y3WHJOVzRfSG9jancwS2VabU5wbUcxRm5iNmYtemhYQTBHbThkOGh6R1V5TGkwRzc3b3hTaldESy1mTjJxcTZLb1paMWF1SHBVc3pyTkFvYXExWXptVEF5ZDkyaUpZX1JnM2ppYXA; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:29 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "525.0",
+          "x-ratelimit-reset": "511",
+          "x-ratelimit-used": "75",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:29",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22private_feeds%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "52",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444889163.Z0FBQUFBQmFrT09aWDVseHFQNTZEMnZNbjBqRlctWDl3X3FKd2Y3WHJOVzRfSG9jancwS2VabU5wbUcxRm5iNmYtemhYQTBHbThkOGh6R1V5TGkwRzc3b3hTaldESy1mTjJxcTZLb1paMWF1SHBVc3pyTkFvYXExWXptVEF5ZDkyaUpZX1JnM2ppYXA",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": true, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:29 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444889.256707,VS0,VE102",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444889299.Z0FBQUFBQmFrT09aNGpLSW5VWGZ2Y1FpYUlUd2duRW9HbnJZRk95S2hGMzVlakxDRDViTXZ2SGVfbk94UFFIczg0R0N1R19CMDRhaG5USmkyQ05IVkh3bnlBSXRLekVWR01kWm1vYVlmekdvOFVfM1owWGZXQ2pIZ19tRTlwYW1EVTVxWUlwa0tlQUw; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:29 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "524.0",
+          "x-ratelimit-reset": "511",
+          "x-ratelimit-used": "76",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:29",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22private_feeds%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "53",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444889299.Z0FBQUFBQmFrT09aNGpLSW5VWGZ2Y1FpYUlUd2duRW9HbnJZRk95S2hGMzVlakxDRDViTXZ2SGVfbk94UFFIczg0R0N1R19CMDRhaG5USmkyQ05IVkh3bnlBSXRLekVWR01kWm1vYVlmekdvOFVfM1owWGZXQ2pIZ19tRTlwYW1EVTVxWUlwa0tlQUw",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1684",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:29 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444889.384893,VS0,VE106",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444889414.Z0FBQUFBQmFrT09aZUkwcHNPVG50N0tuamZFRGNrV1YyYWJaUzhSY0YyWjBLOXpVQi0ydkFnejBnaVBtMGJOWWlVUkM3NkNMYzJXVVBqUjIyamswOU1OY0dra0hTV1k4R21vbkMyLS1mWE9TQW1NOGs5aWtxbDlvQVQ1VDZNN2MxZkNKU3BvWU1GNXo; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:29 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "523.0",
+          "x-ratelimit-reset": "511",
+          "x-ratelimit-used": "77",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:29",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22profile_opt_out%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "54",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444889414.Z0FBQUFBQmFrT09aZUkwcHNPVG50N0tuamZFRGNrV1YyYWJaUzhSY0YyWjBLOXpVQi0ydkFnejBnaVBtMGJOWWlVUkM3NkNMYzJXVVBqUjIyamswOU1OY0dra0hTV1k4R21vbkMyLS1mWE9TQW1NOGs5aWtxbDlvQVQ1VDZNN2MxZkNKU3BvWU1GNXo",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": true, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:29 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444890.518216,VS0,VE107",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444889555.Z0FBQUFBQmFrT09aSDFwWDVFVURHWldZOU52MDZKYW92c0FETUlYblNLWVFHTXZSdF9xMUFwNTUzUU1jRDhyX2NKbDNxN2xwZHp4c0ZLSDFWcFZ4UFo3aFhadWhxcjA0T0RtTmd1Y2licXpUX0dQQnA2RDVCNkdybkJTT2tYLWxOcFliVEctSU1XLUc; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:29 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "522.0",
+          "x-ratelimit-reset": "511",
+          "x-ratelimit-used": "78",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:29",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22profile_opt_out%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "55",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444889555.Z0FBQUFBQmFrT09aSDFwWDVFVURHWldZOU52MDZKYW92c0FETUlYblNLWVFHTXZSdF9xMUFwNTUzUU1jRDhyX2NKbDNxN2xwZHp4c0ZLSDFWcFZ4UFo3aFhadWhxcjA0T0RtTmd1Y2licXpUX0dQQnA2RDVCNkdybkJTT2tYLWxOcFliVEctSU1XLUc",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1684",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:29 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444890.650852,VS0,VE158",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444889683.Z0FBQUFBQmFrT09aZWZrWXVFYmJVSTdFNlYzelRCUGJUVWR5MUFvVEZic09LaDE2c3RuX0JmZm94eXAtUG9xRnp0QjRKSUdzU2hSQjlBY2FTam1CSTIyNi1BTWNOeVpHWGdrTEZUTzh2TXNUZGpBeHdlNExjWnBLcktaNktuT1lQYXp5WVZOYkZTWFA; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:29 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "521.0",
+          "x-ratelimit-reset": "511",
+          "x-ratelimit-used": "79",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:29",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22public_votes%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "51",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444889683.Z0FBQUFBQmFrT09aZWZrWXVFYmJVSTdFNlYzelRCUGJUVWR5MUFvVEZic09LaDE2c3RuX0JmZm94eXAtUG9xRnp0QjRKSUdzU2hSQjlBY2FTam1CSTIyNi1BTWNOeVpHWGdrTEZUTzh2TXNUZGpBeHdlNExjWnBLcktaNktuT1lQYXp5WVZOYkZTWFA",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": true, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:29 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444890.836400,VS0,VE104",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444889873.Z0FBQUFBQmFrT09aZDVCV2VQM0tDYUY1OEtBZG9keGVfVXI5MzUtLXdjMGdfcS1vdjBpV18xYTNkTThsNnF5c0FyUDFhMnZKWUVXNVFDZjFLUVhXeHlhS2VsM1J3YXpVUUJCcGtjaW8tMklmTHNoUWpYS1BLU3Utd3NXU3NiUnFZd3VocklqcTRIbUc; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:29 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "520.0",
+          "x-ratelimit-reset": "511",
+          "x-ratelimit-used": "80",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:30",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22public_votes%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "52",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444889873.Z0FBQUFBQmFrT09aZDVCV2VQM0tDYUY1OEtBZG9keGVfVXI5MzUtLXdjMGdfcS1vdjBpV18xYTNkTThsNnF5c0FyUDFhMnZKWUVXNVFDZjFLUVhXeHlhS2VsM1J3YXpVUUJCcGtjaW8tMklmTHNoUWpYS1BLU3Utd3NXU3NiUnFZd3VocklqcTRIbUc",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1684",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:30 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444890.966871,VS0,VE100",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444890005.Z0FBQUFBQmFrT09hdmhuZnVVeno2bG1fcnRveTB6NzB0OXhfVDdEcEJfekowZkdnNWNHT3Z3VmpfeElCSGpYbVRyalV6ZVotem9iaFhLS1dyV0MtT1JlaVRnTVpDYmRDcGZVZ1ZoUF9SaGV2TnBGRk9xLTA3UWJwaGlOWmplbzdLSkpLZ2MwNURYajI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:30 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "519.0",
+          "x-ratelimit-reset": "510",
+          "x-ratelimit-used": "81",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:30",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22research%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "47",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444890005.Z0FBQUFBQmFrT09hdmhuZnVVeno2bG1fcnRveTB6NzB0OXhfVDdEcEJfekowZkdnNWNHT3Z3VmpfeElCSGpYbVRyalV6ZVotem9iaFhLS1dyV0MtT1JlaVRnTVpDYmRDcGZVZ1ZoUF9SaGV2TnBGRk9xLTA3UWJwaGlOWmplbzdLSkpLZ2MwNURYajI",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": true, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:30 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444890.094159,VS0,VE300",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444890130.Z0FBQUFBQmFrT09hekFSdU1mM3N0aHpPSExYUWRpcGVmd2lUQTBNM3p2enBZSjRONzBuOTBpZzlxc2FCYm5yX3poSk9MazJzLWRmZjREWWdZWW1KR2lYZU54aHRicVgxdWRqdW52SnIweEZCWTBDdVgwTjk1MG9JOTl5YmFQeXdodFl5ZDljZm9yd3g; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:30 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "518.0",
+          "x-ratelimit-reset": "510",
+          "x-ratelimit-used": "82",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:30",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22research%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "48",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444890130.Z0FBQUFBQmFrT09hekFSdU1mM3N0aHpPSExYUWRpcGVmd2lUQTBNM3p2enBZSjRONzBuOTBpZzlxc2FCYm5yX3poSk9MazJzLWRmZjREWWdZWW1KR2lYZU54aHRicVgxdWRqdW52SnIweEZCWTBDdVgwTjk1MG9JOTl5YmFQeXdodFl5ZDljZm9yd3g",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1684",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:30 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444890.487331,VS0,VE122",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444890523.Z0FBQUFBQmFrT09hcnJYZTFYWE9KY0NuMWx0RFd0MVlNNW5qbnZhVWZ5eEZlNVFsZ21pYUF0dnZoaWtXaEk3cGhXcXdIZmQwRkJidGowQ3Flb3JXanVlX2lmRG12b2FZQWFSTVJlM0dDR1F6ZlZIQ0d4OVhEMlVQZU9qMG5sVWlfWTBLZlIxQmVmcVA; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:30 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "517.0",
+          "x-ratelimit-reset": "510",
+          "x-ratelimit-used": "83",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:30",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22search_include_over_18%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "61",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444890523.Z0FBQUFBQmFrT09hcnJYZTFYWE9KY0NuMWx0RFd0MVlNNW5qbnZhVWZ5eEZlNVFsZ21pYUF0dnZoaWtXaEk3cGhXcXdIZmQwRkJidGowQ3Flb3JXanVlX2lmRG12b2FZQWFSTVJlM0dDR1F6ZlZIQ0d4OVhEMlVQZU9qMG5sVWlfWTBLZlIxQmVmcVA",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": true, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:30 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444891.635121,VS0,VE103",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444890668.Z0FBQUFBQmFrT09hMzBKa1B1M0w1ak9YdmpsZGxjcEFXcTBXV1dXSzZWRFV0emtyRTJaOGwwQWVOX0RrcFdkdW0wcGtZckxnMHN5c0J1RS00eldpMXd3WnlSdmctclJFRjlPXzg5N05Odk9JUHdHbVFFazVENW1JbkZjNVBLNGJzaFdtRGhIcXJUQm0; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:30 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "516.0",
+          "x-ratelimit-reset": "510",
+          "x-ratelimit-used": "84",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:30",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22search_include_over_18%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "62",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444890668.Z0FBQUFBQmFrT09hMzBKa1B1M0w1ak9YdmpsZGxjcEFXcTBXV1dXSzZWRFV0emtyRTJaOGwwQWVOX0RrcFdkdW0wcGtZckxnMHN5c0J1RS00eldpMXd3WnlSdmctclJFRjlPXzg5N05Odk9JUHdHbVFFazVENW1JbkZjNVBLNGJzaFdtRGhIcXJUQm0",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1684",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:30 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444891.765009,VS0,VE103",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444890817.Z0FBQUFBQmFrT09hb2I4bHUtUGhyYlozT2RxSDVpR2FkaEVJMnRoMFFjX1JTcTlLSVZadG9XR3RrY2lMVXBYY1A0SFZlTlFWaWhnOEllYld1T2RXYWJqTUNsUGJfUDN5VlZBaDdrS3hlUWI3UkxNSllWd29Ta3cxZEk0RGxyUWdqU2J1cU1ld053bHA; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:30 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "515.0",
+          "x-ratelimit-reset": "510",
+          "x-ratelimit-used": "85",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:30",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22show_flair%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "49",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444890817.Z0FBQUFBQmFrT09hb2I4bHUtUGhyYlozT2RxSDVpR2FkaEVJMnRoMFFjX1JTcTlLSVZadG9XR3RrY2lMVXBYY1A0SFZlTlFWaWhnOEllYld1T2RXYWJqTUNsUGJfUDN5VlZBaDdrS3hlUWI3UkxNSllWd29Ta3cxZEk0RGxyUWdqU2J1cU1ld053bHA",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": true, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:30 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444891.895543,VS0,VE97",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444890932.Z0FBQUFBQmFrT09hSmdWZDIzeF9Ka2lsbzFmblNsYk1ZaHp1bVY1NmRRVUhzemNuUERXZXp0VnBKUEhsdlhISXotTnhhb05lRXlOTkNLalh6dWYtbjVjNGpqNWpYeTRtV2NzVHR2d2gyTkFDblpVRlMzcDlBcm45WUw4aTUtREZwOEN5U1JDQ1ZPRlM; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:30 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "514.0",
+          "x-ratelimit-reset": "510",
+          "x-ratelimit-used": "86",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22show_flair%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "50",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444890932.Z0FBQUFBQmFrT09hSmdWZDIzeF9Ka2lsbzFmblNsYk1ZaHp1bVY1NmRRVUhzemNuUERXZXp0VnBKUEhsdlhISXotTnhhb05lRXlOTkNLalh6dWYtbjVjNGpqNWpYeTRtV2NzVHR2d2gyTkFDblpVRlMzcDlBcm45WUw4aTUtREZwOEN5U1JDQ1ZPRlM",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1684",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:31 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444891.018223,VS0,VE105",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444891050.Z0FBQUFBQmFrT09ialY4X0ZVb2pxS1FZSXVoRFFiY2hweXI2elI1WVl1bHBONnA0c2drWjQwbW4zSWIyTGRGRTNJZ0ZwVmoxcHhEdTV5b1llX29jdjFwU3NVWW5TdHR1STZwRTJzMXZiSXlyMXVQS2VWNUhjMmFQNk9zS1VNWjdJY1ZEbWF4WlpQdW4; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:31 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "513.0",
+          "x-ratelimit-reset": "509",
+          "x-ratelimit-used": "87",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22show_link_flair%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "54",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444891050.Z0FBQUFBQmFrT09ialY4X0ZVb2pxS1FZSXVoRFFiY2hweXI2elI1WVl1bHBONnA0c2drWjQwbW4zSWIyTGRGRTNJZ0ZwVmoxcHhEdTV5b1llX29jdjFwU3NVWW5TdHR1STZwRTJzMXZiSXlyMXVQS2VWNUhjMmFQNk9zS1VNWjdJY1ZEbWF4WlpQdW4",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": true, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:31 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444891.150810,VS0,VE97",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444891193.Z0FBQUFBQmFrT09iU1ZOYndKaFVObTE5cEFndXRlNHJCVXJlLUp2NFpvRk5EUDlBTmJsM0FsdzlZMFZXSmQ3bTQ1VmN3TTFhdEo5RHM2eXRaSlROb2RxaHFnc01TUDI4SzZWYXgxRWdkN2ZmY0NhUTJuVnlIQWV1QVo0R09kUWRFbDN2aWE0NV9oQlQ; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:31 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "512.0",
+          "x-ratelimit-reset": "509",
+          "x-ratelimit-used": "88",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22show_link_flair%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "55",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444891193.Z0FBQUFBQmFrT09iU1ZOYndKaFVObTE5cEFndXRlNHJCVXJlLUp2NFpvRk5EUDlBTmJsM0FsdzlZMFZXSmQ3bTQ1VmN3TTFhdEo5RHM2eXRaSlROb2RxaHFnc01TUDI4SzZWYXgxRWdkN2ZmY0NhUTJuVnlIQWV1QVo0R09kUWRFbDN2aWE0NV9oQlQ",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1684",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:31 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444891.273992,VS0,VE97",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444891309.Z0FBQUFBQmFrT09icXdvVDhiM0lucTVNWENrRVdnRVQtU3VEYktwTE4zM20yRTJrcm1CVzBnUXp3WDJFMVpIUkhXdGlpYjAxblZKU1RoZmNrWDNvWExkY2RzdHViWlZneXM0cGJHbzQ5QjBvMnlRVEd2cDZpQThwN01FZGZKRXBEY0tjZ2dGaHpLOTg; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:31 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "511.0",
+          "x-ratelimit-reset": "509",
+          "x-ratelimit-used": "89",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22show_stylesheets%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "55",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444891309.Z0FBQUFBQmFrT09icXdvVDhiM0lucTVNWENrRVdnRVQtU3VEYktwTE4zM20yRTJrcm1CVzBnUXp3WDJFMVpIUkhXdGlpYjAxblZKU1RoZmNrWDNvWExkY2RzdHViWlZneXM0cGJHbzQ5QjBvMnlRVEd2cDZpQThwN01FZGZKRXBEY0tjZ2dGaHpLOTg",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": true, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:31 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444891.399651,VS0,VE96",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444891436.Z0FBQUFBQmFrT09iVU5IWU05MTB6TWZpeXB0YUFiLVBkNlNHeHh2d2hxOHllMkVvd3FmR3B3Mks3RzJEbWIyeGZYdjlFWUNrd1RkRFBKSF9UT1lWQWV1Qlhma0t1U0dqR1JMaWJFb0NGWlo5TGZSc0dnWnJRZUY0WWluNkhLY0xjLXVqcDBhYUdWVzI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:31 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "510.0",
+          "x-ratelimit-reset": "509",
+          "x-ratelimit-used": "90",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22show_stylesheets%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "56",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444891436.Z0FBQUFBQmFrT09iVU5IWU05MTB6TWZpeXB0YUFiLVBkNlNHeHh2d2hxOHllMkVvd3FmR3B3Mks3RzJEbWIyeGZYdjlFWUNrd1RkRFBKSF9UT1lWQWV1Qlhma0t1U0dqR1JMaWJFb0NGWlo5TGZSc0dnWnJRZUY0WWluNkhLY0xjLXVqcDBhYUdWVzI",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1684",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:31 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444892.521772,VS0,VE96",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444891555.Z0FBQUFBQmFrT09iYUhwLThmNzNVMTFmNS1vV1VjdWNPT29pem1VM1FHS3FqNVo0MEJnelJnSTdRdDNTLV9iQ05pZUdReWdwN0RxS1MxOHY0b2dqWThzTlZWM2RPTC0tZmxPZy1OaVk1V3lKX0hBZ1J0LUxWdE5ZNzktWEdRR1htTk9VSUpUMC1Tb1A; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:31 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "509.0",
+          "x-ratelimit-reset": "509",
+          "x-ratelimit-used": "91",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22show_trending%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "52",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444891555.Z0FBQUFBQmFrT09iYUhwLThmNzNVMTFmNS1vV1VjdWNPT29pem1VM1FHS3FqNVo0MEJnelJnSTdRdDNTLV9iQ05pZUdReWdwN0RxS1MxOHY0b2dqWThzTlZWM2RPTC0tZmxPZy1OaVk1V3lKX0hBZ1J0LUxWdE5ZNzktWEdRR1htTk9VSUpUMC1Tb1A",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": true, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:31 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444892.644292,VS0,VE105",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444891674.Z0FBQUFBQmFrT09iQUlWVzZzVG00aHpwR1pSeVRocEwxLWYyelE0U19oQ3A1ZjNPMzZsN1BaVFBkSTlzSWtQQWY0cUxGQ1pDOGFTYjBGZjJYVVBmTmNNLU1YWW1ETEVlX2hLaXlRRldnT3ZGYUpVNmpiX3QxN1RxeHdmem56bDZNa0JIX3JCTzBUZU0; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:31 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "508.0",
+          "x-ratelimit-reset": "509",
+          "x-ratelimit-used": "92",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22show_trending%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "53",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444891674.Z0FBQUFBQmFrT09iQUlWVzZzVG00aHpwR1pSeVRocEwxLWYyelE0U19oQ3A1ZjNPMzZsN1BaVFBkSTlzSWtQQWY0cUxGQ1pDOGFTYjBGZjJYVVBmTmNNLU1YWW1ETEVlX2hLaXlRRldnT3ZGYUpVNmpiX3QxN1RxeHdmem56bDZNa0JIX3JCTzBUZU0",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1684",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:31 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444892.780936,VS0,VE107",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444891817.Z0FBQUFBQmFrT09ia0Rzd2FUMGJfZnZkVC1mY1F2SUxSaHo5R1VhX3B2Z001VkdXa3BOOXpmODhJOUY0b2R0cWFxaGMyNUFyeUNsWmFOVzNBeDBIMm4zQmEwRXhVMlFYUGc5NHpuVUJEUHpsU1dGRG1kYXhDbGZKS2lfanNkWi1SWWlmY1Z1cVBxcEM; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:31 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "507.0",
+          "x-ratelimit-reset": "509",
+          "x-ratelimit-used": "93",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:32",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22store_visits%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "51",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444891817.Z0FBQUFBQmFrT09ia0Rzd2FUMGJfZnZkVC1mY1F2SUxSaHo5R1VhX3B2Z001VkdXa3BOOXpmODhJOUY0b2R0cWFxaGMyNUFyeUNsWmFOVzNBeDBIMm4zQmEwRXhVMlFYUGc5NHpuVUJEUHpsU1dGRG1kYXhDbGZKS2lfanNkWi1SWWlmY1Z1cVBxcEM",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": true, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:32 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444892.915626,VS0,VE112",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444891951.Z0FBQUFBQmFrT09iY2lwSTBqSkVuMGk4eDIyZURsdzdEdUJTYlp0cmJnUm1jMUtuSDJJeTdUU184MUxFVXpGTWVzOTRTYnFUQ3hjN01UWm9sSlMybFFqdTlJZjNRZWpRWjJKVnFyT3ozTkkzNzNNTXZ0d1k1dXZGX19nQ3RHb1E4SjEyZ1JFSzR3OG0; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:31 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "506.0",
+          "x-ratelimit-reset": "509",
+          "x-ratelimit-used": "94",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:32",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22store_visits%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "52",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444891951.Z0FBQUFBQmFrT09iY2lwSTBqSkVuMGk4eDIyZURsdzdEdUJTYlp0cmJnUm1jMUtuSDJJeTdUU184MUxFVXpGTWVzOTRTYnFUQ3hjN01UWm9sSlMybFFqdTlJZjNRZWpRWjJKVnFyT3ozTkkzNzNNTXZ0d1k1dXZGX19nQ3RHb1E4SjEyZ1JFSzR3OG0",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1684",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:32 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444892.054463,VS0,VE104",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444892088.Z0FBQUFBQmFrT09jeFdLaTB1NVNvUV9Rb1VXMXpLUzdxU1ppU1c4YlR1RWdkZTBueHBocXpuUkhxRS0xOHRaWHowbFVqdzl4OVF6anZXcjQ2aW0zQVVIaEpGS2FqRUp0SGsxcDVZR2cyaXRyYXRrVk9Lb1Y5NklZb3hKS3FNWlR3bmp3aGN2TmhRQlQ; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:32 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "505.0",
+          "x-ratelimit-reset": "508",
+          "x-ratelimit-used": "95",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:32",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22threaded_messages%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "56",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444892088.Z0FBQUFBQmFrT09jeFdLaTB1NVNvUV9Rb1VXMXpLUzdxU1ppU1c4YlR1RWdkZTBueHBocXpuUkhxRS0xOHRaWHowbFVqdzl4OVF6anZXcjQ2aW0zQVVIaEpGS2FqRUp0SGsxcDVZR2cyaXRyYXRrVk9Lb1Y5NklZb3hKS3FNWlR3bmp3aGN2TmhRQlQ",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": true, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:32 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444892.185180,VS0,VE95",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444892208.Z0FBQUFBQmFrT09jRVRWWF9JbWpOcmJ5QmtuWllXX0djaTk4WTZoMUc3UkpDYzJxbDlrR2RycXg1dDJXUC1rZF9ISGpoNUNqd0wydDVlZmc2V3lWZjZieHdEOUQ4WWxZSjEwYUc4NWJkdGxfRGx0blV6b2lXcFZvVkVKdHJYdlpVNUlTeks1ZkJTaUc; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:32 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "504.0",
+          "x-ratelimit-reset": "508",
+          "x-ratelimit-used": "96",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:32",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22threaded_messages%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "57",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444892208.Z0FBQUFBQmFrT09jRVRWWF9JbWpOcmJ5QmtuWllXX0djaTk4WTZoMUc3UkpDYzJxbDlrR2RycXg1dDJXUC1rZF9ISGpoNUNqd0wydDVlZmc2V3lWZjZieHdEOUQ4WWxZSjEwYUc4NWJkdGxfRGx0blV6b2lXcFZvVkVKdHJYdlpVNUlTeks1ZkJTaUc",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1684",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:32 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444892.306782,VS0,VE477",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444892344.Z0FBQUFBQmFrT09jLVRocHQtUEEwVnZERVNHUGZOSzVXU0JxTjEybFdBYm9Xd0tiNG84T045c2xCQWtaU0dBc0t6X3FZOGdhWFNQUjZqR0lZNW1CdmNabHJ4OEgxREhUNHN3dEZkV0FKZDk4TDNTR3JwTEpyOWRYRU1NOTUxUGF5TVpTRjNMbnE3Z08; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:32 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "503.0",
+          "x-ratelimit-reset": "508",
+          "x-ratelimit-used": "97",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:32",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22threaded_modmail%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "55",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444892344.Z0FBQUFBQmFrT09jLVRocHQtUEEwVnZERVNHUGZOSzVXU0JxTjEybFdBYm9Xd0tiNG84T045c2xCQWtaU0dBc0t6X3FZOGdhWFNQUjZqR0lZNW1CdmNabHJ4OEgxREhUNHN3dEZkV0FKZDk4TDNTR3JwTEpyOWRYRU1NOTUxUGF5TVpTRjNMbnE3Z08",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": true, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:32 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444893.842406,VS0,VE108",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444892883.Z0FBQUFBQmFrT09jSkxRUUd4OFZGVUFLRkpha3lTQTlaMDl4SnBTYXRxNzZTOTN2UjVKZHNfZVIxMlZzVzVFMmN5X0xFWWgySXBSS3ViTmVpTk9PQVpMZFlKa1Y5dC1oY3RjRm5VLVptWXVocW8tSWRTeDRDOVpCUHpZbEZSSzhuZ0p1aDhuNVk5OGY; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:32 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "502.0",
+          "x-ratelimit-reset": "508",
+          "x-ratelimit-used": "98",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:33",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22threaded_modmail%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "56",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444892883.Z0FBQUFBQmFrT09jSkxRUUd4OFZGVUFLRkpha3lTQTlaMDl4SnBTYXRxNzZTOTN2UjVKZHNfZVIxMlZzVzVFMmN5X0xFWWgySXBSS3ViTmVpTk9PQVpMZFlKa1Y5dC1oY3RjRm5VLVptWXVocW8tSWRTeDRDOVpCUHpZbEZSSzhuZ0p1aDhuNVk5OGY",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1684",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:33 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444893.975238,VS0,VE101",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444893011.Z0FBQUFBQmFrT09kR2hxQzhQa0Y4T0dqSnN4UUVxTGY3WFllMmxUTXdrcU5JTEJmNzR5T1FqYVg1REJ1TkhDWjNDczlxRHpIZ3dSd2N2U3dib2VyYy02TUZIVGtsVWFYNmlWRW1jNDBPNktaZTExaFdPUjdWQlE1ckw3NU1FZy1GWmFzOWU1OG12LS0; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:33 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "501.0",
+          "x-ratelimit-reset": "507",
+          "x-ratelimit-used": "99",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:33",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22top_karma_subreddits%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "59",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444893011.Z0FBQUFBQmFrT09kR2hxQzhQa0Y4T0dqSnN4UUVxTGY3WFllMmxUTXdrcU5JTEJmNzR5T1FqYVg1REJ1TkhDWjNDczlxRHpIZ3dSd2N2U3dib2VyYy02TUZIVGtsVWFYNmlWRW1jNDBPNktaZTExaFdPUjdWQlE1ckw3NU1FZy1GWmFzOWU1OG12LS0",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": true, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:33 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444893.102911,VS0,VE106",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444893138.Z0FBQUFBQmFrT09kWklWZFZUX3JIZ21aVHoxdjJVM0x4Q01pZS1HWTM1eVZTSVhJbWZ3RlVYRG5sVlZ3Z1cyUzZLU2Q2Yk93cGRXVnVNMHNVdHZWMG5sVXBYWUtJUWNsX0JrV2Nib2lqTUQ4Mk1rSTY5YWM0d2ZHeHBhdDAydk54REhSN2o1a0lJOEc; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:33 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "500.0",
+          "x-ratelimit-reset": "507",
+          "x-ratelimit-used": "100",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:33",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22top_karma_subreddits%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "60",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444893138.Z0FBQUFBQmFrT09kWklWZFZUX3JIZ21aVHoxdjJVM0x4Q01pZS1HWTM1eVZTSVhJbWZ3RlVYRG5sVlZ3Z1cyUzZLU2Q2Yk93cGRXVnVNMHNVdHZWMG5sVXBYWUtJUWNsX0JrV2Nib2lqTUQ4Mk1rSTY5YWM0d2ZHeHBhdDAydk54REhSN2o1a0lJOEc",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1684",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:33 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444893.235533,VS0,VE105",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444893270.Z0FBQUFBQmFrT09kem5ZZGFRZjhaR3ZUQkszeXBnMzN3VklRUjRUMzNvQXM4SElpcTNVY2VIRTFGZkNqS1VsN3RoR2hVS1RqU0lvYnItLW9PN3ItZW9pVjBjUHQybllZYlNOSGYzakMzZ3lsdUZMeHlSNWVsR1lDdGlJazRSVXFCNW5RRm9oUWJ1bjM; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:33 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "499.0",
+          "x-ratelimit-reset": "507",
+          "x-ratelimit-used": "101",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:33",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22use_global_defaults%22%3A+true%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "58",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444893270.Z0FBQUFBQmFrT09kem5ZZGFRZjhaR3ZUQkszeXBnMzN3VklRUjRUMzNvQXM4SElpcTNVY2VIRTFGZkNqS1VsN3RoR2hVS1RqU0lvYnItLW9PN3ItZW9pVjBjUHQybllZYlNOSGYzakMzZ3lsdUZMeHlSNWVsR1lDdGlJazRSVXFCNW5RRm9oUWJ1bjM",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": true, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:33 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444893.367321,VS0,VE97",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444893400.Z0FBQUFBQmFrT09kLXE2MWRYdEVFcXFvSjBOVHBjb1hxYXJZcXZFREx4SkI4Y1ZIUjdreXRvYTU4V20ycUNuQ3g4SVZleHJLR2FKV3NpZ0pNZ2tQN0d3OEx4MDdHenZEelQyQjZxZkRYbGZTWVhXY2hiLW14NXlscVc5MU91VFRXekkyNFhlZF9iR3A; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:33 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "498.0",
+          "x-ratelimit-reset": "507",
+          "x-ratelimit-used": "102",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:33",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22use_global_defaults%22%3A+false%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "59",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444893400.Z0FBQUFBQmFrT09kLXE2MWRYdEVFcXFvSjBOVHBjb1hxYXJZcXZFREx4SkI4Y1ZIUjdreXRvYTU4V20ycUNuQ3g4SVZleHJLR2FKV3NpZ0pNZ2tQN0d3OEx4MDdHenZEelQyQjZxZkRYbGZTWVhXY2hiLW14NXlscVc5MU91VFRXekkyNFhlZF9iR3A",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1684",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:33 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444893.493788,VS0,VE101",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444893526.Z0FBQUFBQmFrT09kTC10RzkxVG1MVjViQWk2Z2piMnRSck5GVGM2OTdnMkRzV01JcTNCcWw5R3RUNk93NlpHWkxMa0dOMVJHVlUyVjVWNEZDRGIxcGZESjRjWGxmUGM0NkhtSFlpVVdGWXcyQmNvSm1hWWVPUXlZVmZVbS1XVmVrX3VqaVpXRUhmcWM; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:33 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "497.0",
+          "x-ratelimit-reset": "507",
+          "x-ratelimit-used": "103",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:33",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22default_comment_sort%22%3A+%22confidence%22%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "71",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444893526.Z0FBQUFBQmFrT09kTC10RzkxVG1MVjViQWk2Z2piMnRSck5GVGM2OTdnMkRzV01JcTNCcWw5R3RUNk93NlpHWkxMa0dOMVJHVlUyVjVWNEZDRGIxcGZESjRjWGxmUGM0NkhtSFlpVVdGWXcyQmNvSm1hWWVPUXlZVmZVbS1XVmVrX3VqaVpXRUhmcWM",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"confidence\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1691",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:33 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444894.620564,VS0,VE104",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444893659.Z0FBQUFBQmFrT09kT3ZseG04MTJtZkNLS1kwYlduOHYxeEJDMW9NTERNQzl4VDBvc1NEc0hBRkIzWU9rYVZCRGF6bTNncnhyeDR2Sm9hVnRENnRzNHZiZTh5akFhdW1XcnpjZ3htMVhaOEpZZDJrTTA2czY3WFhDd2ExYWtQcGpIREYyalREdDlISGQ; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:33 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "496.0",
+          "x-ratelimit-reset": "507",
+          "x-ratelimit-used": "104",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:33",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22default_comment_sort%22%3A+%22top%22%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "64",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444893659.Z0FBQUFBQmFrT09kT3ZseG04MTJtZkNLS1kwYlduOHYxeEJDMW9NTERNQzl4VDBvc1NEc0hBRkIzWU9rYVZCRGF6bTNncnhyeDR2Sm9hVnRENnRzNHZiZTh5akFhdW1XcnpjZ3htMVhaOEpZZDJrTTA2czY3WFhDd2ExYWtQcGpIREYyalREdDlISGQ",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1684",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:33 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444894.751266,VS0,VE104",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444893786.Z0FBQUFBQmFrT09kQUUwZ2djQmRIZTdCMDhEdlFORmV1VkJZazlwMzBUR3VVcW5ocTlEcS1zZUttV011Q291S3IySUVMelpkMjlVTGZQc3doeGlkZ3IwcjlET3VrNE9MVFEwMzFrTXplOVR5ZTFWQ0N0dmhucWNvWVVHZVlUMDM3bWZ0bmJWQURPVng; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:33 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "495.0",
+          "x-ratelimit-reset": "507",
+          "x-ratelimit-used": "105",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:33",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22lang%22%3A+%22es%22%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "47",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444893786.Z0FBQUFBQmFrT09kQUUwZ2djQmRIZTdCMDhEdlFORmV1VkJZazlwMzBUR3VVcW5ocTlEcS1zZUttV011Q291S3IySUVMelpkMjlVTGZQc3doeGlkZ3IwcjlET3VrNE9MVFEwMzFrTXplOVR5ZTFWQ0N0dmhucWNvWVVHZVlUMDM3bWZ0bmJWQURPVng",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"es\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1684",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:33 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444894.881484,VS0,VE105",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444893915.Z0FBQUFBQmFrT09kS0pZTnAzN21zbDA5RUZicXh0cFMxMTMybm5aTlhKQWpEd2dGMEU2MldORjZCaEc2WDg5MXdIQkR0VHRVNTRFYm8yUEpXR0Q1U2VuSk9YU19hYzdJcE0zallSbi1TakJQR1JWdnVZeDM4ejg0S3Jqc1N2UHNqX2hIaWR1UktUdFI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:33 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "494.0",
+          "x-ratelimit-reset": "507",
+          "x-ratelimit-used": "106",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:34",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22lang%22%3A+%22en%22%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "47",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444893915.Z0FBQUFBQmFrT09kS0pZTnAzN21zbDA5RUZicXh0cFMxMTMybm5aTlhKQWpEd2dGMEU2MldORjZCaEc2WDg5MXdIQkR0VHRVNTRFYm8yUEpXR0Q1U2VuSk9YU19hYzdJcE0zallSbi1TakJQR1JWdnVZeDM4ejg0S3Jqc1N2UHNqX2hIaWR1UktUdFI",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1684",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:34 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444894.012446,VS0,VE195",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444894046.Z0FBQUFBQmFrT09lZUNrTF9XdE9uS0R5LUhwZTlSem4wSFNfS2ZnZDR2YUJIRy13YWFMZVlCYW9YbHJJN1FXcWR0QmU1VDdoVlE4NWgwZldZaWpBdWtSbXRiWlp4UXIycmFBWDJzamliM2lrbVBPeHhVQmN5S2ZUUzQzZ0pYczg4VHlpaHl5RDJuNU0; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:34 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "493.0",
+          "x-ratelimit-reset": "506",
+          "x-ratelimit-used": "107",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:34",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22media%22%3A+%22on%22%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "48",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444894046.Z0FBQUFBQmFrT09lZUNrTF9XdE9uS0R5LUhwZTlSem4wSFNfS2ZnZDR2YUJIRy13YWFMZVlCYW9YbHJJN1FXcWR0QmU1VDdoVlE4NWgwZldZaWpBdWtSbXRiWlp4UXIycmFBWDJzamliM2lrbVBPeHhVQmN5S2ZUUzQzZ0pYczg4VHlpaHl5RDJuNU0",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"on\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:34 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444894.232977,VS0,VE169",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444894274.Z0FBQUFBQmFrT09lTDc1X2tBS2k0LWljTm9fYUNpcVFJbEI0V3pEOGQxZk9mLWNpRzIzV3M3akhVTnhNWTFLRkpnNm9lRVhleFRSNkd2MjNxMThqOEVIR1JSdERzMjdsQ1ZjejJIcXdjUElXOW92eVBFYlo2bWFfM2lNRFZsWXFicVk5OU16VEVPX28; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:34 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "492.0",
+          "x-ratelimit-reset": "506",
+          "x-ratelimit-used": "108",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:34",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22media%22%3A+%22off%22%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "49",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444894274.Z0FBQUFBQmFrT09lTDc1X2tBS2k0LWljTm9fYUNpcVFJbEI0V3pEOGQxZk9mLWNpRzIzV3M3akhVTnhNWTFLRkpnNm9lRVhleFRSNkd2MjNxMThqOEVIR1JSdERzMjdsQ1ZjejJIcXdjUElXOW92eVBFYlo2bWFfM2lNRFZsWXFicVk5OU16VEVPX28",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1684",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:34 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444894.430189,VS0,VE108",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444894471.Z0FBQUFBQmFrT09lMmxJRGkwNmdONWd6WnR6Yk1HSDV6bmN1b21qbkZSUVhWVU90LXN4U3FSc2hvWVZ0TXM4cXluS2lsZUdVUHlYQW1mYm5oSmFSMzNuVkd3NnpKZXgyVmVmeTh6clY5VEZhd0pObkRqZS0yVXBfS3R0SG9vUno5c2FVcGhYQVotWjI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:34 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "491.0",
+          "x-ratelimit-reset": "506",
+          "x-ratelimit-used": "109",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:34",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22media_preview%22%3A+%22on%22%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "56",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444894471.Z0FBQUFBQmFrT09lMmxJRGkwNmdONWd6WnR6Yk1HSDV6bmN1b21qbkZSUVhWVU90LXN4U3FSc2hvWVZ0TXM4cXluS2lsZUdVUHlYQW1mYm5oSmFSMzNuVkd3NnpKZXgyVmVmeTh6clY5VEZhd0pObkRqZS0yVXBfS3R0SG9vUno5c2FVcGhYQVotWjI",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"on\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1683",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:34 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444895.566189,VS0,VE105",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444894598.Z0FBQUFBQmFrT09lSUVXY2lQZ3hqRzRTVEkwbVY2ZEQwV3p3S2hGZko1YjZpd2pLYVFjV1drYlp3azdXcVVDRkQ5YjVxLUI0a2dTakFtbzQ2bjlqRTM5OUFKTURlVE5DVC1VZGxyVF8xR01qSHotUE1KTFFRLTBWYTZ0M1pWaDZ2b29PQ2pzTFNvTm4; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:34 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "490.0",
+          "x-ratelimit-reset": "506",
+          "x-ratelimit-used": "110",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T04:01:34",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22media_preview%22%3A+%22off%22%7D"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Content-Length": "57",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "Cookie": "edgebucket=Z6rnH8Lp7BE3kkQWfr; session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444894598.Z0FBQUFBQmFrT09lSUVXY2lQZ3hqRzRTVEkwbVY2ZEQwV3p3S2hGZko1YjZpd2pLYVFjV1drYlp3azdXcVVDRkQ5YjVxLUI0a2dTakFtbzQ2bjlqRTM5OUFKTURlVE5DVC1VZGxyVF8xR01qSHotUE1KTFFRLTBWYTZ0M1pWaDZ2b29PQ2pzTFNvTm4",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": false, \"show_link_flair\": false, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": true, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": false, \"email_digests\": false, \"num_comments\": 3, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": false, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": false, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": false, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": false, \"store_visits\": false, \"threaded_modmail\": false, \"min_link_score\": 3, \"media_preview\": \"off\", \"highlight_controversial\": false, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 3, \"public_votes\": false, \"no_video_autoplay\": false, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": false, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": false, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 3, \"legacy_search\": false, \"media\": \"off\", \"show_gold_expiration\": false, \"highlight_new_comments\": false, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"top\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"whitelisted\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1684",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 04:01:34 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3131-SJC",
+          "X-Timer": "S1519444895.697380,VS0,VE104",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=p3hz3IDfHCJyyUgfPt.0.1519444894734.Z0FBQUFBQmFrT09lNEJINVcyWnF5VTdJTV9hem4wbEtObDlxRFBpbWJIeXB2YjNfUkliZlBUMlpSVDBhbnFsRDB3ZUxLZXkyZVl0MkpxZkJrTGtEUVVHanh2ODRKOUdlOHY5WE1qSTBBN211Q2gtMTduVEFUbDBqT0xPLWdjb1FMbk1KVTdtV2FxeVE; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 06:01:34 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "489.0",
+          "x-ratelimit-reset": "506",
+          "x-ratelimit-used": "111",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/tests/integration/cassettes/TestPreferences.test_view.json
+++ b/tests/integration/cassettes/TestPreferences.test_view.json
@@ -1,0 +1,111 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-02-24T02:14:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "Basic <BASIC_AUTH>",
+          "Connection": "keep-alive",
+          "Content-Length": "53",
+          "Content-Type": "application/x-www-form-urlencoded",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "105",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 02:14:31 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3147-SJC",
+          "X-Timer": "S1519438470.144184,VS0,VE1007",
+          "cache-control": "max-age=0, must-revalidate",
+          "set-cookie": "session_tracker=LIYyB8MHPVQxAEaEmV.0.1519438470182.Z0FBQUFBQmFrTXFIQzM5eUZqN1VzRU5qLUU3M0I5eVNnUjJROTZ6OXFJSXF4XzNhcmNPbXUtcWhhQTJLbS1ZVnBLd2VTaUFySDZRZnlrU1hNRzAwNTE2cTZWQnllRlE5cndrSWZ3OXhMY0ExNUNpNF9XY0p1d2JPSVVBVGZLV1NnM2pBV1p3d3BKTE0; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 04:14:31 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2018-02-24T02:14:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": "*/*",
+          "Accept-Encoding": "identity",
+          "Authorization": "bearer <ACCESS_TOKEN>",
+          "Connection": "keep-alive",
+          "Cookie": "edgebucket=O7lI35NmOfBccwGiMq; session_tracker=LIYyB8MHPVQxAEaEmV.0.1519438470182.Z0FBQUFBQmFrTXFIQzM5eUZqN1VzRU5qLUU3M0I5eVNnUjJROTZ6OXFJSXF4XzNhcmNPbXUtcWhhQTJLbS1ZVnBLd2VTaUFySDZRZnlrU1hNRzAwNTE2cTZWQnllRlE5cndrSWZ3OXhMY0ExNUNpNF9XY0p1d2JPSVVBVGZLV1NnM2pBV1p3d3BKTE0",
+          "User-Agent": "<USER_AGENT> PRAW/5.4.0.dev0 prawcore/0.14.0"
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"default_theme_sr\": null, \"threaded_messages\": false, \"hide_downs\": false, \"label_nsfw\": true, \"activity_relevant_ads\": false, \"show_stylesheets\": false, \"profile_opt_out\": true, \"show_link_flair\": true, \"creddit_autorenew\": false, \"show_trending\": false, \"no_profanity\": false, \"private_feeds\": false, \"monitor_mentions\": false, \"research\": false, \"ignore_suggested_sort\": true, \"email_digests\": false, \"num_comments\": 199, \"clickgadget\": false, \"3rd_party_site_data_personalized_content\": false, \"use_global_defaults\": false, \"show_snoovatar\": false, \"domain_details\": true, \"email_messages\": false, \"live_orangereds\": false, \"enable_default_themes\": false, \"3rd_party_data_personalized_ads\": false, \"over_18\": true, \"collapse_left_bar\": true, \"lang\": \"en\", \"hide_ups\": true, \"public_server_seconds\": false, \"allow_clicktracking\": false, \"hide_from_robots\": false, \"compress\": true, \"store_visits\": false, \"threaded_modmail\": true, \"min_link_score\": -5, \"media_preview\": \"off\", \"highlight_controversial\": true, \"geopopular\": \"\", \"content_langs\": [\"en\"], \"show_promote\": null, \"hide_locationbar\": false, \"min_comment_score\": 1, \"public_votes\": false, \"no_video_autoplay\": true, \"organic\": false, \"collapse_read_messages\": false, \"show_flair\": true, \"mark_messages_read\": false, \"search_include_over_18\": false, \"force_https\": false, \"hide_ads\": false, \"beta\": true, \"top_karma_subreddits\": false, \"newwindow\": false, \"numsites\": 50, \"legacy_search\": true, \"media\": \"on\", \"show_gold_expiration\": false, \"highlight_new_comments\": true, \"email_unsubscribe_all\": false, \"default_comment_sort\": \"new\", \"3rd_party_site_data_personalized_ads\": false, \"accept_pms\": \"everyone\"}"
+        },
+        "headers": {
+          "Accept-Ranges": "bytes",
+          "Connection": "keep-alive",
+          "Content-Length": "1671",
+          "Content-Type": "application/json; charset=UTF-8",
+          "Date": "Sat, 24 Feb 2018 02:14:31 GMT",
+          "Server": "snooserv",
+          "Strict-Transport-Security": "max-age=15552000; includeSubDomains; preload",
+          "Vary": "accept-encoding",
+          "Via": "1.1 varnish",
+          "X-Cache": "MISS",
+          "X-Cache-Hits": "0",
+          "X-Moose": "majestic",
+          "X-Served-By": "cache-sjc3642-SJC",
+          "X-Timer": "S1519438471.256385,VS0,VE88",
+          "cache-control": "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate",
+          "expires": "-1",
+          "set-cookie": "session_tracker=LIYyB8MHPVQxAEaEmV.0.1519438471287.Z0FBQUFBQmFrTXFIdGotX2J3WXJCcmMydDhSWmVSOVVJamt6M3hRbGI0TjV5MU00WDAtWE5VQ3MtMnRqVm4wYUgwbklBVkhNREpkRzdGMWxDU3dFQWpRUzBiT0dmNFpBM2ozdVhBYzFCZzJxcmlNLW5DTF9qcUtMMEgxcGktNUNSOWZDUUJJZGdlNnE; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 24-Feb-2018 04:14:31 GMT; secure",
+          "x-content-type-options": "nosniff",
+          "x-frame-options": "SAMEORIGIN",
+          "x-ratelimit-remaining": "596.0",
+          "x-ratelimit-reset": "329",
+          "x-ratelimit-used": "4",
+          "x-xss-protection": "1; mode=block"
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/prefs?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.0"
+}

--- a/tests/integration/models/test_preferences.py
+++ b/tests/integration/models/test_preferences.py
@@ -10,16 +10,15 @@ class TestPreferences(IntegrationTest):
         assert isinstance(prefs_obj, Preferences)
 
     def test_view(self):
-        some_known_keys = ('allow_clicktracking', 'default_comment_sort',
+        some_known_keys = {'allow_clicktracking', 'default_comment_sort',
                            'hide_from_robots', 'lang', 'no_profanity',
-                           'over_18', 'public_votes', 'show_link_flair')
+                           'over_18', 'public_votes', 'show_link_flair'}
 
         self.reddit.read_only = False
         with self.recorder.use_cassette('TestPreferences.test_view'):
             prefs_dict = self.reddit.user.preferences()
         assert isinstance(prefs_dict, dict)
-        for known_key in some_known_keys:
-            assert known_key in prefs_dict
+        assert some_known_keys.issubset(prefs_dict)
 
     @mock.patch('time.sleep', return_value=None)
     def test_update(self, _):

--- a/tests/integration/models/test_preferences.py
+++ b/tests/integration/models/test_preferences.py
@@ -73,9 +73,9 @@ class TestPreferences(IntegrationTest):
                 assert response[param] == 3
             for param in bool_params:
                 response = preferences.update(**{param: True})
-                assert response[param] == True
+                assert response[param] is True
                 response = preferences.update(**{param: False})
-                assert response[param] == False
+                assert response[param] is False
             for param, values in str_params.items():
                 response = preferences.update(**{param: values[0]})
                 assert response[param] == values[0]

--- a/tests/integration/models/test_preferences.py
+++ b/tests/integration/models/test_preferences.py
@@ -1,0 +1,83 @@
+import mock
+
+from praw.models import Preferences
+from .. import IntegrationTest
+
+
+class TestPreferences(IntegrationTest):
+    def test_creation(self):
+        prefs_obj = self.reddit.user.preferences
+        assert isinstance(prefs_obj, Preferences)
+
+    def test_view(self):
+        some_known_keys = ('allow_clicktracking', 'default_comment_sort',
+                           'hide_from_robots', 'lang', 'no_profanity',
+                           'over_18', 'public_votes', 'show_link_flair')
+
+        self.reddit.read_only = False
+        with self.recorder.use_cassette('TestPreferences.test_view'):
+            prefs_dict = self.reddit.user.preferences()
+        assert isinstance(prefs_dict, dict)
+        for known_key in some_known_keys:
+            assert known_key in prefs_dict
+
+    @mock.patch('time.sleep', return_value=None)
+    def test_update(self, _):
+        # boolean params — as many as are reproducible on multiple accounts.
+        bool_params = ('allow_clicktracking',
+                       'beta', 'clickgadget', 'collapse_read_messages',
+                       'compress', 'creddit_autorenew', 'domain_details',
+                       'email_digests', 'email_messages',
+                       'email_unsubscribe_all', 'enable_default_themes',
+                       'hide_downs', 'hide_from_robots',
+                       'hide_locationbar', 'hide_ups',
+                       'highlight_controversial', 'highlight_new_comments',
+                       'ignore_suggested_sort',
+                       'legacy_search',
+                       'live_orangereds', 'mark_messages_read',
+                       'monitor_mentions', 'newwindow',
+                       'no_video_autoplay', 'organic',
+                       'over_18', 'private_feeds',
+                       'profile_opt_out', 'public_votes', 'research',
+                       'search_include_over_18', 'show_flair',
+                       'show_link_flair',
+                       'show_stylesheets', 'show_trending',
+                       'store_visits', 'threaded_messages',
+                       'threaded_modmail', 'top_karma_subreddits',
+                       'use_global_defaults')
+
+        int_params = ('min_comment_score', 'min_link_score', 'num_comments',
+                      'numsites')
+        # parameters that accept string types, and two valid values
+        str_params = {'default_comment_sort': ('confidence', 'top'),
+                      'lang': ('es', 'en'),
+                      'media': ('on', 'off'),
+                      'media_preview': ('on', 'off')}
+
+        # there are also subreddit-name parameters related to the Gold
+        # styling feature. It's impractical to test for that because not every
+        # account has Gold, and the test fails on normal accounts.
+
+        self.reddit.read_only = False
+        preferences = self.reddit.user.preferences
+
+        with self.recorder.use_cassette('TestPreferences.test_update'):
+
+            # test an empty update
+            preferences.update()
+
+            for param in int_params:
+                response = preferences.update(**{param: 1})
+                assert response[param] == 1
+                response = preferences.update(**{param: 3})
+                assert response[param] == 3
+            for param in bool_params:
+                response = preferences.update(**{param: True})
+                assert response[param] == True
+                response = preferences.update(**{param: False})
+                assert response[param] == False
+            for param, values in str_params.items():
+                response = preferences.update(**{param: values[0]})
+                assert response[param] == values[0]
+                response = preferences.update(**{param: values[1]})
+                assert response[param] == values[1]

--- a/tests/integration/models/test_preferences.py
+++ b/tests/integration/models/test_preferences.py
@@ -49,10 +49,10 @@ class TestPreferences(IntegrationTest):
         int_params = ('min_comment_score', 'min_link_score', 'num_comments',
                       'numsites')
         # parameters that accept string types, and two valid values
-        str_params = {'default_comment_sort': ('confidence', 'top'),
-                      'lang': ('es', 'en'),
-                      'media': ('on', 'off'),
-                      'media_preview': ('on', 'off')}
+        str_params = (('default_comment_sort', ('confidence', 'top')),
+                      ('lang', ('es', 'en')),
+                      ('media', ('on', 'off')),
+                      ('media_preview', ('on', 'off')))
 
         # there are also subreddit-name parameters related to the Gold
         # styling feature. It's impractical to test for that because not every
@@ -76,7 +76,7 @@ class TestPreferences(IntegrationTest):
                 assert response[param] is True
                 response = preferences.update(**{param: False})
                 assert response[param] is False
-            for param, values in str_params.items():
+            for param, values in str_params:
                 response = preferences.update(**{param: values[0]})
                 assert response[param] == values[0]
                 response = preferences.update(**{param: values[1]})

--- a/tests/integration/models/test_preferences.py
+++ b/tests/integration/models/test_preferences.py
@@ -23,7 +23,7 @@ class TestPreferences(IntegrationTest):
 
     @mock.patch('time.sleep', return_value=None)
     def test_update(self, _):
-        # boolean params — as many as are reproducible on multiple accounts.
+        # boolean params, as many as are reproducible on multiple accounts.
         bool_params = ('allow_clicktracking',
                        'beta', 'clickgadget', 'collapse_read_messages',
                        'compress', 'creddit_autorenew', 'domain_details',


### PR DESCRIPTION
## Feature Summary and Justification

This feature provides an interface to view and update Reddit preferences. Usage is intended to be as follows:

```python
prefs = reddit.user.preferences()  # view
print(prefs['show_link_flair'])

reddit.user.preferences.update(show_link_flair=True)  # update
```

Preferences are returned as a dict by a call to `reddit.user.preferences()` and can be updated with the `reddit.user.preferences.update()` method, with keyword-argument names being the preference names, and the values being the values. Preferences that have names that would be illegal keyword-argument names in Python (there are three at present) can still be updated like so:

```python
reddit.user.preferences.update(**{'3rd_party_data_personalized_ads': False})
```

I documented the keyword-arguments as best I can, but some of them either have unclear effects to me (e.g. `store_visits`) or may not always be honored by Reddit (e.g. `g`). 