### PR TITLE
Removal Reasons and Removal Messages support

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -41,4 +41,5 @@ Source Contributors
 - Andrew Arnold `@asquared31415 <https://github.com/asquared31415>`_
 - bakonydraco `@bakonydraco <https://github.com/bakonydraco>`_
 - salehio `@salehio <https://github.com/salehio>`_
+- Declan Hoare <declanhoare@exemail.com.au> `@NetwideRogue <https://github.com/NetwideRogue>`_
 - Add "Name <email (optional)> and github profile link" above this line.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,11 @@ Unreleased
 
 * Add method :meth:`.Redditor.trophies` to get a list of the Redditor's
   trophies.
+* Add class :class:`.RemovalReason` to manage subreddit removal reasons.
+* Add method ``Submission.mod.set_removal_reason`` to set a removal
+  reason and mod note on one or more Submissions and/or Comments.
+* Add method ``Submission.mod.send_removal_message`` to send a removal
+  message about the Submission or Comment.
 
 **Changed**
 

--- a/docs/code_overview/other.rst
+++ b/docs/code_overview/other.rst
@@ -85,10 +85,12 @@ instances of them bound to an attribute of one of the PRAW models.
    other/preferences
    other/redditbase
    other/redditorlist
+   other/removalreason
    other/sublisting
    other/submenu
    other/subredditemoji
    other/subredditmessage
+   other/subredditremovalreasons
    other/redditorstream
    other/trophy
    other/util

--- a/docs/code_overview/other/removalreason.rst
+++ b/docs/code_overview/other/removalreason.rst
@@ -1,0 +1,5 @@
+RemovalReason
+=============
+
+.. autoclass:: praw.models.reddit.removalreason.RemovalReason
+   :inherited-members:

--- a/docs/code_overview/other/subredditremovalreasons.rst
+++ b/docs/code_overview/other/subredditremovalreasons.rst
@@ -1,0 +1,5 @@
+SubredditRemovalReasons
+=======================
+
+.. autoclass:: praw.models.reddit.removalreason.SubredditRemovalReasons
+   :inherited-members:

--- a/praw/const.py
+++ b/praw/const.py
@@ -123,6 +123,12 @@ API_PATH = {
     'quarantine_opt_in':      'api/quarantine_optin',
     'quarantine_opt_out':     'api/quarantine_optout',
     'read_message':           'api/read_message/',
+    ('removal_comment_'
+     'message'):              'api/v1/modactions/removal_comment_message',
+    'removal_link_message':   'api/v1/modactions/removal_link_message',
+    'removal_reasons':        'api/v1/{subreddit}/removal_reasons',
+    'removal_reason_update':  'api/v1/{subreddit}/removal_reasons/{id}',
+    'removal_reason_set':     'api/v1/modactions/removal_reasons',
     'remove':                 'api/remove/',
     'report':                 'api/report/',
     'rules':                  'r/{subreddit}/about/rules',

--- a/praw/models/__init__.py
+++ b/praw/models/__init__.py
@@ -19,6 +19,7 @@ from .reddit.modmail import (ModmailAction, ModmailConversation,  # NOQA
 from .reddit.more import MoreComments  # NOQA
 from .reddit.multi import Multireddit  # NOQA
 from .reddit.redditor import Redditor  # NOQA
+from .reddit.removalreason import RemovalReason  # NOQA
 from .reddit.submission import Submission  # NOQA
 from .reddit.subreddit import Subreddit  # NOQA
 from .reddit.widgets import (Button, ButtonWidget, Calendar,  # NOQA
@@ -39,8 +40,8 @@ __all__ = ('Auth', 'Button', 'ButtonWidget', 'Calendar', 'Comment',
            'ListingGenerator', 'LiveHelper', 'LiveThread', 'Menu', 'MenuLink',
            'Message', 'ModAction', 'ModeratorsWidget', 'ModmailConversation',
            'MoreComments', 'Multireddit', 'MultiredditHelper',
-           'Preferences', 'Redditor', 'RedditorList', 'RulesWidget',
-           'Stylesheet', 'Submenu', 'Submission', 'Subreddit',
+           'Preferences', 'Redditor', 'RedditorList', 'RemovalReason',
+           'RulesWidget', 'Stylesheet', 'Submenu', 'Submission', 'Subreddit',
            'SubredditHelper', 'SubredditMessage', 'SubredditWidgets',
            'Subreddits', 'TextArea', 'Trophy', 'TrophyList', 'User',
            'Widget', 'WikiPage')

--- a/praw/models/reddit/comment.py
+++ b/praw/models/reddit/comment.py
@@ -265,7 +265,7 @@ class CommentModeration(ThingModerationMixin):
 
     """
 
-    REMOVAL_MESSAGE_API = "removal_comment_message"
+    REMOVAL_MESSAGE_API = 'removal_comment_message'
 
     def __init__(self, comment):
         """Create a CommentModeration instance.

--- a/praw/models/reddit/comment.py
+++ b/praw/models/reddit/comment.py
@@ -265,6 +265,8 @@ class CommentModeration(ThingModerationMixin):
 
     """
 
+    REMOVAL_MESSAGE_API = "removal_comment_message"
+
     def __init__(self, comment):
         """Create a CommentModeration instance.
 

--- a/praw/models/reddit/mixins/__init__.py
+++ b/praw/models/reddit/mixins/__init__.py
@@ -115,7 +115,7 @@ class ThingModerationMixin(object):
         self.thing._reddit.post(API_PATH['remove'], data=data)
 
     def send_removal_message(self, type,  # pylint: disable=redefined-builtin
-                             title=None, message=None):
+                             title, message):
         """Send a removal message for a Comment or Submission.
 
         Reddit adds human-readable information about the object to the message.

--- a/praw/models/reddit/mixins/__init__.py
+++ b/praw/models/reddit/mixins/__init__.py
@@ -135,16 +135,16 @@ class ThingModerationMixin(object):
         url = API_PATH[self.REMOVAL_MESSAGE_API]
 
         # Only the first element of the item_id list is used.
-        data = {"item_id": [self.thing.fullname],
-                "message": message,
-                "title": title,
-                "type": str(type)}
+        data = {'item_id': [self.thing.fullname],
+                'message': message,
+                'title': title,
+                'type': str(type)}
 
         # Use the core to make the request in order to send the data as
         # JSON - this endpoint doesn't like URL encoding.
         self.thing._reddit._core.request('POST', url, json=data)
 
-    def set_removal_reason(self, reason=None, mod_note="", other_things=None):
+    def set_removal_reason(self, reason=None, mod_note='', other_things=None):
         """Set a removal reason for a Comment or Submission.
 
         Note that the removal message is not sent.  This can be done separately

--- a/praw/models/reddit/mixins/__init__.py
+++ b/praw/models/reddit/mixins/__init__.py
@@ -127,6 +127,8 @@ class ThingModerationMixin(object):
         :param title: The short reason given in the message.
             (Ignored if type is 'public'.)
         :param message: The body of the message.
+
+        If ``type`` is 'public', the new :class:`~.Comment` is returned.
         """
         # The API endpoint used to send removal messages is different
         # for posts and comments, so the derived classes specify which one.
@@ -142,7 +144,10 @@ class ThingModerationMixin(object):
 
         # Use the core to make the request in order to send the data as
         # JSON - this endpoint doesn't like URL encoding.
-        self.thing._reddit._core.request('POST', url, json=data)
+        ret = self.thing._reddit._core.request('POST', url, json=data)
+        if ret != {}:
+            from ..comment import Comment
+            return Comment(self.thing._reddit, _data=ret)
 
     def set_removal_reason(self, reason=None, mod_note='', other_things=None):
         """Set a removal reason for a Comment or Submission.

--- a/praw/models/reddit/mixins/__init__.py
+++ b/praw/models/reddit/mixins/__init__.py
@@ -148,6 +148,7 @@ class ThingModerationMixin(object):
         if ret != {}:
             from ..comment import Comment
             return Comment(self.thing._reddit, _data=ret)
+        return None
 
     def set_removal_reason(self, reason=None, mod_note='', other_things=None):
         """Set a removal reason for a Comment or Submission.

--- a/praw/models/reddit/mixins/__init__.py
+++ b/praw/models/reddit/mixins/__init__.py
@@ -14,6 +14,8 @@ from .votable import VotableMixin  # NOQA
 class ThingModerationMixin(object):
     """Provides moderation methods for Comments and Submissions."""
 
+    REMOVAL_MESSAGE_API = None
+
     def approve(self):
         """Approve a :class:`~.Comment` or :class:`~.Submission`.
 
@@ -111,6 +113,61 @@ class ThingModerationMixin(object):
         """
         data = {'id': self.thing.fullname, 'spam': bool(spam)}
         self.thing._reddit.post(API_PATH['remove'], data=data)
+
+    def send_removal_message(self, type,  # pylint: disable=redefined-builtin
+                             title=None, message=None):
+        """Send a removal message for a Comment or Submission.
+
+        Reddit adds human-readable information about the object to the message.
+
+        :param type: One of 'public', 'private', 'private_exposed'.
+            'public' leaves a stickied comment on the post.
+            'private' sends a Modmail message with hidden username.
+            'private_exposed' sends a Modmail message without hidden username.
+        :param title: The short reason given in the message.
+            (Ignored if type is 'public'.)
+        :param message: The body of the message.
+        """
+        # The API endpoint used to send removal messages is different
+        # for posts and comments, so the derived classes specify which one.
+        if self.REMOVAL_MESSAGE_API is None:
+            raise NotImplementedError('ThingModerationMixin must be extended.')
+        url = API_PATH[self.REMOVAL_MESSAGE_API]
+
+        # Only the first element of the item_id list is used.
+        data = {"item_id": [self.thing.fullname],
+                "message": message,
+                "title": title,
+                "type": str(type)}
+
+        # Use the core to make the request in order to send the data as
+        # JSON - this endpoint doesn't like URL encoding.
+        self.thing._reddit._core.request('POST', url, json=data)
+
+    def set_removal_reason(self, reason=None, mod_note="", other_things=None):
+        """Set a removal reason for a Comment or Submission.
+
+        Note that the removal message is not sent.  This can be done separately
+        using :meth:`~.send_removal_message`.
+
+        You can provide no reason if you only want to set mod_note.
+
+        :param reason: The :class:`~.RemovalReason` to use.
+        :param mod_note: A private note shown to moderators alongside the
+            reason.
+        :param other_things: When provided, set the same reason and mod_note on
+            this list of :class:`~.Comment` and/or :class:`~.Submission`
+            instances as part of a single request (default: None).
+        """
+        item_ids = [self.thing.fullname]
+        if other_things is not None:
+            item_ids += [t.fullname for t in other_things]
+        data = {'item_ids': item_ids,
+                'reason_id': None if reason is None else str(reason),
+                'mod_note': mod_note}
+
+        url = API_PATH['removal_reason_set']
+        self.thing._reddit._core.request('POST', url, json=data)
 
     def undistinguish(self):
         """Remove mod, admin, or special distinguishing on object.

--- a/praw/models/reddit/removalreason.py
+++ b/praw/models/reddit/removalreason.py
@@ -105,7 +105,6 @@ class SubredditRemovalReasons(object):
                                 reason,
                                 _data=raw['data'][reason])
 
-
     def add(self, title, message):
         """Add a removal reason to this subreddit.
 

--- a/praw/models/reddit/removalreason.py
+++ b/praw/models/reddit/removalreason.py
@@ -34,6 +34,8 @@ class RemovalReason(RedditBase):
         except KeyError:
             raise ClientException('/r/{} does not have the removal reason {}'
                                   .format(self.subreddit, self.id))
+        else:
+            self._fetched = True
 
     def delete(self):
         """Delete a removal reason from its subreddit."""

--- a/praw/models/reddit/removalreason.py
+++ b/praw/models/reddit/removalreason.py
@@ -38,12 +38,8 @@ class RemovalReason(RedditBase):
         # Update the list to match.
         self.subreddit.removal_reasons._reasons.remove(self)
 
-    def edit(self, title=None, message=None):
+    def edit(self, title, message):
         """Edit a removal reason."""
-        if title is None:
-            title = self.title
-        if message is None:
-            message = self.message
         url = API_PATH['removal_reason_update'].format(
             id=self.id, subreddit=self.subreddit)
         self._reddit.request('PUT', url, {'title': title, 'message': message})

--- a/praw/models/reddit/removalreason.py
+++ b/praw/models/reddit/removalreason.py
@@ -50,16 +50,16 @@ class RemovalReason(RedditBase):
 class SubredditRemovalReasons(object):
     """Provides management functions for a subreddit's removal reasons."""
 
-    def __getitem__(self, id):  # pylint:disable=invalid-name,redefined-builtin
-        """Return a :class:`.RemovalReason` from this subreddit by ID.
+    def __getitem__(self, key):
+        """Return a :class:`.RemovalReason` from this subreddit by ID or index.
 
-        :param id: The ID of the removal reason
+        :param key: The ID or index of the removal reason
         """
-        for reason in self._reasons:
-            if reason.id == id:
+        for i, reason in enumerate(self._reasons):
+            if i == key or reason == key:
                 return reason
-        raise KeyError('/r/{} does not have a removal reason of ID {}'
-                       .format(self.subreddit, id))
+        raise KeyError('/r/{} does not have a removal reason {}'
+                       .format(self.subreddit, key))
 
     def __init__(self, subreddit):
         """Create a SubredditRemovalReasons instance.

--- a/praw/models/reddit/removalreason.py
+++ b/praw/models/reddit/removalreason.py
@@ -1,0 +1,109 @@
+"""Provide the RemovalReason class."""
+from ...const import API_PATH
+from .base import RedditBase
+
+
+class RemovalReason(RedditBase):
+    """A removal reason for a subreddit."""
+
+    STR_FIELD = 'id'
+
+    def __eq__(self, other):
+        """Return whether the other instance equals the current."""
+        if isinstance(other, str):
+            return other == str(self)
+        return (isinstance(other, self.__class__) and
+                str(self) == str(other))
+
+    def __hash__(self):
+        """Return the hash of the current instance."""
+        return hash(str(self))
+
+    def __init__(self, reddit, subreddit,
+                 id,  # pylint: disable=redefined-builtin
+                 title, message, _data=None):
+        """Construct an instance of the RemovalReason object."""
+        self.subreddit = subreddit
+        self.id = id  # pylint: disable=invalid-name
+        self.title = title
+        self.message = message
+        super(RemovalReason, self).__init__(reddit, _data)
+
+    def delete(self):
+        """Delete a removal reason from its subreddit."""
+        url = API_PATH['removal_reason_update'].format(
+            id=self.id, subreddit=self.subreddit)
+        self._reddit.request('DELETE', url)
+
+        # Update the list to match.
+        self.subreddit.removal_reasons._reasons.remove(self)
+
+    def edit(self, title=None, message=None):
+        """Edit a removal reason."""
+        if title is None:
+            title = self.title
+        if message is None:
+            message = self.message
+        url = API_PATH['removal_reason_update'].format(
+            id=self.id, subreddit=self.subreddit)
+        self._reddit.request('PUT', url, {"title": title, "message": message})
+        self.title = title
+        self.message = message
+
+
+class SubredditRemovalReasons(object):
+    """Provides management functions for a subreddit's removal reasons."""
+
+    def __getitem__(self, id):  # pylint:disable=invalid-name,redefined-builtin
+        """Return a :class:`.RemovalReason` from this subreddit by ID.
+
+        :param id: The ID of the removal reason
+        """
+        for reason in self._reasons:
+            if reason.id == id:
+                return reason
+        raise KeyError('/r/{} does not have a removal reason of ID {}'
+                       .format(self.subreddit, id))
+
+    def __init__(self, subreddit):
+        """Create a SubredditRemovalReasons instance.
+
+        :param subreddit: The subreddit whose removal reasons are
+            affected
+        """
+        self.subreddit = subreddit
+        self._reddit = subreddit._reddit
+        raw = self._reddit.get(
+            API_PATH['removal_reasons'].format(subreddit=self.subreddit))
+        # The returned object has a dictionary called "data", followed by
+        # a list called "order" which has dictionary keys in iteration
+        # order, so start by getting the corresponding values:
+        data = (raw["data"][k] for k in raw["order"])
+        # then convert them to our model:
+        self._reasons = [RemovalReason(self._reddit,
+                                       self.subreddit,
+                                       reason["id"],
+                                       reason["title"],
+                                       reason["message"])
+                         for reason in data]
+
+    def __iter__(self):
+        """Iterate over the removal reasons for this subreddit, in order."""
+        return iter(self._reasons)
+
+    def add(self, title, message):
+        """Add a removal reason to this subreddit.
+
+        :param title: The title of the removal reason
+        :param message: The body of the removal reason
+        :returns: The RemovalReason added
+        """
+        url = API_PATH['removal_reasons'].format(subreddit=self.subreddit)
+        response = self._reddit.post(url, {"title": title, "message": message})
+        reason = RemovalReason(self._reddit,
+                               self.subreddit,
+                               response["id"],
+                               title,
+                               message)
+        self._reasons.append(reason)
+        return reason

--- a/praw/models/reddit/removalreason.py
+++ b/praw/models/reddit/removalreason.py
@@ -46,7 +46,7 @@ class RemovalReason(RedditBase):
             message = self.message
         url = API_PATH['removal_reason_update'].format(
             id=self.id, subreddit=self.subreddit)
-        self._reddit.request('PUT', url, {"title": title, "message": message})
+        self._reddit.request('PUT', url, {'title': title, 'message': message})
         self.title = title
         self.message = message
 
@@ -78,13 +78,13 @@ class SubredditRemovalReasons(object):
         # The returned object has a dictionary called "data", followed by
         # a list called "order" which has dictionary keys in iteration
         # order, so start by getting the corresponding values:
-        data = (raw["data"][k] for k in raw["order"])
+        data = (raw['data'][k] for k in raw['order'])
         # then convert them to our model:
         self._reasons = [RemovalReason(self._reddit,
                                        self.subreddit,
-                                       reason["id"],
-                                       reason["title"],
-                                       reason["message"])
+                                       reason['id'],
+                                       reason['title'],
+                                       reason['message'])
                          for reason in data]
 
     def __iter__(self):
@@ -99,10 +99,10 @@ class SubredditRemovalReasons(object):
         :returns: The RemovalReason added
         """
         url = API_PATH['removal_reasons'].format(subreddit=self.subreddit)
-        response = self._reddit.post(url, {"title": title, "message": message})
+        response = self._reddit.post(url, {'title': title, 'message': message})
         reason = RemovalReason(self._reddit,
                                self.subreddit,
-                               response["id"],
+                               response['id'],
                                title,
                                message)
         self._reasons.append(reason)

--- a/praw/models/reddit/removalreason.py
+++ b/praw/models/reddit/removalreason.py
@@ -1,5 +1,6 @@
 """Provide the RemovalReason class."""
 from ...const import API_PATH
+from ...exceptions import ClientException
 from .base import RedditBase
 
 

--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -369,7 +369,7 @@ class SubmissionModeration(ThingModerationMixin):
 
     """
 
-    REMOVAL_MESSAGE_API = "removal_link_message"
+    REMOVAL_MESSAGE_API = 'removal_link_message'
 
     def __init__(self, submission):
         """Create a SubmissionModeration instance.

--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -369,6 +369,8 @@ class SubmissionModeration(ThingModerationMixin):
 
     """
 
+    REMOVAL_MESSAGE_API = "removal_link_message"
+
     def __init__(self, submission):
         """Create a SubmissionModeration instance.
 

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -13,6 +13,7 @@ from .base import RedditBase
 from .emoji import SubredditEmoji
 from .mixins import MessageableMixin
 from .modmail import ModmailConversation
+from .removalreason import SubredditRemovalReasons
 from .widgets import SubredditWidgets
 from .wikipage import WikiPage
 
@@ -303,6 +304,13 @@ class Subreddit(RedditBase, MessageableMixin, SubredditListingMixin):
         return self._quarantine
 
     @property
+    def removal_reasons(self):
+        """Provide an instance of :class:`.SubredditRemovalReasons`."""
+        if self._removal_reasons is None:
+            self._removal_reasons = SubredditRemovalReasons(self)
+        return self._removal_reasons
+
+    @property
     def stream(self):
         """Provide an instance of :class:`.SubredditStream`.
 
@@ -399,7 +407,7 @@ class Subreddit(RedditBase, MessageableMixin, SubredditListingMixin):
         if display_name:
             self.display_name = display_name
         self._banned = self._contributor = self._filters = self._flair = None
-        self._emoji = self._widgets = None
+        self._emoji = self._removal_reasons = self._widgets = None
         self._mod = self._moderator = self._modmail = self._muted = None
         self._quarantine = self._stream = self._stylesheet = self._wiki = None
         self._path = API_PATH['subreddit'].format(subreddit=self)

--- a/tests/integration/cassettes/TestCommentModeration.test_send_removal_message.json
+++ b/tests/integration/cassettes/TestCommentModeration.test_send_removal_message.json
@@ -1,0 +1,564 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-10-07T09:48:33",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "207"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "118"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 07 Oct 2018 09:48:30 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "edgebucket=zbIcxEdMiOaqIyPM5U; Domain=reddit.com; Max-Age=63071999; Path=/;  secure"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18925-SYD"
+          ],
+          "X-Timer": [
+            "S1538905710.196618,VS0,VE511"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2018-10-07T09:48:46",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t1_e7b7z5y&spam=False"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "38"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "edgebucket=zbIcxEdMiOaqIyPM5U"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/remove/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 07 Oct 2018 09:48:45 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18928-SYD"
+          ],
+          "X-Timer": [
+            "S1538905725.031185,VS0,VE337"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "574.0"
+          ],
+          "x-ratelimit-reset": [
+            "75"
+          ],
+          "x-ratelimit-used": [
+            "26"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/remove/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-10-07T09:48:48",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"item_id\": [\"t1_e7b7z5y\"], \"message\": \"message\", \"title\": \"title\", \"type\": \"public\"}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "85"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Cookie": [
+            "edgebucket=zbIcxEdMiOaqIyPM5U"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/v1/modactions/removal_comment_message?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"subreddit_id\": \"t5_phv9h\", \"approved_at_utc\": null, \"ups\": 1, \"mod_reason_by\": null, \"banned_by\": null, \"author_flair_type\": \"text\", \"removal_reason\": null, \"link_id\": \"t3_9m1ya8\", \"author_flair_template_id\": null, \"likes\": true, \"replies\": \"\", \"user_reports\": [], \"body_html\": \"<div class=\\\"md\\\"><p>message</p>\\n</div>\", \"saved\": false, \"id\": \"e7bpbl9\", \"banned_at_utc\": null, \"mod_reason_title\": null, \"gilded\": 0, \"archived\": false, \"no_follow\": false, \"author\": \"<TEST_SUBREDDIT>\", \"can_mod_post\": true, \"send_replies\": true, \"parent_id\": \"t1_e7b7z5y\", \"score\": 1, \"author_fullname\": \"t2_2cvck8ii\", \"report_reasons\": [], \"approved_by\": null, \"downs\": 0, \"ignore_reports\": false, \"body\": \"message\", \"edited\": false, \"author_flair_css_class\": null, \"collapsed\": false, \"author_flair_richtext\": [], \"is_submitter\": false, \"collapsed_reason\": null, \"gildings\": {\"gid_1\": 0, \"gid_2\": 0, \"gid_3\": 0}, \"spam\": false, \"stickied\": false, \"subreddit_type\": \"public\", \"can_gild\": false, \"removed\": false, \"approved\": false, \"author_flair_text_color\": null, \"score_hidden\": false, \"permalink\": \"/r/<TEST_SUBREDDIT>/comments/9m1ya8/epic_win/e7bpbl9/\", \"num_reports\": 0, \"name\": \"t1_e7bpbl9\", \"created\": 1538934527.0, \"subreddit\": \"<TEST_SUBREDDIT>\", \"author_flair_text\": null, \"rte_mode\": \"markdown\", \"created_utc\": 1538905727.0, \"subreddit_name_prefixed\": \"r/<TEST_SUBREDDIT>\", \"controversiality\": 0, \"author_flair_background_color\": null, \"mod_reports\": [], \"mod_note\": null, \"distinguished\": \"moderator\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1508"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 07 Oct 2018 09:48:47 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Vary": [
+            "accept-encoding"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18928-SYD"
+          ],
+          "X-Timer": [
+            "S1538905727.006312,VS0,VE409"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "573.0"
+          ],
+          "x-ratelimit-reset": [
+            "73"
+          ],
+          "x-ratelimit-used": [
+            "27"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/modactions/removal_comment_message?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-10-07T09:48:49",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"item_id\": [\"t1_e7b7z5y\"], \"message\": \"message\", \"title\": \"title\", \"type\": \"private\"}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "86"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Cookie": [
+            "edgebucket=zbIcxEdMiOaqIyPM5U"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/v1/modactions/removal_comment_message?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 07 Oct 2018 09:48:48 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18928-SYD"
+          ],
+          "X-Timer": [
+            "S1538905729.568733,VS0,VE350"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "572.0"
+          ],
+          "x-ratelimit-reset": [
+            "72"
+          ],
+          "x-ratelimit-used": [
+            "28"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/modactions/removal_comment_message?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-10-07T09:48:50",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"item_id\": [\"t1_e7b7z5y\"], \"message\": \"message\", \"title\": \"title\", \"type\": \"private_exposed\"}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "94"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Cookie": [
+            "edgebucket=zbIcxEdMiOaqIyPM5U"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/v1/modactions/removal_comment_message?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 07 Oct 2018 09:48:50 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18928-SYD"
+          ],
+          "X-Timer": [
+            "S1538905730.888340,VS0,VE414"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "571.0"
+          ],
+          "x-ratelimit-reset": [
+            "70"
+          ],
+          "x-ratelimit-used": [
+            "29"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/modactions/removal_comment_message?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/integration/cassettes/TestRemovalReason.test__fetch.json
+++ b/tests/integration/cassettes/TestRemovalReason.test__fetch.json
@@ -1,0 +1,326 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-10-07T09:49:11",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "207"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "118"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 07 Oct 2018 09:49:07 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "edgebucket=rBMjpvgb6knxy3Slkb; Domain=reddit.com; Max-Age=63071999; Path=/;  secure"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18930-SYD"
+          ],
+          "X-Timer": [
+            "S1538905747.680527,VS0,VE509"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2018-10-07T09:49:32",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "edgebucket=rBMjpvgb6knxy3Slkb"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/api/v1/<TEST_SUBREDDIT>/removal_reasons?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"data\": {\"11qjnfc3wdghj\": {\"message\": \"Test Reason Message\", \"id\": \"11qjnfc3wdghj\", \"title\": \"Test Reason Title\"}, \"11qiw1rp2mlqd\": {\"message\": \"This is a test removal reason\", \"id\": \"11qiw1rp2mlqd\", \"title\": \"Test removal reason...\"}, \"11qpplj402nbj\": {\"message\": \"new message\", \"id\": \"11qpplj402nbj\", \"title\": \"New test\"}, \"11qjnh8qcsbdj\": {\"message\": \"new message\", \"id\": \"11qjnh8qcsbdj\", \"title\": \"new title\"}, \"11qqi94tnyzae\": {\"message\": \"adding a test reason\", \"id\": \"11qqi94tnyzae\", \"title\": \"test\"}, \"11qobsiud9b5v\": {\"message\": \"used in the getitem test\", \"id\": \"11qobsiud9b5v\", \"title\": \"Get Test Reason\"}, \"11qq98vi9vjo1\": {\"message\": \"adding a test reason\", \"id\": \"11qq98vi9vjo1\", \"title\": \"test\"}, \"11qq89lls191u\": {\"message\": \"adding a test reason\", \"id\": \"11qq89lls191u\", \"title\": \"test\"}, \"11qpdeyfmjj26\": {\"message\": \"adding a new removal reason without fetching the existing ones!\", \"id\": \"11qpdeyfmjj26\", \"title\": \"Fetch test\"}, \"11qqil974lade\": {\"message\": \"This reason is only here to be deleted by the PRAW tests :(\", \"id\": \"11qqil974lade\", \"title\": \"Delete Test Reason\"}, \"11qo9awftokz1\": {\"message\": \"This reason will be edited.\", \"id\": \"11qo9awftokz1\", \"title\": \"Edit Test Reason\"}, \"11qpoe6c636p5\": {\"message\": \"Test Reason Message\", \"id\": \"11qpoe6c636p5\", \"title\": \"Test Reason\"}}, \"order\": [\"11qiw1rp2mlqd\", \"11qjnfc3wdghj\", \"11qjnh8qcsbdj\", \"11qo9awftokz1\", \"11qobsiud9b5v\", \"11qpdeyfmjj26\", \"11qpoe6c636p5\", \"11qpplj402nbj\", \"11qq89lls191u\", \"11qq98vi9vjo1\", \"11qqi94tnyzae\", \"11qqil974lade\"]}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1525"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 07 Oct 2018 09:49:29 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Vary": [
+            "accept-encoding"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18931-SYD"
+          ],
+          "X-Timer": [
+            "S1538905770.663598,VS0,VE336"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "570.0"
+          ],
+          "x-ratelimit-reset": [
+            "31"
+          ],
+          "x-ratelimit-used": [
+            "30"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/<TEST_SUBREDDIT>/removal_reasons?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-10-07T09:49:35",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "edgebucket=rBMjpvgb6knxy3Slkb"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/api/v1/<TEST_SUBREDDIT>/removal_reasons?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"data\": {\"11qjnfc3wdghj\": {\"message\": \"Test Reason Message\", \"id\": \"11qjnfc3wdghj\", \"title\": \"Test Reason Title\"}, \"11qiw1rp2mlqd\": {\"message\": \"This is a test removal reason\", \"id\": \"11qiw1rp2mlqd\", \"title\": \"Test removal reason...\"}, \"11qpplj402nbj\": {\"message\": \"new message\", \"id\": \"11qpplj402nbj\", \"title\": \"New test\"}, \"11qjnh8qcsbdj\": {\"message\": \"new message\", \"id\": \"11qjnh8qcsbdj\", \"title\": \"new title\"}, \"11qqi94tnyzae\": {\"message\": \"adding a test reason\", \"id\": \"11qqi94tnyzae\", \"title\": \"test\"}, \"11qobsiud9b5v\": {\"message\": \"used in the getitem test\", \"id\": \"11qobsiud9b5v\", \"title\": \"Get Test Reason\"}, \"11qq98vi9vjo1\": {\"message\": \"adding a test reason\", \"id\": \"11qq98vi9vjo1\", \"title\": \"test\"}, \"11qq89lls191u\": {\"message\": \"adding a test reason\", \"id\": \"11qq89lls191u\", \"title\": \"test\"}, \"11qpdeyfmjj26\": {\"message\": \"adding a new removal reason without fetching the existing ones!\", \"id\": \"11qpdeyfmjj26\", \"title\": \"Fetch test\"}, \"11qqil974lade\": {\"message\": \"This reason is only here to be deleted by the PRAW tests :(\", \"id\": \"11qqil974lade\", \"title\": \"Delete Test Reason\"}, \"11qo9awftokz1\": {\"message\": \"This reason will be edited.\", \"id\": \"11qo9awftokz1\", \"title\": \"Edit Test Reason\"}, \"11qpoe6c636p5\": {\"message\": \"Test Reason Message\", \"id\": \"11qpoe6c636p5\", \"title\": \"Test Reason\"}}, \"order\": [\"11qiw1rp2mlqd\", \"11qjnfc3wdghj\", \"11qjnh8qcsbdj\", \"11qo9awftokz1\", \"11qobsiud9b5v\", \"11qpdeyfmjj26\", \"11qpoe6c636p5\", \"11qpplj402nbj\", \"11qq89lls191u\", \"11qq98vi9vjo1\", \"11qqi94tnyzae\", \"11qqil974lade\"]}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1525"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 07 Oct 2018 09:49:33 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Vary": [
+            "accept-encoding"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18931-SYD"
+          ],
+          "X-Timer": [
+            "S1538905773.902319,VS0,VE256"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "569.0"
+          ],
+          "x-ratelimit-reset": [
+            "27"
+          ],
+          "x-ratelimit-used": [
+            "31"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/<TEST_SUBREDDIT>/removal_reasons?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/integration/cassettes/TestRemovalReason.test_delete.json
+++ b/tests/integration/cassettes/TestRemovalReason.test_delete.json
@@ -1,0 +1,216 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-10-07T09:49:51",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "207"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "118"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 07 Oct 2018 09:49:50 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "edgebucket=nRXQx9lwvDcLI4pEDl; Domain=reddit.com; Max-Age=63071999; Path=/;  secure"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18922-SYD"
+          ],
+          "X-Timer": [
+            "S1538905790.562814,VS0,VE498"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2018-10-07T09:50:04",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "0"
+          ],
+          "Cookie": [
+            "edgebucket=nRXQx9lwvDcLI4pEDl"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "DELETE",
+        "uri": "https://oauth.reddit.com/api/v1/<TEST_SUBREDDIT>/removal_reasons/11qqil974lade?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "0"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 07 Oct 2018 09:50:02 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18925-SYD"
+          ],
+          "X-Timer": [
+            "S1538905802.166749,VS0,VE278"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "599.0"
+          ],
+          "x-ratelimit-reset": [
+            "598"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/<TEST_SUBREDDIT>/removal_reasons/11qqil974lade?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/integration/cassettes/TestRemovalReason.test_edit.json
+++ b/tests/integration/cassettes/TestRemovalReason.test_edit.json
@@ -1,7 +1,108 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2018-10-07T09:50:36",
+      "recorded_at": "2018-10-07T10:02:26",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "207"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "118"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 07 Oct 2018 10:02:25 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "edgebucket=3qaiTqZzXxY4GKGGs7; Domain=reddit.com; Max-Age=63071999; Path=/;  secure"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18932-SYD"
+          ],
+          "X-Timer": [
+            "S1538906545.194466,VS0,VE514"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2018-10-07T10:02:40",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -15,7 +116,117 @@
             "identity"
           ],
           "Authorization": [
-            "bearer 184745267226-D2A5fBAN2IE5b76lvmY682RsKn4"
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "edgebucket=3qaiTqZzXxY4GKGGs7"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/api/v1/<TEST_SUBREDDIT>/removal_reasons?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"data\": {\"11qjnfc3wdghj\": {\"message\": \"Test Reason Message\", \"id\": \"11qjnfc3wdghj\", \"title\": \"Test Reason Title\"}, \"11qiw1rp2mlqd\": {\"message\": \"This is a test removal reason\", \"id\": \"11qiw1rp2mlqd\", \"title\": \"Test removal reason...\"}, \"11qpplj402nbj\": {\"message\": \"new message\", \"id\": \"11qpplj402nbj\", \"title\": \"New test\"}, \"11qqjwr033xba\": {\"message\": \"adding a test reason\", \"id\": \"11qqjwr033xba\", \"title\": \"test\"}, \"11qjnh8qcsbdj\": {\"message\": \"new message\", \"id\": \"11qjnh8qcsbdj\", \"title\": \"new title\"}, \"11qqi94tnyzae\": {\"message\": \"adding a test reason\", \"id\": \"11qqi94tnyzae\", \"title\": \"test\"}, \"11qobsiud9b5v\": {\"message\": \"used in the getitem test\", \"id\": \"11qobsiud9b5v\", \"title\": \"Get Test Reason\"}, \"11qq98vi9vjo1\": {\"message\": \"adding a test reason\", \"id\": \"11qq98vi9vjo1\", \"title\": \"test\"}, \"11qq89lls191u\": {\"message\": \"adding a test reason\", \"id\": \"11qq89lls191u\", \"title\": \"test\"}, \"11qpdeyfmjj26\": {\"message\": \"adding a new removal reason without fetching the existing ones!\", \"id\": \"11qpdeyfmjj26\", \"title\": \"Fetch test\"}, \"11qo9awftokz1\": {\"message\": \"This reason will be edited.\", \"id\": \"11qo9awftokz1\", \"title\": \"Edit Test Reason\"}, \"11qpoe6c636p5\": {\"message\": \"Test Reason Message\", \"id\": \"11qpoe6c636p5\", \"title\": \"Test Reason\"}}, \"order\": [\"11qiw1rp2mlqd\", \"11qjnfc3wdghj\", \"11qjnh8qcsbdj\", \"11qo9awftokz1\", \"11qobsiud9b5v\", \"11qpdeyfmjj26\", \"11qpoe6c636p5\", \"11qpplj402nbj\", \"11qq89lls191u\", \"11qq98vi9vjo1\", \"11qqi94tnyzae\", \"11qqjwr033xba\"]}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1472"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 07 Oct 2018 10:02:38 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Vary": [
+            "accept-encoding"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18926-SYD"
+          ],
+          "X-Timer": [
+            "S1538906558.886686,VS0,VE291"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "599.0"
+          ],
+          "x-ratelimit-reset": [
+            "442"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/<TEST_SUBREDDIT>/removal_reasons?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-10-07T10:02:43",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
           ],
           "Connection": [
             "keep-alive"
@@ -24,7 +235,7 @@
             "0"
           ],
           "Cookie": [
-            "edgebucket=VnHx3QW95jFLh3ilgC"
+            "edgebucket=3qaiTqZzXxY4GKGGs7"
           ],
           "User-Agent": [
             "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
@@ -52,7 +263,7 @@
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Sun, 07 Oct 2018 09:50:33 GMT"
+            "Sun, 07 Oct 2018 10:02:40 GMT"
           ],
           "Server": [
             "snooserv"
@@ -73,10 +284,10 @@
             "majestic"
           ],
           "X-Served-By": [
-            "cache-syd18925-SYD"
+            "cache-syd18926-SYD"
           ],
           "X-Timer": [
-            "S1538905833.304726,VS0,VE336"
+            "S1538906560.155130,VS0,VE263"
           ],
           "cache-control": [
             "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
@@ -91,13 +302,13 @@
             "SAMEORIGIN"
           ],
           "x-ratelimit-remaining": [
-            "597.0"
+            "598.0"
           ],
           "x-ratelimit-reset": [
-            "567"
+            "440"
           ],
           "x-ratelimit-used": [
-            "3"
+            "2"
           ],
           "x-xss-protection": [
             "1; mode=block"

--- a/tests/integration/cassettes/TestRemovalReason.test_edit.json
+++ b/tests/integration/cassettes/TestRemovalReason.test_edit.json
@@ -1,0 +1,115 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-10-07T09:50:36",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer 184745267226-D2A5fBAN2IE5b76lvmY682RsKn4"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "0"
+          ],
+          "Cookie": [
+            "edgebucket=VnHx3QW95jFLh3ilgC"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "PUT",
+        "uri": "https://oauth.reddit.com/api/v1/<TEST_SUBREDDIT>/removal_reasons/11qo9awftokz1?title=Edit+Test+Reason&message=now+this+reason+is+being+edited&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "0"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 07 Oct 2018 09:50:33 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18925-SYD"
+          ],
+          "X-Timer": [
+            "S1538905833.304726,VS0,VE336"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "597.0"
+          ],
+          "x-ratelimit-reset": [
+            "567"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/<TEST_SUBREDDIT>/removal_reasons/11qo9awftokz1?title=Edit+Test+Reason&message=now+this+reason+is+being+edited&raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/integration/cassettes/TestSubmissionModeration.test_send_removal_message.json
+++ b/tests/integration/cassettes/TestSubmissionModeration.test_send_removal_message.json
@@ -1,0 +1,564 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-10-07T09:52:20",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "207"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "118"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 07 Oct 2018 09:52:18 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "edgebucket=ZgIPNFHNiQi2lFF51E; Domain=reddit.com; Max-Age=63071999; Path=/;  secure"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18934-SYD"
+          ],
+          "X-Timer": [
+            "S1538905938.545003,VS0,VE508"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2018-10-07T09:52:35",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t3_9m1ya8&spam=False"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "37"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "edgebucket=ZgIPNFHNiQi2lFF51E"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/remove/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 07 Oct 2018 09:52:34 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18929-SYD"
+          ],
+          "X-Timer": [
+            "S1538905954.945081,VS0,VE396"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "592.0"
+          ],
+          "x-ratelimit-reset": [
+            "446"
+          ],
+          "x-ratelimit-used": [
+            "8"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/remove/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-10-07T09:52:36",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"item_id\": [\"t3_9m1ya8\"], \"message\": \"message\", \"title\": \"title\", \"type\": \"public\"}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "84"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Cookie": [
+            "edgebucket=ZgIPNFHNiQi2lFF51E"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/v1/modactions/removal_link_message?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"subreddit_id\": \"t5_phv9h\", \"approved_at_utc\": null, \"ups\": 1, \"mod_reason_by\": null, \"banned_by\": null, \"author_flair_type\": \"text\", \"removal_reason\": null, \"link_id\": \"t3_9m1ya8\", \"author_flair_template_id\": null, \"likes\": true, \"replies\": \"\", \"user_reports\": [], \"body_html\": \"<div class=\\\"md\\\"><p>message</p>\\n</div>\", \"saved\": false, \"id\": \"e7bpf5t\", \"banned_at_utc\": null, \"mod_reason_title\": null, \"gilded\": 0, \"archived\": false, \"no_follow\": false, \"author\": \"<TEST_SUBREDDIT>\", \"can_mod_post\": true, \"send_replies\": true, \"parent_id\": \"t3_9m1ya8\", \"score\": 1, \"author_fullname\": \"t2_2cvck8ii\", \"report_reasons\": [], \"approved_by\": null, \"downs\": 0, \"ignore_reports\": false, \"body\": \"message\", \"edited\": false, \"author_flair_css_class\": null, \"collapsed\": false, \"author_flair_richtext\": [], \"is_submitter\": false, \"collapsed_reason\": null, \"gildings\": {\"gid_1\": 0, \"gid_2\": 0, \"gid_3\": 0}, \"spam\": false, \"stickied\": true, \"subreddit_type\": \"public\", \"can_gild\": false, \"removed\": false, \"approved\": false, \"author_flair_text_color\": null, \"score_hidden\": false, \"permalink\": \"/r/<TEST_SUBREDDIT>/comments/9m1ya8/epic_win/e7bpf5t/\", \"num_reports\": 0, \"name\": \"t1_e7bpf5t\", \"created\": 1538934755.0, \"subreddit\": \"<TEST_SUBREDDIT>\", \"author_flair_text\": null, \"rte_mode\": \"markdown\", \"created_utc\": 1538905955.0, \"subreddit_name_prefixed\": \"r/<TEST_SUBREDDIT>\", \"controversiality\": 0, \"author_flair_background_color\": null, \"mod_reports\": [], \"mod_note\": null, \"distinguished\": \"moderator\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1506"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 07 Oct 2018 09:52:35 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Vary": [
+            "accept-encoding"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18929-SYD"
+          ],
+          "X-Timer": [
+            "S1538905955.377197,VS0,VE407"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "591.0"
+          ],
+          "x-ratelimit-reset": [
+            "445"
+          ],
+          "x-ratelimit-used": [
+            "9"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/modactions/removal_link_message?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-10-07T09:52:37",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"item_id\": [\"t3_9m1ya8\"], \"message\": \"message\", \"title\": \"title\", \"type\": \"private\"}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "85"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Cookie": [
+            "edgebucket=ZgIPNFHNiQi2lFF51E"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/v1/modactions/removal_link_message?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 07 Oct 2018 09:52:37 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18929-SYD"
+          ],
+          "X-Timer": [
+            "S1538905957.711873,VS0,VE354"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "590.0"
+          ],
+          "x-ratelimit-reset": [
+            "444"
+          ],
+          "x-ratelimit-used": [
+            "10"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/modactions/removal_link_message?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-10-07T09:52:39",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"item_id\": [\"t3_9m1ya8\"], \"message\": \"message\", \"title\": \"title\", \"type\": \"private_exposed\"}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "93"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Cookie": [
+            "edgebucket=ZgIPNFHNiQi2lFF51E"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/v1/modactions/removal_link_message?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 07 Oct 2018 09:52:38 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18929-SYD"
+          ],
+          "X-Timer": [
+            "S1538905958.909569,VS0,VE343"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "589.0"
+          ],
+          "x-ratelimit-reset": [
+            "442"
+          ],
+          "x-ratelimit-used": [
+            "11"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/modactions/removal_link_message?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/integration/cassettes/TestSubmissionModeration.test_set_removal_reason.json
+++ b/tests/integration/cassettes/TestSubmissionModeration.test_set_removal_reason.json
@@ -1,0 +1,900 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-10-07T09:52:46",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "207"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "118"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 07 Oct 2018 09:52:43 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "edgebucket=90wMZMrOntsLJfOXB2; Domain=reddit.com; Max-Age=63071999; Path=/;  secure"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18921-SYD"
+          ],
+          "X-Timer": [
+            "S1538905963.030537,VS0,VE673"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2018-10-07T09:53:06",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "edgebucket=90wMZMrOntsLJfOXB2"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/comments/9m1ya8/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"dist\": 1, \"children\": [{\"kind\": \"t3\", \"data\": {\"approved_at_utc\": null, \"subreddit\": \"<TEST_SUBREDDIT>\", \"selftext\": \"This is a test post\", \"user_reports\": [], \"saved\": false, \"mod_reason_title\": null, \"gilded\": 0, \"clicked\": false, \"title\": \"epic win!\", \"link_flair_richtext\": [], \"subreddit_name_prefixed\": \"r/<TEST_SUBREDDIT>\", \"hidden\": false, \"pwls\": null, \"link_flair_css_class\": null, \"downs\": 0, \"thumbnail_height\": null, \"parent_whitelist_status\": null, \"hide_score\": false, \"name\": \"t3_9m1ya8\", \"quarantine\": false, \"link_flair_text_color\": \"dark\", \"upvote_ratio\": 1.0, \"author_flair_background_color\": null, \"subreddit_type\": \"public\", \"ups\": 1, \"domain\": \"self.<TEST_SUBREDDIT>\", \"media_embed\": {}, \"thumbnail_width\": null, \"author_flair_template_id\": null, \"is_original_content\": false, \"author_fullname\": \"t2_28sly032\", \"secure_media\": null, \"is_reddit_media_domain\": false, \"is_meta\": false, \"category\": null, \"num_comments\": 8, \"secure_media_embed\": {}, \"link_flair_text\": null, \"can_mod_post\": true, \"score\": 1, \"approved_by\": null, \"ignore_reports\": false, \"thumbnail\": \"default\", \"edited\": false, \"author_flair_css_class\": null, \"previous_visits\": [1538902690.0, 1538903651.0], \"author_flair_richtext\": [], \"gildings\": {\"gid_1\": 0, \"gid_2\": 0, \"gid_3\": 0}, \"content_categories\": null, \"is_self\": true, \"mod_note\": null, \"created\": 1538909490.0, \"link_flair_type\": \"text\", \"wls\": null, \"banned_by\": \"<TEST_SUBREDDIT>\", \"author_flair_type\": \"text\", \"contest_mode\": false, \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EThis is a test post\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"likes\": null, \"suggested_sort\": null, \"banned_at_utc\": 1538905954, \"view_count\": 5, \"archived\": false, \"no_follow\": true, \"spam\": false, \"is_crosspostable\": false, \"pinned\": false, \"over_18\": false, \"media_only\": false, \"link_flair_template_id\": null, \"can_gild\": true, \"removed\": true, \"spoiler\": false, \"locked\": false, \"author_flair_text\": null, \"visited\": false, \"num_reports\": 0, \"distinguished\": null, \"subreddit_id\": \"t5_phv9h\", \"mod_reason_by\": null, \"removal_reason\": null, \"link_flair_background_color\": \"\", \"ban_note\": \"remove not spam\", \"id\": \"9m1ya8\", \"is_robot_indexable\": true, \"report_reasons\": [], \"author\": \"NetwideRogue\", \"num_crossposts\": 0, \"media\": null, \"send_replies\": true, \"approved\": false, \"author_flair_text_color\": null, \"permalink\": \"/r/<TEST_SUBREDDIT>/comments/9m1ya8/epic_win/\", \"whitelist_status\": null, \"stickied\": false, \"url\": \"https://www.reddit.com/r/<TEST_SUBREDDIT>/comments/9m1ya8/epic_win/\", \"subreddit_subscribers\": 1, \"created_utc\": 1538880690.0, \"mod_reports\": [], \"is_video\": false}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"dist\": null, \"children\": [{\"kind\": \"t1\", \"data\": {\"subreddit_id\": \"t5_phv9h\", \"approved_at_utc\": null, \"ups\": 1, \"mod_reason_by\": null, \"banned_by\": null, \"author_flair_type\": \"text\", \"removal_reason\": null, \"link_id\": \"t3_9m1ya8\", \"author_flair_template_id\": null, \"likes\": true, \"replies\": \"\", \"user_reports\": [], \"body_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Emessage\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"saved\": false, \"id\": \"e7bpf5t\", \"banned_at_utc\": null, \"mod_reason_title\": null, \"gilded\": 0, \"archived\": false, \"no_follow\": false, \"author\": \"<TEST_SUBREDDIT>\", \"can_mod_post\": true, \"send_replies\": true, \"parent_id\": \"t3_9m1ya8\", \"score\": 1, \"author_fullname\": \"t2_2cvck8ii\", \"report_reasons\": [], \"approved_by\": null, \"downs\": 0, \"ignore_reports\": false, \"body\": \"message\", \"edited\": false, \"author_flair_css_class\": null, \"collapsed\": false, \"author_flair_richtext\": [], \"is_submitter\": false, \"collapsed_reason\": null, \"gildings\": {\"gid_1\": 0, \"gid_2\": 0, \"gid_3\": 0}, \"spam\": false, \"stickied\": true, \"subreddit_type\": \"public\", \"can_gild\": false, \"removed\": false, \"approved\": false, \"author_flair_text_color\": null, \"score_hidden\": false, \"permalink\": \"/r/<TEST_SUBREDDIT>/comments/9m1ya8/epic_win/e7bpf5t/\", \"num_reports\": 0, \"name\": \"t1_e7bpf5t\", \"created\": 1538934755.0, \"subreddit\": \"<TEST_SUBREDDIT>\", \"author_flair_text\": null, \"rte_mode\": \"markdown\", \"created_utc\": 1538905955.0, \"subreddit_name_prefixed\": \"r/<TEST_SUBREDDIT>\", \"controversiality\": 0, \"depth\": 0, \"author_flair_background_color\": null, \"mod_reports\": [], \"mod_note\": null, \"distinguished\": \"moderator\"}}, {\"kind\": \"t1\", \"data\": {\"subreddit_id\": \"t5_phv9h\", \"approved_at_utc\": null, \"ups\": 1, \"mod_reason_by\": null, \"banned_by\": \"<TEST_SUBREDDIT>\", \"author_flair_type\": \"text\", \"removal_reason\": null, \"link_id\": \"t3_9m1ya8\", \"author_flair_template_id\": null, \"likes\": null, \"replies\": {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"dist\": null, \"children\": [{\"kind\": \"t1\", \"data\": {\"subreddit_id\": \"t5_phv9h\", \"approved_at_utc\": null, \"ups\": 1, \"mod_reason_by\": null, \"banned_by\": null, \"author_flair_type\": \"text\", \"removal_reason\": null, \"link_id\": \"t3_9m1ya8\", \"author_flair_template_id\": null, \"likes\": true, \"replies\": \"\", \"user_reports\": [], \"saved\": false, \"id\": \"e7boewj\", \"banned_at_utc\": null, \"mod_reason_title\": null, \"gilded\": 0, \"archived\": false, \"removed\": false, \"no_follow\": false, \"author\": \"<TEST_SUBREDDIT>\", \"can_mod_post\": true, \"send_replies\": true, \"parent_id\": \"t1_e7b7z5y\", \"score\": 1, \"author_fullname\": \"t2_2cvck8ii\", \"report_reasons\": [], \"approved_by\": null, \"downs\": 0, \"ignore_reports\": false, \"body\": \"message\", \"edited\": false, \"author_flair_css_class\": null, \"collapsed\": false, \"author_flair_richtext\": [], \"is_submitter\": false, \"collapsed_reason\": null, \"body_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Emessage\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"spam\": false, \"stickied\": false, \"subreddit_type\": \"public\", \"can_gild\": false, \"gildings\": {\"gid_1\": 0, \"gid_2\": 0, \"gid_3\": 0}, \"approved\": false, \"author_flair_text_color\": null, \"score_hidden\": false, \"permalink\": \"/r/<TEST_SUBREDDIT>/comments/9m1ya8/epic_win/e7boewj/\", \"num_reports\": 0, \"name\": \"t1_e7boewj\", \"created\": 1538932439.0, \"subreddit\": \"<TEST_SUBREDDIT>\", \"author_flair_text\": null, \"rte_mode\": \"markdown\", \"created_utc\": 1538903639.0, \"subreddit_name_prefixed\": \"r/<TEST_SUBREDDIT>\", \"controversiality\": 0, \"depth\": 1, \"author_flair_background_color\": null, \"mod_reports\": [], \"mod_note\": null, \"distinguished\": \"moderator\"}}, {\"kind\": \"t1\", \"data\": {\"subreddit_id\": \"t5_phv9h\", \"approved_at_utc\": null, \"ups\": 1, \"mod_reason_by\": null, \"banned_by\": null, \"author_flair_type\": \"text\", \"removal_reason\": null, \"link_id\": \"t3_9m1ya8\", \"author_flair_template_id\": null, \"likes\": true, \"replies\": \"\", \"user_reports\": [], \"saved\": false, \"id\": \"e7bp5qw\", \"banned_at_utc\": null, \"mod_reason_title\": null, \"gilded\": 0, \"archived\": false, \"removed\": false, \"no_follow\": false, \"author\": \"<TEST_SUBREDDIT>\", \"can_mod_post\": true, \"send_replies\": true, \"parent_id\": \"t1_e7b7z5y\", \"score\": 1, \"author_fullname\": \"t2_2cvck8ii\", \"report_reasons\": [], \"approved_by\": null, \"downs\": 0, \"ignore_reports\": false, \"body\": \"message\", \"edited\": false, \"author_flair_css_class\": null, \"collapsed\": false, \"author_flair_richtext\": [], \"is_submitter\": false, \"collapsed_reason\": null, \"body_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Emessage\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"spam\": false, \"stickied\": false, \"subreddit_type\": \"public\", \"can_gild\": false, \"gildings\": {\"gid_1\": 0, \"gid_2\": 0, \"gid_3\": 0}, \"approved\": false, \"author_flair_text_color\": null, \"score_hidden\": false, \"permalink\": \"/r/<TEST_SUBREDDIT>/comments/9m1ya8/epic_win/e7bp5qw/\", \"num_reports\": 0, \"name\": \"t1_e7bp5qw\", \"created\": 1538934151.0, \"subreddit\": \"<TEST_SUBREDDIT>\", \"author_flair_text\": null, \"rte_mode\": \"markdown\", \"created_utc\": 1538905351.0, \"subreddit_name_prefixed\": \"r/<TEST_SUBREDDIT>\", \"controversiality\": 0, \"depth\": 1, \"author_flair_background_color\": null, \"mod_reports\": [], \"mod_note\": null, \"distinguished\": \"moderator\"}}, {\"kind\": \"t1\", \"data\": {\"subreddit_id\": \"t5_phv9h\", \"approved_at_utc\": null, \"ups\": 1, \"mod_reason_by\": null, \"banned_by\": null, \"author_flair_type\": \"text\", \"removal_reason\": null, \"link_id\": \"t3_9m1ya8\", \"author_flair_template_id\": null, \"likes\": true, \"replies\": \"\", \"user_reports\": [], \"saved\": false, \"id\": \"e7bpbl9\", \"banned_at_utc\": null, \"mod_reason_title\": null, \"gilded\": 0, \"archived\": false, \"removed\": false, \"no_follow\": false, \"author\": \"<TEST_SUBREDDIT>\", \"can_mod_post\": true, \"send_replies\": true, \"parent_id\": \"t1_e7b7z5y\", \"score\": 1, \"author_fullname\": \"t2_2cvck8ii\", \"report_reasons\": [], \"approved_by\": null, \"downs\": 0, \"ignore_reports\": false, \"body\": \"message\", \"edited\": false, \"author_flair_css_class\": null, \"collapsed\": false, \"author_flair_richtext\": [], \"is_submitter\": false, \"collapsed_reason\": null, \"body_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Emessage\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"spam\": false, \"stickied\": false, \"subreddit_type\": \"public\", \"can_gild\": false, \"gildings\": {\"gid_1\": 0, \"gid_2\": 0, \"gid_3\": 0}, \"approved\": false, \"author_flair_text_color\": null, \"score_hidden\": false, \"permalink\": \"/r/<TEST_SUBREDDIT>/comments/9m1ya8/epic_win/e7bpbl9/\", \"num_reports\": 0, \"name\": \"t1_e7bpbl9\", \"created\": 1538934527.0, \"subreddit\": \"<TEST_SUBREDDIT>\", \"author_flair_text\": null, \"rte_mode\": \"markdown\", \"created_utc\": 1538905727.0, \"subreddit_name_prefixed\": \"r/<TEST_SUBREDDIT>\", \"controversiality\": 0, \"depth\": 1, \"author_flair_background_color\": null, \"mod_reports\": [], \"mod_note\": null, \"distinguished\": \"moderator\"}}], \"after\": null, \"before\": null}}, \"user_reports\": [], \"ban_note\": \"remove not spam\", \"saved\": false, \"id\": \"e7b7z5y\", \"banned_at_utc\": 1538905725, \"mod_reason_title\": null, \"gilded\": 0, \"archived\": false, \"no_follow\": true, \"author\": \"NetwideRogue\", \"can_mod_post\": true, \"send_replies\": true, \"parent_id\": \"t3_9m1ya8\", \"score\": 1, \"author_fullname\": \"t2_28sly032\", \"report_reasons\": [], \"approved_by\": null, \"downs\": 0, \"ignore_reports\": false, \"body\": \"and this is a test comment\", \"edited\": false, \"author_flair_css_class\": null, \"collapsed\": false, \"author_flair_richtext\": [], \"is_submitter\": true, \"collapsed_reason\": null, \"gildings\": {\"gid_1\": 0, \"gid_2\": 0, \"gid_3\": 0}, \"stickied\": false, \"subreddit_type\": \"public\", \"can_gild\": true, \"removed\": true, \"approved\": false, \"author_flair_text_color\": null, \"score_hidden\": false, \"permalink\": \"/r/<TEST_SUBREDDIT>/comments/9m1ya8/epic_win/e7b7z5y/\", \"num_reports\": 0, \"name\": \"t1_e7b7z5y\", \"created\": 1538909500.0, \"subreddit\": \"<TEST_SUBREDDIT>\", \"author_flair_text\": null, \"spam\": false, \"created_utc\": 1538880700.0, \"subreddit_name_prefixed\": \"r/<TEST_SUBREDDIT>\", \"controversiality\": 0, \"depth\": 0, \"author_flair_background_color\": null, \"mod_reports\": [], \"body_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Eand this is a test comment\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"mod_note\": null, \"distinguished\": null}}, {\"kind\": \"t1\", \"data\": {\"subreddit_id\": \"t5_phv9h\", \"approved_at_utc\": null, \"ups\": 1, \"mod_reason_by\": null, \"banned_by\": null, \"author_flair_type\": \"text\", \"removal_reason\": null, \"link_id\": \"t3_9m1ya8\", \"author_flair_template_id\": null, \"likes\": true, \"replies\": \"\", \"user_reports\": [], \"body_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Emessage\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"saved\": false, \"id\": \"e7bozra\", \"banned_at_utc\": null, \"mod_reason_title\": null, \"gilded\": 0, \"archived\": false, \"no_follow\": false, \"author\": \"<TEST_SUBREDDIT>\", \"can_mod_post\": true, \"send_replies\": true, \"parent_id\": \"t3_9m1ya8\", \"score\": 1, \"author_fullname\": \"t2_2cvck8ii\", \"report_reasons\": [], \"approved_by\": null, \"downs\": 0, \"ignore_reports\": false, \"body\": \"message\", \"edited\": false, \"author_flair_css_class\": null, \"collapsed\": false, \"author_flair_richtext\": [], \"is_submitter\": false, \"collapsed_reason\": null, \"gildings\": {\"gid_1\": 0, \"gid_2\": 0, \"gid_3\": 0}, \"spam\": false, \"stickied\": false, \"subreddit_type\": \"public\", \"can_gild\": false, \"removed\": false, \"approved\": false, \"author_flair_text_color\": null, \"score_hidden\": false, \"permalink\": \"/r/<TEST_SUBREDDIT>/comments/9m1ya8/epic_win/e7bozra/\", \"num_reports\": 0, \"name\": \"t1_e7bozra\", \"created\": 1538933777.0, \"subreddit\": \"<TEST_SUBREDDIT>\", \"author_flair_text\": null, \"rte_mode\": \"markdown\", \"created_utc\": 1538904977.0, \"subreddit_name_prefixed\": \"r/<TEST_SUBREDDIT>\", \"controversiality\": 0, \"depth\": 0, \"author_flair_background_color\": null, \"mod_reports\": [], \"mod_note\": null, \"distinguished\": \"moderator\"}}, {\"kind\": \"t1\", \"data\": {\"subreddit_id\": \"t5_phv9h\", \"approved_at_utc\": null, \"ups\": 1, \"mod_reason_by\": null, \"banned_by\": null, \"author_flair_type\": \"text\", \"removal_reason\": null, \"link_id\": \"t3_9m1ya8\", \"author_flair_template_id\": null, \"likes\": true, \"replies\": \"\", \"user_reports\": [], \"body_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Emessage\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"saved\": false, \"id\": \"e7bp12y\", \"banned_at_utc\": null, \"mod_reason_title\": null, \"gilded\": 0, \"archived\": false, \"no_follow\": false, \"author\": \"<TEST_SUBREDDIT>\", \"can_mod_post\": true, \"send_replies\": true, \"parent_id\": \"t3_9m1ya8\", \"score\": 1, \"author_fullname\": \"t2_2cvck8ii\", \"report_reasons\": [], \"approved_by\": null, \"downs\": 0, \"ignore_reports\": false, \"body\": \"message\", \"edited\": false, \"author_flair_css_class\": null, \"collapsed\": false, \"author_flair_richtext\": [], \"is_submitter\": false, \"collapsed_reason\": null, \"gildings\": {\"gid_1\": 0, \"gid_2\": 0, \"gid_3\": 0}, \"spam\": false, \"stickied\": false, \"subreddit_type\": \"public\", \"can_gild\": false, \"removed\": false, \"approved\": false, \"author_flair_text_color\": null, \"score_hidden\": false, \"permalink\": \"/r/<TEST_SUBREDDIT>/comments/9m1ya8/epic_win/e7bp12y/\", \"num_reports\": 0, \"name\": \"t1_e7bp12y\", \"created\": 1538933862.0, \"subreddit\": \"<TEST_SUBREDDIT>\", \"author_flair_text\": null, \"rte_mode\": \"markdown\", \"created_utc\": 1538905062.0, \"subreddit_name_prefixed\": \"r/<TEST_SUBREDDIT>\", \"controversiality\": 0, \"depth\": 0, \"author_flair_background_color\": null, \"mod_reports\": [], \"mod_note\": null, \"distinguished\": \"moderator\"}}, {\"kind\": \"t1\", \"data\": {\"subreddit_id\": \"t5_phv9h\", \"approved_at_utc\": null, \"ups\": 1, \"mod_reason_by\": null, \"banned_by\": null, \"author_flair_type\": \"text\", \"removal_reason\": null, \"link_id\": \"t3_9m1ya8\", \"author_flair_template_id\": null, \"likes\": true, \"replies\": \"\", \"user_reports\": [], \"body_html\": \"\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Emessage\\u003C/p\\u003E\\n\\u003C/div\\u003E\", \"saved\": false, \"id\": \"e7bp63f\", \"banned_at_utc\": null, \"mod_reason_title\": null, \"gilded\": 0, \"archived\": false, \"no_follow\": false, \"author\": \"<TEST_SUBREDDIT>\", \"can_mod_post\": true, \"send_replies\": true, \"parent_id\": \"t3_9m1ya8\", \"score\": 1, \"author_fullname\": \"t2_2cvck8ii\", \"report_reasons\": [], \"approved_by\": null, \"downs\": 0, \"ignore_reports\": false, \"body\": \"message\", \"edited\": false, \"author_flair_css_class\": null, \"collapsed\": false, \"author_flair_richtext\": [], \"is_submitter\": false, \"collapsed_reason\": null, \"gildings\": {\"gid_1\": 0, \"gid_2\": 0, \"gid_3\": 0}, \"spam\": false, \"stickied\": false, \"subreddit_type\": \"public\", \"can_gild\": false, \"removed\": false, \"approved\": false, \"author_flair_text_color\": null, \"score_hidden\": false, \"permalink\": \"/r/<TEST_SUBREDDIT>/comments/9m1ya8/epic_win/e7bp63f/\", \"num_reports\": 0, \"name\": \"t1_e7bp63f\", \"created\": 1538934172.0, \"subreddit\": \"<TEST_SUBREDDIT>\", \"author_flair_text\": null, \"rte_mode\": \"markdown\", \"created_utc\": 1538905372.0, \"subreddit_name_prefixed\": \"r/<TEST_SUBREDDIT>\", \"controversiality\": 0, \"depth\": 0, \"author_flair_background_color\": null, \"mod_reports\": [], \"mod_note\": null, \"distinguished\": \"moderator\"}}], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "15720"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 07 Oct 2018 09:52:57 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Vary": [
+            "accept-encoding"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18926-SYD"
+          ],
+          "X-Timer": [
+            "S1538905977.074923,VS0,VE535"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "588.0"
+          ],
+          "x-ratelimit-reset": [
+            "423"
+          ],
+          "x-ratelimit-used": [
+            "12"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/comments/9m1ya8/?limit=2048&sort=best&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-10-07T09:53:09",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "edgebucket=90wMZMrOntsLJfOXB2"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/api/v1/<TEST_SUBREDDIT>/removal_reasons?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"data\": {\"11qjnfc3wdghj\": {\"message\": \"Test Reason Message\", \"id\": \"11qjnfc3wdghj\", \"title\": \"Test Reason Title\"}, \"11qiw1rp2mlqd\": {\"message\": \"This is a test removal reason\", \"id\": \"11qiw1rp2mlqd\", \"title\": \"Test removal reason...\"}, \"11qpplj402nbj\": {\"message\": \"new message\", \"id\": \"11qpplj402nbj\", \"title\": \"New test\"}, \"11qqjwr033xba\": {\"message\": \"adding a test reason\", \"id\": \"11qqjwr033xba\", \"title\": \"test\"}, \"11qjnh8qcsbdj\": {\"message\": \"new message\", \"id\": \"11qjnh8qcsbdj\", \"title\": \"new title\"}, \"11qqi94tnyzae\": {\"message\": \"adding a test reason\", \"id\": \"11qqi94tnyzae\", \"title\": \"test\"}, \"11qobsiud9b5v\": {\"message\": \"used in the getitem test\", \"id\": \"11qobsiud9b5v\", \"title\": \"Get Test Reason\"}, \"11qq98vi9vjo1\": {\"message\": \"adding a test reason\", \"id\": \"11qq98vi9vjo1\", \"title\": \"test\"}, \"11qq89lls191u\": {\"message\": \"adding a test reason\", \"id\": \"11qq89lls191u\", \"title\": \"test\"}, \"11qpdeyfmjj26\": {\"message\": \"adding a new removal reason without fetching the existing ones!\", \"id\": \"11qpdeyfmjj26\", \"title\": \"Fetch test\"}, \"11qo9awftokz1\": {\"message\": \"now this reason is being edited\", \"id\": \"11qo9awftokz1\", \"title\": \"Edit Test Reason\"}, \"11qpoe6c636p5\": {\"message\": \"Test Reason Message\", \"id\": \"11qpoe6c636p5\", \"title\": \"Test Reason\"}}, \"order\": [\"11qiw1rp2mlqd\", \"11qjnfc3wdghj\", \"11qjnh8qcsbdj\", \"11qo9awftokz1\", \"11qobsiud9b5v\", \"11qpdeyfmjj26\", \"11qpoe6c636p5\", \"11qpplj402nbj\", \"11qq89lls191u\", \"11qq98vi9vjo1\", \"11qqi94tnyzae\", \"11qqjwr033xba\"]}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1476"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 07 Oct 2018 09:53:06 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Vary": [
+            "accept-encoding"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18926-SYD"
+          ],
+          "X-Timer": [
+            "S1538905987.686014,VS0,VE259"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "587.0"
+          ],
+          "x-ratelimit-reset": [
+            "414"
+          ],
+          "x-ratelimit-used": [
+            "13"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/<TEST_SUBREDDIT>/removal_reasons?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-10-07T09:53:12",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t3_9m1ya8&spam=False"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "37"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "edgebucket=90wMZMrOntsLJfOXB2"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/remove/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 07 Oct 2018 09:53:10 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18926-SYD"
+          ],
+          "X-Timer": [
+            "S1538905989.098964,VS0,VE1125"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "586.0"
+          ],
+          "x-ratelimit-reset": [
+            "411"
+          ],
+          "x-ratelimit-used": [
+            "14"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/remove/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-10-07T09:53:14",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t1_e7b7z5y&spam=False"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "38"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "edgebucket=90wMZMrOntsLJfOXB2"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/remove/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 07 Oct 2018 09:53:13 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18926-SYD"
+          ],
+          "X-Timer": [
+            "S1538905993.726171,VS0,VE342"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "585.0"
+          ],
+          "x-ratelimit-reset": [
+            "408"
+          ],
+          "x-ratelimit-used": [
+            "15"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/remove/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-10-07T09:53:15",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"item_ids\": [\"t3_9m1ya8\", \"t1_e7b7z5y\"], \"reason_id\": \"11qiw1rp2mlqd\", \"mod_note\": \"this is a note\"}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "101"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Cookie": [
+            "edgebucket=90wMZMrOntsLJfOXB2"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/v1/modactions/removal_reasons?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "0"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 07 Oct 2018 09:53:14 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18926-SYD"
+          ],
+          "X-Timer": [
+            "S1538905994.406187,VS0,VE266"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "584.0"
+          ],
+          "x-ratelimit-reset": [
+            "406"
+          ],
+          "x-ratelimit-used": [
+            "16"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/modactions/removal_reasons?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-10-07T09:53:17",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"item_ids\": [\"t3_9m1ya8\", \"t1_e7b7z5y\"], \"reason_id\": null, \"mod_note\": \"this is still a note\"}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "96"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Cookie": [
+            "edgebucket=90wMZMrOntsLJfOXB2"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/v1/modactions/removal_reasons?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "0"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 07 Oct 2018 09:53:15 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18926-SYD"
+          ],
+          "X-Timer": [
+            "S1538905995.484391,VS0,VE275"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "583.0"
+          ],
+          "x-ratelimit-reset": [
+            "405"
+          ],
+          "x-ratelimit-used": [
+            "17"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/modactions/removal_reasons?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-10-07T09:53:20",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"item_ids\": [\"t3_9m1ya8\", \"t1_e7b7z5y\"], \"reason_id\": \"11qiw1rp2mlqd\", \"mod_note\": \"\"}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "87"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Cookie": [
+            "edgebucket=90wMZMrOntsLJfOXB2"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/v1/modactions/removal_reasons?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "0"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 07 Oct 2018 09:53:18 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18926-SYD"
+          ],
+          "X-Timer": [
+            "S1538905998.794357,VS0,VE934"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "582.0"
+          ],
+          "x-ratelimit-reset": [
+            "402"
+          ],
+          "x-ratelimit-used": [
+            "18"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/modactions/removal_reasons?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/integration/cassettes/TestSubredditRemovalReasons.test__getitem.json
+++ b/tests/integration/cassettes/TestSubredditRemovalReasons.test__getitem.json
@@ -1,0 +1,216 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-10-07T09:50:54",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "207"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "118"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 07 Oct 2018 09:50:51 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "edgebucket=P6e1JGRnHQj23Idv3Y; Domain=reddit.com; Max-Age=63071999; Path=/;  secure"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18932-SYD"
+          ],
+          "X-Timer": [
+            "S1538905851.197136,VS0,VE497"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2018-10-07T09:51:02",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "edgebucket=P6e1JGRnHQj23Idv3Y"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/api/v1/<TEST_SUBREDDIT>/removal_reasons?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"data\": {\"11qjnfc3wdghj\": {\"message\": \"Test Reason Message\", \"id\": \"11qjnfc3wdghj\", \"title\": \"Test Reason Title\"}, \"11qiw1rp2mlqd\": {\"message\": \"This is a test removal reason\", \"id\": \"11qiw1rp2mlqd\", \"title\": \"Test removal reason...\"}, \"11qpplj402nbj\": {\"message\": \"new message\", \"id\": \"11qpplj402nbj\", \"title\": \"New test\"}, \"11qjnh8qcsbdj\": {\"message\": \"new message\", \"id\": \"11qjnh8qcsbdj\", \"title\": \"new title\"}, \"11qqi94tnyzae\": {\"message\": \"adding a test reason\", \"id\": \"11qqi94tnyzae\", \"title\": \"test\"}, \"11qobsiud9b5v\": {\"message\": \"used in the getitem test\", \"id\": \"11qobsiud9b5v\", \"title\": \"Get Test Reason\"}, \"11qq98vi9vjo1\": {\"message\": \"adding a test reason\", \"id\": \"11qq98vi9vjo1\", \"title\": \"test\"}, \"11qq89lls191u\": {\"message\": \"adding a test reason\", \"id\": \"11qq89lls191u\", \"title\": \"test\"}, \"11qpdeyfmjj26\": {\"message\": \"adding a new removal reason without fetching the existing ones!\", \"id\": \"11qpdeyfmjj26\", \"title\": \"Fetch test\"}, \"11qo9awftokz1\": {\"message\": \"now this reason is being edited\", \"id\": \"11qo9awftokz1\", \"title\": \"Edit Test Reason\"}, \"11qpoe6c636p5\": {\"message\": \"Test Reason Message\", \"id\": \"11qpoe6c636p5\", \"title\": \"Test Reason\"}}, \"order\": [\"11qiw1rp2mlqd\", \"11qjnfc3wdghj\", \"11qjnh8qcsbdj\", \"11qo9awftokz1\", \"11qobsiud9b5v\", \"11qpdeyfmjj26\", \"11qpoe6c636p5\", \"11qpplj402nbj\", \"11qq89lls191u\", \"11qq98vi9vjo1\", \"11qqi94tnyzae\"]}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1365"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 07 Oct 2018 09:50:59 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Vary": [
+            "accept-encoding"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18920-SYD"
+          ],
+          "X-Timer": [
+            "S1538905859.333332,VS0,VE249"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "596.0"
+          ],
+          "x-ratelimit-reset": [
+            "541"
+          ],
+          "x-ratelimit-used": [
+            "4"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/<TEST_SUBREDDIT>/removal_reasons?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/integration/cassettes/TestSubredditRemovalReasons.test__iter.json
+++ b/tests/integration/cassettes/TestSubredditRemovalReasons.test__iter.json
@@ -1,0 +1,216 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-10-07T09:51:21",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "207"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "118"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 07 Oct 2018 09:51:18 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "edgebucket=GjsFgDEDOudJd8lrAT; Domain=reddit.com; Max-Age=63071999; Path=/;  secure"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18920-SYD"
+          ],
+          "X-Timer": [
+            "S1538905878.836547,VS0,VE512"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2018-10-07T09:51:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "edgebucket=GjsFgDEDOudJd8lrAT"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/api/v1/<TEST_SUBREDDIT>/removal_reasons?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"data\": {\"11qjnfc3wdghj\": {\"message\": \"Test Reason Message\", \"id\": \"11qjnfc3wdghj\", \"title\": \"Test Reason Title\"}, \"11qiw1rp2mlqd\": {\"message\": \"This is a test removal reason\", \"id\": \"11qiw1rp2mlqd\", \"title\": \"Test removal reason...\"}, \"11qpplj402nbj\": {\"message\": \"new message\", \"id\": \"11qpplj402nbj\", \"title\": \"New test\"}, \"11qjnh8qcsbdj\": {\"message\": \"new message\", \"id\": \"11qjnh8qcsbdj\", \"title\": \"new title\"}, \"11qqi94tnyzae\": {\"message\": \"adding a test reason\", \"id\": \"11qqi94tnyzae\", \"title\": \"test\"}, \"11qobsiud9b5v\": {\"message\": \"used in the getitem test\", \"id\": \"11qobsiud9b5v\", \"title\": \"Get Test Reason\"}, \"11qq98vi9vjo1\": {\"message\": \"adding a test reason\", \"id\": \"11qq98vi9vjo1\", \"title\": \"test\"}, \"11qq89lls191u\": {\"message\": \"adding a test reason\", \"id\": \"11qq89lls191u\", \"title\": \"test\"}, \"11qpdeyfmjj26\": {\"message\": \"adding a new removal reason without fetching the existing ones!\", \"id\": \"11qpdeyfmjj26\", \"title\": \"Fetch test\"}, \"11qo9awftokz1\": {\"message\": \"now this reason is being edited\", \"id\": \"11qo9awftokz1\", \"title\": \"Edit Test Reason\"}, \"11qpoe6c636p5\": {\"message\": \"Test Reason Message\", \"id\": \"11qpoe6c636p5\", \"title\": \"Test Reason\"}}, \"order\": [\"11qiw1rp2mlqd\", \"11qjnfc3wdghj\", \"11qjnh8qcsbdj\", \"11qo9awftokz1\", \"11qobsiud9b5v\", \"11qpdeyfmjj26\", \"11qpoe6c636p5\", \"11qpplj402nbj\", \"11qq89lls191u\", \"11qq98vi9vjo1\", \"11qqi94tnyzae\"]}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1365"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 07 Oct 2018 09:51:29 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Vary": [
+            "accept-encoding"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18921-SYD"
+          ],
+          "X-Timer": [
+            "S1538905889.432176,VS0,VE254"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "595.0"
+          ],
+          "x-ratelimit-reset": [
+            "511"
+          ],
+          "x-ratelimit-used": [
+            "5"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/<TEST_SUBREDDIT>/removal_reasons?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/integration/cassettes/TestSubredditRemovalReasons.test_add.json
+++ b/tests/integration/cassettes/TestSubredditRemovalReasons.test_add.json
@@ -1,0 +1,329 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2018-10-07T09:51:40",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "207"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "118"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 07 Oct 2018 09:51:38 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "edgebucket=KKL1HcEPWjbhdHKjxJ; Domain=reddit.com; Max-Age=63071999; Path=/;  secure"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18934-SYD"
+          ],
+          "X-Timer": [
+            "S1538905898.070428,VS0,VE498"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2018-10-07T09:52:07",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&message=adding+a+test+reason&title=test"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "53"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "edgebucket=KKL1HcEPWjbhdHKjxJ"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/v1/<TEST_SUBREDDIT>/removal_reasons?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"id\": \"11qqjwr033xba\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "23"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 07 Oct 2018 09:52:07 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18927-SYD"
+          ],
+          "X-Timer": [
+            "S1538905927.524248,VS0,VE508"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "594.0"
+          ],
+          "x-ratelimit-reset": [
+            "474"
+          ],
+          "x-ratelimit-used": [
+            "6"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/<TEST_SUBREDDIT>/removal_reasons?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2018-10-07T09:52:09",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "edgebucket=KKL1HcEPWjbhdHKjxJ"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/api/v1/<TEST_SUBREDDIT>/removal_reasons?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"data\": {\"11qjnfc3wdghj\": {\"message\": \"Test Reason Message\", \"id\": \"11qjnfc3wdghj\", \"title\": \"Test Reason Title\"}, \"11qiw1rp2mlqd\": {\"message\": \"This is a test removal reason\", \"id\": \"11qiw1rp2mlqd\", \"title\": \"Test removal reason...\"}, \"11qpplj402nbj\": {\"message\": \"new message\", \"id\": \"11qpplj402nbj\", \"title\": \"New test\"}, \"11qqjwr033xba\": {\"message\": \"adding a test reason\", \"id\": \"11qqjwr033xba\", \"title\": \"test\"}, \"11qjnh8qcsbdj\": {\"message\": \"new message\", \"id\": \"11qjnh8qcsbdj\", \"title\": \"new title\"}, \"11qqi94tnyzae\": {\"message\": \"adding a test reason\", \"id\": \"11qqi94tnyzae\", \"title\": \"test\"}, \"11qobsiud9b5v\": {\"message\": \"used in the getitem test\", \"id\": \"11qobsiud9b5v\", \"title\": \"Get Test Reason\"}, \"11qq98vi9vjo1\": {\"message\": \"adding a test reason\", \"id\": \"11qq98vi9vjo1\", \"title\": \"test\"}, \"11qq89lls191u\": {\"message\": \"adding a test reason\", \"id\": \"11qq89lls191u\", \"title\": \"test\"}, \"11qpdeyfmjj26\": {\"message\": \"adding a new removal reason without fetching the existing ones!\", \"id\": \"11qpdeyfmjj26\", \"title\": \"Fetch test\"}, \"11qo9awftokz1\": {\"message\": \"now this reason is being edited\", \"id\": \"11qo9awftokz1\", \"title\": \"Edit Test Reason\"}, \"11qpoe6c636p5\": {\"message\": \"Test Reason Message\", \"id\": \"11qpoe6c636p5\", \"title\": \"Test Reason\"}}, \"order\": [\"11qiw1rp2mlqd\", \"11qjnfc3wdghj\", \"11qjnh8qcsbdj\", \"11qo9awftokz1\", \"11qobsiud9b5v\", \"11qpdeyfmjj26\", \"11qpoe6c636p5\", \"11qpplj402nbj\", \"11qq89lls191u\", \"11qq98vi9vjo1\", \"11qqi94tnyzae\", \"11qqjwr033xba\"]}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1476"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 07 Oct 2018 09:52:08 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Vary": [
+            "accept-encoding"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18927-SYD"
+          ],
+          "X-Timer": [
+            "S1538905928.936559,VS0,VE257"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "593.0"
+          ],
+          "x-ratelimit-reset": [
+            "472"
+          ],
+          "x-ratelimit-used": [
+            "7"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/<TEST_SUBREDDIT>/removal_reasons?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/integration/models/reddit/test_comment.py
+++ b/tests/integration/models/reddit/test_comment.py
@@ -254,7 +254,7 @@ class TestCommentModeration(IntegrationTest):
             mod.remove()
             message = "message"
             res = [mod.send_removal_message(t, "title", message)
-                for t in ("public", "private", "private_exposed")]
+                   for t in ("public", "private", "private_exposed")]
             assert isinstance(res[0], Comment)
             assert res[0].parent_id == "t1_" + comment.id
             assert res[0].body == message

--- a/tests/integration/models/reddit/test_comment.py
+++ b/tests/integration/models/reddit/test_comment.py
@@ -244,6 +244,23 @@ class TestCommentModeration(IntegrationTest):
                 'TestCommentModeration.test_remove'):
             self.reddit.comment('da2g5y6').mod.remove(spam=True)
 
+    @mock.patch('time.sleep', return_value=None)
+    def test_send_removal_message(self, _):
+        self.reddit.read_only = False
+        with self.recorder.use_cassette(
+                'TestCommentModeration.test_send_removal_message'):
+            comment = self.reddit.comment('e7b7z5y')
+            mod = comment.mod
+            mod.remove()
+            message = "message"
+            res = [mod.send_removal_message(t, "title", message)
+                for t in ("public", "private", "private_exposed")]
+            assert isinstance(res[0], Comment)
+            assert res[0].parent_id == "t1_" + comment.id
+            assert res[0].body == message
+            assert res[1] is None
+            assert res[2] is None
+
     def test_undistinguish(self):
         self.reddit.read_only = False
         with self.recorder.use_cassette(

--- a/tests/integration/models/reddit/test_comment.py
+++ b/tests/integration/models/reddit/test_comment.py
@@ -252,11 +252,11 @@ class TestCommentModeration(IntegrationTest):
             comment = self.reddit.comment('e7b7z5y')
             mod = comment.mod
             mod.remove()
-            message = "message"
-            res = [mod.send_removal_message(t, "title", message)
-                   for t in ("public", "private", "private_exposed")]
+            message = 'message'
+            res = [mod.send_removal_message(t, 'title', message)
+                   for t in ('public', 'private', 'private_exposed')]
             assert isinstance(res[0], Comment)
-            assert res[0].parent_id == "t1_" + comment.id
+            assert res[0].parent_id == 't1_' + comment.id
             assert res[0].body == message
             assert res[1] is None
             assert res[2] is None

--- a/tests/integration/models/reddit/test_removalreason.py
+++ b/tests/integration/models/reddit/test_removalreason.py
@@ -38,7 +38,7 @@ class TestRemovalReason(IntegrationTest):
         self.reddit.read_only = False
         subreddit = self.reddit.subreddit(pytest.placeholders.test_subreddit)
         reason = subreddit.removal_reasons['11qo9awftokz1']
-        newmessage = "now this reason is being edited"
+        newmessage = 'now this reason is being edited'
         with self.recorder.use_cassette('TestRemovalReason.test_edit'):
             reason.edit(reason.title, newmessage)
 
@@ -75,8 +75,8 @@ class TestSubredditRemovalReasons(IntegrationTest):
     def test_add(self, _):
         self.reddit.read_only = False
         subreddit = self.reddit.subreddit(pytest.placeholders.test_subreddit)
-        title = "test"
-        message = "adding a test reason"
+        title = 'test'
+        message = 'adding a test reason'
         with self.recorder.use_cassette(
                 'TestSubredditRemovalReasons.test_add'):
             reason = subreddit.removal_reasons.add(title, message)

--- a/tests/integration/models/reddit/test_removalreason.py
+++ b/tests/integration/models/reddit/test_removalreason.py
@@ -22,8 +22,8 @@ class TestRemovalReason(IntegrationTest):
             with pytest.raises(ClientException) as excinfo:
                 fake.title
             assert (str(excinfo.value) ==
-                '/r/{} does not have the removal reason {}'.format(subreddit,
-                    fake_id))
+                    '/r/{} does not have the removal reason {}'.format(
+                    subreddit, fake_id))
 
     @mock.patch('time.sleep', return_value=None)
     def test_delete(self, _):
@@ -38,8 +38,6 @@ class TestRemovalReason(IntegrationTest):
         self.reddit.read_only = False
         subreddit = self.reddit.subreddit(pytest.placeholders.test_subreddit)
         reason = subreddit.removal_reasons['11qo9awftokz1']
-        oldtitle = reason.title
-        oldmessage = reason.message
         newmessage = "now this reason is being edited"
         with self.recorder.use_cassette('TestRemovalReason.test_edit'):
             reason.edit(reason.title, newmessage)
@@ -51,7 +49,7 @@ class TestSubredditRemovalReasons(IntegrationTest):
         self.reddit.read_only = False
         subreddit = self.reddit.subreddit(pytest.placeholders.test_subreddit)
         with self.recorder.use_cassette(
-            'TestSubredditRemovalReasons.test__getitem'):
+                'TestSubredditRemovalReasons.test__getitem'):
             reason1 = subreddit.removal_reasons[5]
             reason2 = subreddit.removal_reasons[reason1.id]
             assert reason1 == reason2
@@ -63,7 +61,7 @@ class TestSubredditRemovalReasons(IntegrationTest):
         self.reddit.read_only = False
         subreddit = self.reddit.subreddit(pytest.placeholders.test_subreddit)
         with self.recorder.use_cassette(
-            'TestSubredditRemovalReasons.test__iter'):
+                'TestSubredditRemovalReasons.test__iter'):
             count = 0
             seen = set()
             for reason in subreddit.removal_reasons:
@@ -71,7 +69,7 @@ class TestSubredditRemovalReasons(IntegrationTest):
                 seen.add(reason)
                 count += 1
             assert count > 0
-            assert count == len(seen) # No duplicates
+            assert count == len(seen)  # No duplicates
 
     @mock.patch('time.sleep', return_value=None)
     def test_add(self, _):
@@ -79,7 +77,8 @@ class TestSubredditRemovalReasons(IntegrationTest):
         subreddit = self.reddit.subreddit(pytest.placeholders.test_subreddit)
         title = "test"
         message = "adding a test reason"
-        with self.recorder.use_cassette('TestSubredditRemovalReasons.test_add'):
+        with self.recorder.use_cassette(
+                'TestSubredditRemovalReasons.test_add'):
             reason = subreddit.removal_reasons.add(title, message)
             assert isinstance(reason, RemovalReason)
             assert reason == subreddit.removal_reasons[reason.id]

--- a/tests/integration/models/reddit/test_removalreason.py
+++ b/tests/integration/models/reddit/test_removalreason.py
@@ -1,0 +1,87 @@
+from praw.exceptions import ClientException
+from praw.models import RemovalReason
+import mock
+import pytest
+
+from ... import IntegrationTest
+
+
+class TestRemovalReason(IntegrationTest):
+    @mock.patch('time.sleep', return_value=None)
+    def test__fetch(self, _):
+        self.reddit.read_only = False
+        subreddit = self.reddit.subreddit(pytest.placeholders.test_subreddit)
+        real_id = '11qpoe6c636p5'
+        fake_id = '11qaaaaaaaaaa'
+        real = subreddit.removal_reasons[real_id]
+        fake = subreddit.removal_reasons[fake_id]
+        with self.recorder.use_cassette('TestRemovalReason.test__fetch'):
+            assert real.title
+            assert real.message
+            assert real._fetched
+            with pytest.raises(ClientException) as excinfo:
+                fake.title
+            assert (str(excinfo.value) ==
+                '/r/{} does not have the removal reason {}'.format(subreddit,
+                    fake_id))
+
+    @mock.patch('time.sleep', return_value=None)
+    def test_delete(self, _):
+        self.reddit.read_only = False
+        subreddit = self.reddit.subreddit(pytest.placeholders.test_subreddit)
+        reason = subreddit.removal_reasons['11qqil974lade']
+        with self.recorder.use_cassette('TestRemovalReason.test_delete'):
+            reason.delete()
+
+    @mock.patch('time.sleep', return_value=None)
+    def test_edit(self, _):
+        self.reddit.read_only = False
+        subreddit = self.reddit.subreddit(pytest.placeholders.test_subreddit)
+        reason = subreddit.removal_reasons['11qo9awftokz1']
+        oldtitle = reason.title
+        oldmessage = reason.message
+        newmessage = "now this reason is being edited"
+        with self.recorder.use_cassette('TestRemovalReason.test_edit'):
+            reason.edit(reason.title, newmessage)
+
+
+class TestSubredditRemovalReasons(IntegrationTest):
+    @mock.patch('time.sleep', return_value=None)
+    def test__getitem(self, _):
+        self.reddit.read_only = False
+        subreddit = self.reddit.subreddit(pytest.placeholders.test_subreddit)
+        with self.recorder.use_cassette(
+            'TestSubredditRemovalReasons.test__getitem'):
+            reason1 = subreddit.removal_reasons[5]
+            reason2 = subreddit.removal_reasons[reason1.id]
+            assert reason1 == reason2
+            assert isinstance(reason1, RemovalReason)
+            assert isinstance(reason2, RemovalReason)
+
+    @mock.patch('time.sleep', return_value=None)
+    def test__iter(self, _):
+        self.reddit.read_only = False
+        subreddit = self.reddit.subreddit(pytest.placeholders.test_subreddit)
+        with self.recorder.use_cassette(
+            'TestSubredditRemovalReasons.test__iter'):
+            count = 0
+            seen = set()
+            for reason in subreddit.removal_reasons:
+                assert isinstance(reason, RemovalReason)
+                seen.add(reason)
+                count += 1
+            assert count > 0
+            assert count == len(seen) # No duplicates
+
+    @mock.patch('time.sleep', return_value=None)
+    def test_add(self, _):
+        self.reddit.read_only = False
+        subreddit = self.reddit.subreddit(pytest.placeholders.test_subreddit)
+        title = "test"
+        message = "adding a test reason"
+        with self.recorder.use_cassette('TestSubredditRemovalReasons.test_add'):
+            reason = subreddit.removal_reasons.add(title, message)
+            assert isinstance(reason, RemovalReason)
+            assert reason == subreddit.removal_reasons[reason.id]
+            assert reason.title == title
+            assert reason.message == message

--- a/tests/integration/models/reddit/test_submission.py
+++ b/tests/integration/models/reddit/test_submission.py
@@ -305,11 +305,11 @@ class TestSubmissionModeration(IntegrationTest):
             submission = self.reddit.submission('9m1ya8')
             mod = submission.mod
             mod.remove()
-            message = "message"
-            res = [mod.send_removal_message(t, "title", message)
-                   for t in ("public", "private", "private_exposed")]
+            message = 'message'
+            res = [mod.send_removal_message(t, 'title', message)
+                   for t in ('public', 'private', 'private_exposed')]
             assert isinstance(res[0], Comment)
-            assert res[0].parent_id == "t3_" + submission.id
+            assert res[0].parent_id == 't3_' + submission.id
             assert res[0].stickied
             assert res[0].body == message
             assert res[1] is None
@@ -327,8 +327,8 @@ class TestSubmissionModeration(IntegrationTest):
             reason = subreddit.removal_reasons[0]
             submission.mod.remove()
             comment.mod.remove()
-            mod.set_removal_reason(reason, "this is a note", [comment])
-            mod.set_removal_reason(None, "this is still a note", [comment])
+            mod.set_removal_reason(reason, 'this is a note', [comment])
+            mod.set_removal_reason(None, 'this is still a note', [comment])
             mod.set_removal_reason(reason, other_things=[comment])
 
     def test_sfw(self):

--- a/tests/integration/models/reddit/test_submission.py
+++ b/tests/integration/models/reddit/test_submission.py
@@ -307,7 +307,7 @@ class TestSubmissionModeration(IntegrationTest):
             mod.remove()
             message = "message"
             res = [mod.send_removal_message(t, "title", message)
-                for t in ("public", "private", "private_exposed")]
+                   for t in ("public", "private", "private_exposed")]
             assert isinstance(res[0], Comment)
             assert res[0].parent_id == "t3_" + submission.id
             assert res[0].stickied

--- a/tests/unit/models/reddit/mixins/test_thingmoderationmixin.py
+++ b/tests/unit/models/reddit/mixins/test_thingmoderationmixin.py
@@ -1,0 +1,12 @@
+import pytest
+from praw.models.reddit.mixins import ThingModerationMixin
+
+from .... import UnitTest
+
+
+class TestThingModerationMixin(UnitTest):
+    def test_must_be_extended(self):
+        with pytest.raises(NotImplementedError) as excinfo:
+            ThingModerationMixin().send_removal_message('public',
+                                                        'title', 'message')
+        assert str(excinfo.value) == 'ThingModerationMixin must be extended.'

--- a/tests/unit/models/reddit/test_removalreason.py
+++ b/tests/unit/models/reddit/test_removalreason.py
@@ -1,0 +1,55 @@
+import pickle
+
+from praw.models import Subreddit, RemovalReason
+from praw.models.reddit.removalreason import SubredditRemovalReasons
+
+from ... import UnitTest
+
+
+class TestRemovalReason(UnitTest):
+    def test_equality(self):
+        reason1 = RemovalReason(self.reddit, Subreddit(self.reddit, 'a'),
+                                '11qiw1rp2mlqd')
+        reason2 = RemovalReason(self.reddit, Subreddit(self.reddit, 'a'),
+                                '11qiw1rp2mlqd')
+        reason3 = RemovalReason(self.reddit, Subreddit(self.reddit, 'b'),
+                                '11qjnfc3wdghj')
+        assert reason1 == reason1
+        assert reason1 == reason2
+        assert reason2 != reason3
+        assert reason3 == '11qjnfc3wdghj'
+        assert reason2 != '11qjnfc3wdghj'
+
+    def test_hash(self):
+        reason1 = RemovalReason(self.reddit, Subreddit(self.reddit, 'a'),
+                                '11qiw1rp2mlqd')
+        reason2 = RemovalReason(self.reddit, Subreddit(self.reddit, 'a'),
+                                '11qiw1rp2mlqd')
+        reason3 = RemovalReason(self.reddit, Subreddit(self.reddit, 'b'),
+                                '11qjnfc3wdghj')
+        assert hash(reason1) == hash(reason1)
+        assert hash(reason1) == hash(reason2)
+        assert hash(reason2) != hash(reason3)
+
+    def test_pickle(self):
+        reason = RemovalReason(self.reddit, Subreddit(self.reddit, 'a'),
+                               '11qiw1rp2mlqd')
+        for level in range(pickle.HIGHEST_PROTOCOL + 1):
+            other = pickle.loads(pickle.dumps(reason, protocol=level))
+            assert reason == other
+
+    def test_repr(self):
+        reason = RemovalReason(self.reddit, Subreddit(self.reddit, 'a'),
+                               '11qiw1rp2mlqd')
+        assert repr(reason) == ("RemovalReason(id='11qiw1rp2mlqd')")
+
+    def test_str(self):
+        reason = RemovalReason(self.reddit, Subreddit(self.reddit, 'a'),
+                               '11qiw1rp2mlqd')
+        assert str(reason) == '11qiw1rp2mlqd'
+
+
+class TestSubredditEmoji(UnitTest):
+    def test_repr(self):
+        se = SubredditRemovalReasons(subreddit=Subreddit(self.reddit, 'a'))
+        assert repr(se)  # assert it has some repr


### PR DESCRIPTION

## Feature Summary and Justification

Adds support for the new removal-reason-related API endpoints: adding, editing, and deleting the removal reasons of subreddits, setting the removal reasons of submissions and comments, and sending removal messages about submissions and comments. 

It's possible to set one removal reason and note on many Things at once.  The support for that here mimics other bulk operations in PRAW.

There's a new string-enum (passed directly to the API), with options explained in the docstring for send_removal_message.

Some of these endpoints won't accept URL encoded input.  Requests are sent using prawcore in these cases, because I couldn't see another way to send JSON encoded input.

## References

These endpoints are undocumented, so I spent a while using removal reasons in the redesign and watching the requests to see how they worked.