### PR TITLE
pylint now passes perfectly

### DIFF
--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -103,7 +103,7 @@ class Subreddit(RedditBase, MessageableMixin, SubredditListingMixin):
                           suggested_comment_sort=None, title=None,
                           wiki_edit_age=None, wiki_edit_karma=None,
                           wikimode=None, **other_settings):
-        # pylint: disable=invalid-name,too-many-locals
+        # pylint: disable=invalid-name,too-many-locals,too-many-arguments
         model = {'allow_images': allow_images,
                  'allow_post_crossposts': allow_post_crossposts,
                  'allow_top': allow_top,

--- a/praw/objector.py
+++ b/praw/objector.py
@@ -46,6 +46,8 @@ class Objector(object):
             if isinstance(instance, self.parsers[key]):
                 return key
 
+        return None
+
     def _objectify_dict(self, data):
         """Create RedditBase objects from dicts.
 
@@ -100,7 +102,7 @@ class Objector(object):
         """
         # pylint: disable=too-many-return-statements
         if data is None:  # 204 no content
-            return
+            return None
         if isinstance(data, list):
             return [self.objectify(item) for item in data]
         if 'kind' in data and data['kind'] in self.parsers:


### PR DESCRIPTION
pylint fails if a function has over 32 arguments. The function praw.models.reddit.subreddit._create_or_update() had 34, so pylint gave it a fail and caused pre_push.py to exit with code 1. Solution: disable to too-many-arguments check on this function with # pylint: disable=too-many-arguments

the praw.objector file has a couple of functions which use "return" instead of "return None", which again makes pylint fail when there are inconsistent return types. I've updated "return" statements to "return None"

pre_push.py now exits with code 0 (build completely successful).
