### PR TITLE
Add example for getting WikiPage instance from a revision

### DIFF
--- a/praw/models/reddit/wikipage.py
+++ b/praw/models/reddit/wikipage.py
@@ -94,6 +94,13 @@ class WikiPage(RedditBase):
            for item in reddit.subreddit('test').wiki['praw_test'].revisions():
                print(item)
 
+        To get :class:`.WikiPage` objects for each revision:
+
+        .. code:: python
+
+           for item in reddit.subreddit('test').wiki['praw_test'].revisions():
+               print(item['page'])
+
         """
         url = API_PATH['wiki_page_revisions'].format(subreddit=self.subreddit,
                                                      page=self.name)


### PR DESCRIPTION
I was trying to grab the content from an old WikiPage revision last night and it was a bit tricky to see that the `WikiPage` object was mapped from the `'page'` key. This doc update tries to make this more clear.