### PR TITLE
Allow installed apps to use OAuth2 code flow

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -21,6 +21,8 @@ Unreleased
 * Fix ``RecursionError`` on :class:`.SubredditEmoji`'s ``repr`` and ``str``.
 * :meth:`.SubredditFilters.add` and :meth:`.SubredditFilters.remove`
   also accept a :class:`.Subreddit` for the ``subreddit`` parameter.
+* Remove restriction which prevents installed (non-confidential) apps from
+  using OAuth2 authorization code grant flow.
 
 **Removed**
 

--- a/praw/models/auth.py
+++ b/praw/models/auth.py
@@ -1,6 +1,6 @@
 """Provide the Auth class."""
-from prawcore import (Authorizer, ImplicitAuthorizer, TrustedAuthenticator,
-                      UntrustedAuthenticator, session)
+from prawcore import (Authorizer, ImplicitAuthorizer, UntrustedAuthenticator,
+                      session)
 
 from .base import PRAWBase
 from ..exceptions import ClientException
@@ -45,9 +45,6 @@ class Auth(PRAWBase):
 
         """
         authenticator = self._reddit._read_only_core._authorizer._authenticator
-        if not isinstance(authenticator, TrustedAuthenticator) or \
-           self._reddit.config.username:
-            raise ClientException('authorize can only be used with web apps.')
         authorizer = Authorizer(authenticator)
         authorizer.authorize(code)
         authorized_session = session(authorizer)

--- a/praw/reddit.py
+++ b/praw/reddit.py
@@ -349,7 +349,12 @@ class Reddit(object):
                                                self.config.client_id,
                                                self.config.redirect_uri)
         read_only_authorizer = DeviceIDAuthorizer(authenticator)
-        self._core = self._read_only_core = session(read_only_authorizer)
+        self._read_only_core = session(read_only_authorizer)
+        if self.config.refresh_token:
+            authorizer = Authorizer(authenticator, self.config.refresh_token)
+            self._core = self._authorized_core = session(authorizer)
+        else:
+            self._core = self._read_only_core
 
     def comment(self,  # pylint: disable=invalid-name
                 id=None,  # pylint: disable=redefined-builtin

--- a/tests/unit/models/test_auth.py
+++ b/tests/unit/models/test_auth.py
@@ -13,6 +13,11 @@ def installed_app():
 
 def script_app():
     return Reddit(client_id='dummy client', client_secret='dummy secret',
+                  redirect_uri='https://dummy.tld/', user_agent='dummy')
+
+
+def script_app_with_password():
+    return Reddit(client_id='dummy client', client_secret='dummy secret',
                   password='dummy password', user_agent='dummy',
                   username='dummy username')
 
@@ -23,21 +28,20 @@ def web_app():
 
 
 class TestAuth(UnitTest):
-    def test_authorize__from_installed_app(self):
-        with pytest.raises(ClientException):
-            installed_app().auth.authorize('dummy code')
-
-    def test_authorize__from_script_app(self):
-        with pytest.raises(ClientException):
-            script_app().auth.authorize('dummy code')
-
     def test_implicit__from_script_app(self):
         with pytest.raises(ClientException):
             script_app().auth.implicit('dummy token', 10, '')
+        with pytest.raises(ClientException):
+            script_app_with_password().auth.implicit('dummy token', 10, '')
+
+    def test_implicit__from_web_app(self):
+        with pytest.raises(ClientException):
+            web_app().auth.implicit('dummy token', 10, '')
 
     def test_limits(self):
         expected = {'remaining': None, 'reset_timestamp': None, 'used': None}
-        for app in [installed_app(), script_app(), web_app()]:
+        for app in [installed_app(), script_app(), script_app_with_password(),
+                    web_app()]:
             assert expected == app.auth.limits
 
     def test_url__installed_app(self):

--- a/tests/unit/test_reddit.py
+++ b/tests/unit/test_reddit.py
@@ -78,6 +78,16 @@ class TestReddit(UnitTest):
             reddit.read_only = False
             assert not reddit.read_only
 
+    def test_read_only__with_authenticated_core__non_confidential(self):
+        with Reddit(client_id='dummy', client_secret=None,
+                    redirect_uri='dummy', user_agent='dummy',
+                    refresh_token='dummy') as reddit:
+            assert not reddit.read_only
+            reddit.read_only = True
+            assert reddit.read_only
+            reddit.read_only = False
+            assert not reddit.read_only
+
     def test_read_only__with_script_authenticated_core(self):
         with Reddit(password='dummy', username='dummy',
                     **self.REQUIRED_DUMMY_SETTINGS) as reddit:


### PR DESCRIPTION
Fixes #955

## Feature Summary and Justification

This commit allow users to use OAuth2 code flow (which exchanges an authorization code 
for an access token and optional refresh token) from installed apps.

Unfortunately, this commit doesn't have proper integration test for `authorize()`,
because tests in integration/models/test_{comment_forest,inbox,more}.py
doesn't work for installed apps. Those tests use 
`match_requests_on=['uri', 'method', 'body']`, so new cassette is required
if installed apps credentials are given. 

## References

* https://github.com/reddit-archive/reddit/wiki/OAuth2#retrieving-the-access-token