### PR TITLE
Add example showing usage of stream_generator

### DIFF
--- a/praw/models/util.py
+++ b/praw/models/util.py
@@ -96,7 +96,15 @@ def stream_generator(function, pause_after=None):
        time before pause for ``pause_after=N+1`` is approximately twice the
        time before pause for ``pause_after=N``.
 
-    For example to pause a comment stream after six responses with no new
+    For example, to create a stream of comment replies, try:
+
+    .. code:: python
+
+       reply_function = reddit.inbox.comment_replies
+       for reply in praw.models.util.stream_generator(reply_function):
+           print(reply)
+
+    To pause a comment stream after six responses with no new
     comments, try:
 
     .. code:: python


### PR DESCRIPTION
The examples on `stream_generator` show how to use various functions that themselves use `stream_generator`, and thus they show how to use the `pause_after` parameter. However, there isn't an example showing how to call `stream_generator` itself, given some listing function. This PR adds such an example.

The `reply_function` name is a little weird but the line got too long otherwise.