### PR TITLE
Add WidgetModeration and SubredditWidgetsModeration

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,12 @@ Unreleased
 * Add method :meth:`.Redditor.trophies` to get a list of the Redditor's
   trophies.
 * Add class :class:`.PostFlairWidget`.
+* Add class :class:`.SubredditWidgetsModeration` (accessible through
+  :attr:`.SubredditWidgets.mod`) and method :meth:`.add_text_area`.
+* Add class :class:`.WidgetModeration` (accessible through the ``.mod``
+  attribute on any widget) with methods :meth:`~.WidgetModeration.update` and
+  :meth:`~.WidgetModeration.delete`.
+* Add method :meth:`.Reddit.put` for HTTP PUT requests.
 
 **Changed**
 

--- a/docs/code_overview/other.rst
+++ b/docs/code_overview/other.rst
@@ -30,6 +30,8 @@ instances of them bound to an attribute of one of the PRAW models.
    other/commentmoderation
    other/submissionmoderation
    other/subredditmoderation
+   other/subredditwidgetsmoderation
+   other/widgetmoderation
    other/wikipagemoderation
 
 .. toctree::

--- a/docs/code_overview/other/subredditwidgetsmoderation.rst
+++ b/docs/code_overview/other/subredditwidgetsmoderation.rst
@@ -1,0 +1,5 @@
+SubredditWidgetsModeration
+==========================
+
+.. autoclass:: praw.models.SubredditWidgetsModeration
+   :inherited-members:

--- a/docs/code_overview/other/widgetmoderation.rst
+++ b/docs/code_overview/other/widgetmoderation.rst
@@ -1,0 +1,5 @@
+WidgetModeration
+================
+
+.. autoclass:: praw.models.WidgetModeration
+   :inherited-members:

--- a/praw/models/__init__.py
+++ b/praw/models/__init__.py
@@ -26,8 +26,9 @@ from .reddit.widgets import (Button, ButtonWidget, Calendar,  # NOQA
                              Image, ImageData, ImageWidget, Menu,  # NOQA
                              MenuLink, ModeratorsWidget,  # NOQA
                              PostFlairWidget, RulesWidget,  # NOQA
-                             SubredditWidgets, Submenu, TextArea,  # NOQA
-                             Widget)  # NOQA
+                             SubredditWidgets,  # NOQA
+                             SubredditWidgetsModeration, Submenu,  # NOQA
+                             TextArea, Widget, WidgetModeration)  # NOQA
 from .reddit.wikipage import WikiPage  # NOQA
 from .stylesheet import Stylesheet  # NOQA
 from .subreddits import Subreddits  # NOQA
@@ -43,5 +44,5 @@ __all__ = ('Auth', 'Button', 'ButtonWidget', 'Calendar', 'Comment',
            'PostFlairWidget', 'Preferences', 'Redditor', 'RedditorList',
            'RulesWidget', 'Stylesheet', 'Submenu', 'Submission', 'Subreddit',
            'SubredditHelper', 'SubredditMessage', 'SubredditWidgets',
-           'Subreddits', 'TextArea', 'Trophy', 'TrophyList', 'User',
-           'Widget', 'WikiPage')
+           'SubredditWidgetsModeration', 'Subreddits', 'TextArea', 'Trophy',
+           'TrophyList', 'User', 'Widget', 'WidgetModeration', 'WikiPage')

--- a/praw/reddit.py
+++ b/praw/reddit.py
@@ -469,6 +469,17 @@ class Reddit(object):
                             params=params)
         return self._objector.objectify(data)
 
+    def put(self, path, data=None):
+        """Return parsed objects returned from a PUT request to ``path``.
+
+        :param path: The path to fetch.
+        :param data: Dictionary, bytes, or file-like object to send in the body
+            of the request (default: None).
+
+        """
+        data = self.request('PUT', path, data=data)
+        return self._objector.objectify(data)
+
     def random_subreddit(self, nsfw=False):
         """Return a random lazy instance of :class:`~.Subreddit`.
 

--- a/tests/integration/cassettes/TestTextArea.test_create.json
+++ b/tests/integration/cassettes/TestTextArea.test_create.json
@@ -1,0 +1,442 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2019-01-04T02:21:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "53"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "116"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 04 Jan 2019 02:21:22 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "edgebucket=lqM9TWwfVu6DVyyoO2; Domain=reddit.com; Max-Age=63071999; Path=/;  secure"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-pao17422-PAO"
+          ],
+          "X-Timer": [
+            "S1546568483.549433,VS0,VE419"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2019-01-04T02:21:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22shortName%22%3A+%22My+new+widget%21%22%2C+%22text%22%3A+%22Hello+world%21%22%2C+%22styles%22%3A+%7B%22headerColor%22%3A+%22%23123456%22%2C+%22backgroundColor%22%3A+%22%23bb0e00%22%7D%2C+%22kind%22%3A+%22textarea%22%7D"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "242"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "edgebucket=lqM9TWwfVu6DVyyoO2"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/widget?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"styles\": {\"headerColor\": \"#123456\", \"backgroundColor\": \"#bb0e00\"}, \"kind\": \"textarea\", \"textHtml\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EHello world!\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"text\": \"Hello world!\", \"shortName\": \"My new widget!\", \"id\": \"widget_128bgmfs9jr74\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "323"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 04 Jan 2019 02:21:23 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-pao17435-PAO"
+          ],
+          "X-Timer": [
+            "S1546568483.152839,VS0,VE215"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "599.0"
+          ],
+          "x-ratelimit-reset": [
+            "517"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/widget?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2019-01-04T02:21:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&json=%7B%22id%22%3A+%22widget_128bgmfs9jr74%22%2C+%22styles%22%3A+%7B%22headerColor%22%3A+%22%23123456%22%2C+%22backgroundColor%22%3A+%22%23bb0e00%22%7D%2C+%22kind%22%3A+%22textarea%22%2C+%22textHtml%22%3A+%22%3C%21--+SC_OFF+--%3E%3Cdiv+class%3D%5C%22md%5C%22%3E%3Cp%3EHello+world%21%3C%2Fp%3E%5Cn%3C%2Fdiv%3E%3C%21--+SC_ON+--%3E%22%2C+%22text%22%3A+%22Feed+me%22%2C+%22shortName%22%3A+%22My+old+widget+%3A%28%22%7D"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "429"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "edgebucket=lqM9TWwfVu6DVyyoO2"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "PUT",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/widget/widget_128bgmfs9jr74?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"styles\": {\"headerColor\": \"#123456\", \"backgroundColor\": \"#bb0e00\"}, \"kind\": \"textarea\", \"textHtml\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EFeed me\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"text\": \"Feed me\", \"shortName\": \"My old widget :(\", \"id\": \"widget_128bgmfs9jr74\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "315"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 04 Jan 2019 02:21:23 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-pao17435-PAO"
+          ],
+          "X-Timer": [
+            "S1546568483.386161,VS0,VE284"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "598.0"
+          ],
+          "x-ratelimit-reset": [
+            "517"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/widget/widget_128bgmfs9jr74?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2019-01-04T02:21:24",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "0"
+          ],
+          "Cookie": [
+            "edgebucket=lqM9TWwfVu6DVyyoO2"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "DELETE",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/widget/widget_128bgmfs9jr74?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "0"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 04 Jan 2019 02:21:24 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-pao17435-PAO"
+          ],
+          "X-Timer": [
+            "S1546568484.705440,VS0,VE332"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "597.0"
+          ],
+          "x-ratelimit-reset": [
+            "517"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/widget/widget_128bgmfs9jr74?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/integration/models/reddit/test_widgets.py
+++ b/tests/integration/models/reddit/test_widgets.py
@@ -1,3 +1,4 @@
+import mock
 import pytest
 
 from praw.models import (Button, ButtonWidget, Calendar, CommunityList,
@@ -335,6 +336,33 @@ class TestSubredditWidgets(IntegrationTest):
 
 
 class TestTextArea(IntegrationTest):
+    @mock.patch('time.sleep', return_value=None)
+    def test_create_and_update_and_delete(self, _):
+        self.reddit.read_only = False
+
+        subreddit = self.reddit.subreddit(pytest.placeholders.test_subreddit)
+        widgets = subreddit.widgets
+
+        with self.recorder.use_cassette('TestTextArea.test_create'):
+            styles = {'headerColor': '#123456', 'backgroundColor': '#bb0e00'}
+            widget = widgets.mod.add_text_area(short_name='My new widget!',
+                                               text='Hello world!',
+                                               styles=styles)
+
+            assert isinstance(widget, TextArea)
+            assert widget.shortName == 'My new widget!'
+            assert widget.styles == styles
+            assert widget.text == 'Hello world!'
+
+            widget = widget.mod.update(shortName='My old widget :(',
+                                       text='Feed me')
+
+            assert isinstance(widget, TextArea)
+            assert widget.shortName == 'My old widget :('
+            assert widget.styles == styles
+            assert widget.text == 'Feed me'
+
+            widget.mod.delete()
 
     def test_text_area(self):
         subreddit = self.reddit.subreddit(pytest.placeholders.test_subreddit)

--- a/tests/unit/models/reddit/test_widgets.py
+++ b/tests/unit/models/reddit/test_widgets.py
@@ -1,0 +1,15 @@
+from praw.models import (SubredditWidgets, SubredditWidgetsModeration,
+                         Widget, WidgetModeration)
+
+from ... import UnitTest
+
+
+class TestWidgets(UnitTest):
+    def test_subredditwidgets_mod(self):
+        sw = SubredditWidgets(self.reddit.subreddit('fake_subreddit'))
+        assert isinstance(sw.mod, SubredditWidgetsModeration)
+
+    def test_widget_mod(self):
+        w = Widget(self.reddit, {})
+        assert isinstance(w.mod, WidgetModeration)
+        assert w.mod.widget == w


### PR DESCRIPTION
Works towards #941.

## Feature Summary and Justification

This feature provides the `WidgetModeration` class to moderate a particular widget and the `SubredditWidgetsModeration` class to moderate a subreddit's widgets. The former class is used to perform actions on a specific widget, for example, to delete it with `widget.mod.delete()`. The latter is used to perform actions on a subreddit's widgets as a whole, such as (not implemented in this PR) reordering them, or creating them (`widgets.mod.add_text_area()`).

The `SubredditWidgetsModeration` class provides a private helper method for creating widgets, as well as a method to create `TextArea` widgets. More will come in later PRs. In addition, it will support re-ordering widgets.

The `WidgetModeration` class provides `update` and `delete` methods for all `Widget`s.

### Additional changes

- Added a `put` method on the `Reddit` class much like `get`, `post`, and `patch`.
- Removed unnecessary pylint-disabling comments.