### PR TITLE
Disalbe pylint's useless-object-inheritance and no-else-return in .pylintrc

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -33,7 +33,7 @@ load-plugins=
 # can either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once).
-disable=C0111,I0011,I0012,W0142,W0212,R0205
+disable=C0111,I0011,I0012,W0142,W0212,R0205,R1705
 
 
 [REPORTS]

--- a/.pylintrc
+++ b/.pylintrc
@@ -33,7 +33,7 @@ load-plugins=
 # can either give multiple identifier separated by comma (,) or put this option
 # multiple time (only on the command line, not in the configuration file where
 # it should appear only once).
-disable=C0111,I0011,I0012,W0142,W0212
+disable=C0111,I0011,I0012,W0142,W0212,R0205
 
 
 [REPORTS]


### PR DESCRIPTION
Fixes #964 

This PR also disables [no-else-return](http://pylint.pycqa.org/en/latest/technical_reference/features.html?highlight=no-else-return
). If the directive is active, pylint emits following messages:

```
$ pylint praw
************* Module praw.objector
R1705: 123, 8: Unnecessary "elif" after "return" (no-else-return)
************* Module praw.models.auth
R1705: 111, 8: Unnecessary "elif" after "return" (no-else-return)
************* Module praw.models.helpers
R1705: 159, 8: Unnecessary "elif" after "return" (no-else-return)
```

I think this directive is too much. If it should be enabled, I'll follow that.


