### PR TITLE
Submission model docs - changed over18 to over_18

### DIFF
--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -38,7 +38,7 @@ class Submission(RedditBase, SubmissionListingMixin, UserContentMixin):
     ``link_flair_text``      The flair text for the submissions' flair.
     ``locked``               Whether or not the submission has been locked.
     ``num_comments``         The number of comments on the submission.
-    ``over18``               Whether or not the submission has been marked as
+    ``over_18``               Whether or not the submission has been marked as
                              NSFW.
     ``permalink``            A permalink for the submission.
     ``score``                The number of upvotes for the submission.

--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -38,7 +38,7 @@ class Submission(RedditBase, SubmissionListingMixin, UserContentMixin):
     ``link_flair_text``      The flair text for the submissions' flair.
     ``locked``               Whether or not the submission has been locked.
     ``num_comments``         The number of comments on the submission.
-    ``over_18``               Whether or not the submission has been marked as
+    ``over_18``              Whether or not the submission has been marked as
                              NSFW.
     ``permalink``            A permalink for the submission.
     ``score``                The number of upvotes for the submission.


### PR DESCRIPTION
Fixes # (provide issue number of applicable)

N/A

## Feature Summary and Justification

The attribute returned by Reddit denoting NSFW posts is called `over_18` instead of `over18`.

## References

I couldn't find the submission API endpoint in the Reddit API docs but every other usage of the term includes the underscore. It can also be tested by checking the attributes of a submission object i.e. `print(vars(submission_object))`.

