### PR TITLE
Use bulleted list for "System Information" section

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -13,6 +13,6 @@ documentation, Redddit source code changeset).
 
 ## System Information
 
-    PRAW Version:
-  Python Version:
-Operating System:
+- PRAW Version:
+- Python Version:
+- Operating System:


### PR DESCRIPTION
## Feature Summary and Justification

Uses a bulleted list for each item in the "System Information" section.

This prevents "PRAW Version" from appearing as a code block and makes each item render on a separate line.
