### PR TITLE
Added typical attributes for Redditor model

### DIFF
--- a/praw/models/reddit/redditor.py
+++ b/praw/models/reddit/redditor.py
@@ -50,9 +50,9 @@ class Redditor(RedditBase, MessageableMixin, RedditorListingMixin):
                                          NSFW.
     ``subreddit['public_description']``  The public description of the user-
                                          subreddit.
-    `subreddit['subscribers']``          The number of users subscribed to the
+    ``subreddit['subscribers']``         The number of users subscribed to the
                                          user-subreddit.
-    `subreddit['title']``                The title of the user-subreddit.
+    ``subreddit['title']``               The title of the user-subreddit.
     ==================================== ======================================
 
 

--- a/praw/models/reddit/redditor.py
+++ b/praw/models/reddit/redditor.py
@@ -9,7 +9,56 @@ from .mixins import MessageableMixin
 
 
 class Redditor(RedditBase, MessageableMixin, RedditorListingMixin):
-    """A class representing the users of reddit."""
+    """A class representing the users of reddit.
+
+    **Typical Attributes**
+
+    This table describes attributes that typically belong to objects of this
+    class. Since attributes are dynamically provided (see
+    :ref:`determine-available-attributes-of-an-object`), there is not a
+    guarantee that these attributes will always be present, nor is this list
+    comprehensive in any way.
+
+    ==================================== ======================================
+    Attribute                            Description
+    ==================================== ======================================
+    ``comment_karma``                    The comment karma for the Redditor.
+    ``comments``                         Provide an instance of
+                                         :class:`.SubListing` for comment
+                                         access.
+    ``created_utc``                      Time the account was created,
+                                         represented in `Unix Time`_.
+    ``has_verified_email``               Whether or not the Redditor has
+                                         verified their email.
+    ``icon_img``                         The url of the Redditors' avatar.
+    ``id``                               The ID of the Redditor.
+    ``is_employee``                      Whether or not the Redditor is a
+                                         Reddit employee.
+    ``is_friend``                        Whether or not the Redditor is friends
+                                         with the authenticated client.
+    ``is_gold``                          Whether or not the Redditor has active
+                                         gold status.
+    ``link_karma``                       The link karma for the Redditor.
+    ``name``                             The Redditor's username.
+    ``subreddit``                        If the Redditor has created a
+                                         user-subreddit, provides a dictionary
+                                         of additional attributes. See below.
+    ``subreddit['banner_img']``          The url of the user-subreddit banner.
+    ``subreddit['name']``                The name of the user-subreddit
+                                         (prefixed with 't5').
+    ``subreddit['over_18']``             Whether or not the user-subreddit is
+                                         NSFW.
+    ``subreddit['public_description']``  The public description of the user-
+                                         subreddit.
+    `subreddit['subscribers']``          The number of users subscribed to the
+                                         user-subreddit.
+    `subreddit['title']``                The title of the user-subreddit.
+    ==================================== ======================================
+
+
+    .. _Unix Time: https://en.wikipedia.org/wiki/Unix_time
+
+    """
 
     STR_FIELD = 'name'
 


### PR DESCRIPTION
Not 100% sure how I should list the items in the `subreddit` dictionary (if at all). Currently listed them as how they would be accessed, but maybe a separate table would be a bit neater?