### PR TITLE
Added limit argument to stream_generator

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -40,4 +40,5 @@ Source Contributors
 - Andrew Arnold `@asquared31415 <https://github.com/asquared31415>`_
 - bakonydraco `@bakonydraco <https://github.com/bakonydraco>`_
 - salehio `@salehio <https://github.com/salehio>`_
+- Mike Saah `@MichaelSaah <https://github.com/MichaelSaah>`_
 - Add "Name <email (optional)> and github profile link" above this line.

--- a/praw/models/util.py
+++ b/praw/models/util.py
@@ -76,7 +76,8 @@ def permissions_string(permissions, known_permissions):
     return ','.join(to_set)
 
 
-def stream_generator(function, pause_after=None, skip_existing=False, limit=100):
+def stream_generator(function, pause_after=None, skip_existing=False,
+                     limit=100):
     """Yield new items from ListingGenerators and ``None`` when paused.
 
     :param function: A callable that returns a ListingGenerator, e.g.
@@ -93,6 +94,9 @@ def stream_generator(function, pause_after=None, skip_existing=False, limit=100)
     :param skip_existing: When True does not yield any results from the first
         request thereby skipping any items that existed in the stream prior to
         starting the stream (default: False).
+
+    :param limit: An integer which defines the maximum number of items
+       that may be generated
 
     .. note:: This function internally uses an exponential delay with jitter
        between subsequent responses that contain no new results, up to a

--- a/praw/models/util.py
+++ b/praw/models/util.py
@@ -76,7 +76,7 @@ def permissions_string(permissions, known_permissions):
     return ','.join(to_set)
 
 
-def stream_generator(function, pause_after=None, skip_existing=False):
+def stream_generator(function, pause_after=None, skip_existing=False, limit=100):
     """Yield new items from ListingGenerators and ``None`` when paused.
 
     :param function: A callable that returns a ListingGenerator, e.g.
@@ -160,7 +160,7 @@ def stream_generator(function, pause_after=None, skip_existing=False):
     while True:
         found = False
         newest_fullname = None
-        limit = 100
+        #limit = 100
         if before_fullname is None:
             limit -= without_before_counter
             without_before_counter = (without_before_counter + 1) % 30

--- a/praw/models/util.py
+++ b/praw/models/util.py
@@ -157,10 +157,11 @@ def stream_generator(function, pause_after=None, skip_existing=False, limit=100)
     without_before_counter = 0
     responses_without_new = 0
     valid_pause_after = pause_after is not None
+    given_limit = limit
     while True:
         found = False
         newest_fullname = None
-        #limit = 100
+        limit = given_limit
         if before_fullname is None:
             limit -= without_before_counter
             without_before_counter = (without_before_counter + 1) % 30


### PR DESCRIPTION
This is a tentative PR to see if you'd like to integrate this modification. I added a limit argument to stream_generator in util. This came about when I was trying to figure out how to pull down a specific number of submissions from a subreddit's top all-time.

I passed pre_push and have 100% tests passing. I didn't see any tests for stream_generator specifically, so I didn't add/modify any tests.