### PR TITLE
Add an example of the skip_existing argument to the comment stream docs

### DIFF
--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -1841,6 +1841,15 @@ class SubredditStream(object):
            for comment in reddit.subreddit('iama').stream.comments():
                print(comment)
 
+        To only retreive new submissions starting when the stream is
+        created, pass `skip_existing=true`:
+
+        .. code:: python
+
+           subreddit = reddit.subreddit('iama')
+           for comment in subreddit.stream.comments(skip_existing=true):
+               print(comment)
+
         """
         return stream_generator(self.subreddit.comments, **stream_options)
 


### PR DESCRIPTION
There's a question every other week in /r/redditdev about how to skip existing comments in a stream since people don't know to check the streamgenerator docs.