### PR TITLE
Add key_name param to stream generator

### DIFF
--- a/praw/models/util.py
+++ b/praw/models/util.py
@@ -76,7 +76,8 @@ def permissions_string(permissions, known_permissions):
     return ','.join(to_set)
 
 
-def stream_generator(function, pause_after=None, skip_existing=False, key_name="fullname"):
+def stream_generator(function, pause_after=None, skip_existing=False,
+                     key_name="fullname"):
     """Yield new items from ListingGenerators and ``None`` when paused.
 
     :param function: A callable that returns a ListingGenerator, e.g.

--- a/praw/models/util.py
+++ b/praw/models/util.py
@@ -77,7 +77,7 @@ def permissions_string(permissions, known_permissions):
 
 
 def stream_generator(function, pause_after=None, skip_existing=False,
-                     key_name='fullname'):
+                     attribute_name='fullname'):
     """Yield new items from ListingGenerators and ``None`` when paused.
 
     :param function: A callable that returns a ListingGenerator, e.g.
@@ -154,30 +154,30 @@ def stream_generator(function, pause_after=None, skip_existing=False,
            print(comment)
 
     """
-    before_fullname = None
+    before_attribute = None
     exponential_counter = ExponentialCounter(max_counter=16)
-    seen_fullnames = BoundedSet(301)
+    seen_attributes = BoundedSet(301)
     without_before_counter = 0
     responses_without_new = 0
     valid_pause_after = pause_after is not None
     while True:
         found = False
-        newest_fullname = None
+        newest_attribute = None
         limit = 100
-        if before_fullname is None:
+        if before_attribute is None:
             limit -= without_before_counter
             without_before_counter = (without_before_counter + 1) % 30
         for item in reversed(list(function(
-                limit=limit, params={'before': before_fullname}))):
-            key = getattr(item, key_name)
-            if key in seen_fullnames:
+                limit=limit, params={'before': before_attribute}))):
+            attribute = getattr(item, attribute_name)
+            if attribute in seen_attributes:
                 continue
             found = True
-            seen_fullnames.add(key)
-            newest_fullname = key
+            seen_attributes.add(attribute)
+            newest_attribute = attribute
             if not skip_existing:
                 yield item
-        before_fullname = newest_fullname
+        before_attribute = newest_attribute
         skip_existing = False
         if valid_pause_after and pause_after < 0:
             yield None

--- a/praw/models/util.py
+++ b/praw/models/util.py
@@ -95,7 +95,7 @@ def stream_generator(function, pause_after=None, skip_existing=False,
         request thereby skipping any items that existed in the stream prior to
         starting the stream (default: False).
 
-    :param key_name: The field to use as an id (default: "fullname").
+    :param attribute_name: The field to use as an id (default: "fullname").
 
     .. note:: This function internally uses an exponential delay with jitter
        between subsequent responses that contain no new results, up to a

--- a/praw/models/util.py
+++ b/praw/models/util.py
@@ -76,7 +76,7 @@ def permissions_string(permissions, known_permissions):
     return ','.join(to_set)
 
 
-def stream_generator(function, pause_after=None, skip_existing=False):
+def stream_generator(function, pause_after=None, skip_existing=False, key_name="fullname"):
     """Yield new items from ListingGenerators and ``None`` when paused.
 
     :param function: A callable that returns a ListingGenerator, e.g.
@@ -93,6 +93,8 @@ def stream_generator(function, pause_after=None, skip_existing=False):
     :param skip_existing: When True does not yield any results from the first
         request thereby skipping any items that existed in the stream prior to
         starting the stream (default: False).
+
+    :param key_name: The field to use as an id (default: "fullname").
 
     .. note:: This function internally uses an exponential delay with jitter
        between subsequent responses that contain no new results, up to a
@@ -166,11 +168,12 @@ def stream_generator(function, pause_after=None, skip_existing=False):
             without_before_counter = (without_before_counter + 1) % 30
         for item in reversed(list(function(
                 limit=limit, params={'before': before_fullname}))):
-            if item.fullname in seen_fullnames:
+            key = getattr(item, key_name)
+            if key in seen_fullnames:
                 continue
             found = True
-            seen_fullnames.add(item.fullname)
-            newest_fullname = item.fullname
+            seen_fullnames.add(key)
+            newest_fullname = key
             if not skip_existing:
                 yield item
         before_fullname = newest_fullname

--- a/praw/models/util.py
+++ b/praw/models/util.py
@@ -77,7 +77,7 @@ def permissions_string(permissions, known_permissions):
 
 
 def stream_generator(function, pause_after=None, skip_existing=False,
-                     key_name="fullname"):
+                     key_name='fullname'):
     """Yield new items from ListingGenerators and ``None`` when paused.
 
     :param function: A callable that returns a ListingGenerator, e.g.


### PR DESCRIPTION
Adds a key_name parameter to the stream_generator function so it can key off things other than "fullname".

Per: https://old.reddit.com/r/redditdev/comments/9mb0m9/praw_submodlog_stream_generator_throws/