### PR TITLE
Document common Subreddit attributes

### DIFF
--- a/docs/_static/theme_overrides.css
+++ b/docs/_static/theme_overrides.css
@@ -1,0 +1,16 @@
+/* Table text wrapping CSS fix from
+https://rackerlabs.github.io/docs-rackspace/tools/rtd-tables.html */
+
+/* override table width restrictions */
+@media screen and (min-width: 767px) {
+
+   .wy-table-responsive table td {
+      /* !important prevents the common CSS stylesheets from overriding
+         this as on RTD they are loaded after this stylesheet */
+      white-space: normal !important;
+   }
+
+   .wy-table-responsive {
+      overflow: visible !important;
+   }
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,6 +7,9 @@ from praw import __version__
 copyright = '2017, Bryce Boe'
 exclude_patterns = ['_build']
 extensions = ['sphinx.ext.autodoc', 'sphinx.ext.intersphinx']
+html_context = {
+    'css_files': ['_static/theme_overrides.css']
+}
 html_static_path = ['_static']
 html_theme = 'sphinx_rtd_theme'
 html_theme_options = {

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -52,6 +52,32 @@ class Subreddit(RedditBase, MessageableMixin, SubredditListingMixin):
        for submission in reddit.subreddit('all-redditdev').new():
            print(submission)
 
+    **Typical Attributes**
+
+    This table describes attributes that typically belong to objects of this
+    class. Since attributes are dynamically provided (see
+    :ref:`determine-available-attributes-of-an-object`), there is not a
+    guarantee that these attributes will always be present, nor is this list
+    comprehensive in any way.
+
+    ======================= ===================================================
+    Attribute               Description
+    ======================= ===================================================
+    ``created_utc``         Time the subreddit was created, represented in
+                            `Unix Time`_.
+    ``description``         Subreddit description, in Markdown.
+    ``description_html``    Subreddit description, in HTML.
+    ``display_name``        Name of the subreddit.
+    ``over18``              Whether or not the subreddit is NSFW.
+    ``public_description``  Description of the subreddit, shown in searches
+                            and on the "You must be invited to visit this
+                            community" page (if applicable).
+    ``subscribers``         Count of subscribers to the subreddit.
+    ======================= ===================================================
+
+
+    .. _Unix Time: https://en.wikipedia.org/wiki/Unix_time
+
     """
 
     # pylint: disable=too-many-public-methods


### PR DESCRIPTION
In connection with #917. (but this PR and its commits are not meant to close that issue)

I documented common attributes for the Subreddit class. This is intended to be used as a sample/model for others who wish to get involved with PRAW and want to add more of these as a first contribution.

756edc313e45f34933c86835eb989b90618400cd adds a CSS modification to the built doc pages that ensures table cells can wrap their text. Without it, all table cells are displayed as one long horizontally-scrollable line of text. **A potential problem with this commit is that I directly copied and pasted the CSS and Python configuration from [this link](https://rackerlabs.github.io/docs-rackspace/tools/rtd-tables.html)**. I strongly suspect there is a copyright or licensing issue here, but I don't know how else to handle this, seeing as the tutorial/guide I found has code samples and there is really only one "right way" to implement the styling fix.