### PR TITLE
Document configuring a custom requests Session

### DIFF
--- a/docs/getting_started/configuration.rst
+++ b/docs/getting_started/configuration.rst
@@ -39,3 +39,41 @@ environment variable can be provided on the command line like so:
 .. code-block:: bash
 
    HTTPS_PROXY=https://localhost:3128 ./prawbot.py
+
+
+Configuring a custom requests Session
+-------------------------------------
+
+PRAW uses `requests`_ to handle
+networking. If your use-case requires custom configuration, it is possible
+to configure a `Session
+<http://docs.python-requests.org/en/master/user/advanced/#session-objects>`_
+and then use it with PRAW.
+
+For example, some networks use self-signed SSL certificates when connecting
+to HTTPS sites. By default, this would raise an exception in Requests. To
+use a self-signed SSL certificate without an exception from Requests, first
+export the certificate as a ``.pem`` file. Then configure PRAW like so:
+
+.. code-block:: python
+
+   import praw
+   from requests import Session
+
+
+   session = Session()
+   session.verify = '/path/to/certfile.pem'
+   reddit = praw.Reddit(client_id='SI8pN3DSbt0zor',
+                        client_secret='xaxkj7HNh8kwg8e5t4m6KvSrbTI',
+                        password='1guiwevlfo00esyy',
+                        requestor_kwargs={'session': session},  # pass Session
+                        user_agent='testscript by /u/fakebot3',
+                        username='fakebot3')
+
+
+The code above creates a Session and `configures it to use a custom certificate
+<http://docs.python-requests
+.org/en/master/user/advanced/#ssl-cert-verification>`_, then passes it as a
+parameter when creating the :class:`.Reddit` instance. Note that the example
+above uses a :ref:`script_application` authentication type, but this method
+will work for any authentication type.


### PR DESCRIPTION
Fixes #934

## Feature Summary and Justification

Added a section on how to configure and pass in a custom Session when instantiating the Reddit class, with an example based on #934. 

I'm not entirely happy with how this is written, so I'm definitely open to suggestions.

## References

* https://stackoverflow.com/a/50160417/3357935
* #934 
* http://docs.python-requests.org/en/master/user/advanced/#ssl-cert-verification
