### PR TITLE
Fix SubredditEmoji repr

### DIFF
--- a/praw/models/reddit/emoji.py
+++ b/praw/models/reddit/emoji.py
@@ -53,10 +53,8 @@ class Emoji(RedditBase):
         self._reddit.request('DELETE', url)
 
 
-class SubredditEmoji(RedditBase):
+class SubredditEmoji(object):
     """Provides a set of functions to a Subreddit for emoji."""
-
-    __hash__ = RedditBase.__hash__
 
     def __getitem__(self, name):
         """Lazily return the Emoji for the subreddit named ``name``.
@@ -80,7 +78,7 @@ class SubredditEmoji(RedditBase):
 
         """
         self.subreddit = subreddit
-        super(SubredditEmoji, self).__init__(subreddit._reddit, None)
+        self._reddit = subreddit._reddit
 
     def __iter__(self):
         """Return a list of Emoji for the subreddit.

--- a/tests/unit/models/reddit/test_emoji.py
+++ b/tests/unit/models/reddit/test_emoji.py
@@ -1,6 +1,7 @@
 import pickle
 
 from praw.models import Subreddit, Emoji
+from praw.models.reddit.emoji import SubredditEmoji
 
 from ... import UnitTest
 
@@ -72,3 +73,9 @@ class TestEmoji(UnitTest):
         emoji = Emoji(self.reddit, subreddit=Subreddit(self.reddit, 'a'),
                       name='x')
         assert str(emoji) == 'x'
+
+
+class TestSubredditEmoji(UnitTest):
+    def test_repr(self):
+        se = SubredditEmoji(subreddit=Subreddit(self.reddit, 'a'))
+        assert repr(se)  # assert it has some repr


### PR DESCRIPTION
Fixes #909

## Feature Summary and Justification

This feature provides a `__repr__` for the `SubredditEmoji` class. It does not provide a `__str__` because I don't believe a meaningful string representation of `SubredditEmoji` exists. 

It also removes `SubredditEmoji`'s inheritance from `RedditBase`. I think this is an appropriate change because `SubredditEmoji` doesn't implement the necessary structure to support [`_fetch()`](https://github.com/praw-dev/praw/blob/5a8a4aff155b1314cbf0f893425e8379a007d4ca/praw/models/reddit/base.py#L70-L84), so something like `reddit.subreddit('redditdev').emoji.unknown_attr` also raises a `RecursionError`. 
