### PR TITLE
Improve Modmail and ModmailConversation documentation style

### DIFF
--- a/praw/models/reddit/modmail.py
+++ b/praw/models/reddit/modmail.py
@@ -132,7 +132,7 @@ class ModmailConversation(RedditBase):
         self._reddit.request('POST',
                              API_PATH['modmail_mute'].format(id=self.id))
 
-    def read(self, other_conversations=None):
+    def read(self, other_conversations=None):  # noqa: D207, D301
         """Mark the conversation(s) as read.
 
         :param other_conversations: A list of other conversations to mark
@@ -145,8 +145,8 @@ class ModmailConversation(RedditBase):
 
            subreddit = reddit.subreddit('redditdev')
            conversation = subreddit.modmail.conversation('2gmz')
-           conversation.read(
-               other_conversations=conversation.user.recent_convos)
+           conversation.read(\
+other_conversations=conversation.user.recent_convos)
 
         """
         data = {'conversationIds': self._build_conversation_list(
@@ -224,7 +224,7 @@ class ModmailConversation(RedditBase):
         self._reddit.request('POST',
                              API_PATH['modmail_unmute'].format(id=self.id))
 
-    def unread(self, other_conversations=None):
+    def unread(self, other_conversations=None):  # noqa: D207, D301
         """Mark the conversation(s) as unread.
 
         :param other_conversations: A list of other conversations to mark
@@ -237,8 +237,8 @@ class ModmailConversation(RedditBase):
 
            subreddit = reddit.subreddit('redditdev')
            conversation = subreddit.modmail.conversation('2gmz')
-           conversation.unread(
-               other_conversations=conversation.user.recent_convos)
+           conversation.unread(\
+other_conversations=conversation.user.recent_convos)
 
         """
         data = {'conversationIds': self._build_conversation_list(

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -1592,7 +1592,7 @@ class ModeratorRelationship(SubredditRelationship):
 class Modmail(object):
     """Provides modmail functions for a subreddit."""
 
-    def __call__(self, id=None, mark_read=False):
+    def __call__(self, id=None, mark_read=False):  # noqa: D207, D301
         """Return an individual conversation.
 
         :param id: A reddit base36 conversation ID, e.g., ``2gmz``.
@@ -1609,8 +1609,8 @@ class Modmail(object):
 
         .. code:: python
 
-           conversation = reddit.subreddit('redditdev').modmail('2gmz',
-                                                                mark_read=True)
+           conversation = reddit.subreddit('redditdev').modmail('2gmz', \
+mark_read=True)
            for message in conversation.messages:
                print(message.body_markdown)
 
@@ -1624,16 +1624,16 @@ class Modmail(object):
 
         .. code:: python
 
-           conversation = reddit.subreddit('redditdev').modmail('2gmz',
-                                                                mark_read=True)
+           conversation = reddit.subreddit('redditdev').modmail('2gmz', \
+mark_read=True)
            print(conversation.user.ban_status)
 
         To print a list of recent submissions by the user:
 
         .. code:: python
 
-           conversation = reddit.subreddit('redditdev').modmail('2gmz',
-                                                                mark_read=True)
+           conversation = reddit.subreddit('redditdev').modmail('2gmz', \
+mark_read=True)
            print(conversation.user.recent_posts)
 
         """
@@ -1682,7 +1682,7 @@ class Modmail(object):
                 for conversation_id in response['conversation_ids']]
 
     def conversations(self, after=None, limit=None, other_subreddits=None,
-                      sort=None, state=None):
+                      sort=None, state=None):  # noqa: D207, D301
         """Generate :class:`.ModmailConversation` objects for subreddit(s).
 
         :param after: A base36 modmail conversation id. When provided, the
@@ -1703,8 +1703,8 @@ class Modmail(object):
 
         .. code:: python
 
-            conversations = reddit.subreddit('all').modmail.conversations(
-                state='mod')
+            conversations = reddit.subreddit('all').modmail.conversations(\
+state='mod')
 
         """
         params = {}

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -1703,7 +1703,8 @@ class Modmail(object):
 
         .. code:: python
 
-            conversations = reddit.subreddit('all').conversations(state='mod')
+            conversations = reddit.subreddit('all').modmail.conversations(
+                state='mod')
 
         """
         params = {}


### PR DESCRIPTION
## Feature Summary and Justification

A mistake in the docstring of `Modmail.conversations` used `reddit.subreddit('all').conversations(state='mod')` where it should have used `reddit.subreddit('all').modmail.conversations(state='mod')`. This PR fixes that.

In addition, many of the code samples are forced to line-wrap sooner than is ideal because of indentation eating into the line-width cap. This PR fixes this by escaping the newlines and unindenting the following lines where this occurs so that the documentation will render code in just one line where appropriate. This fix required disabling two pydocstyle rules for each docstring where it was applied.

As an example of the fix, code currently rendered in documentation as

```python
conversation = reddit.subreddit('redditdev').modmail('2gmz',
                                                     mark_read=True)
```

becomes

```python
conversation = reddit.subreddit('redditdev').modmail('2gmz', mark_read=True)
```

All lines where this fix was applied are still under 80 characters in their "rendered form."