### PR TITLE
Replace usage of `api/leavemoderator` with  `/api/unfriend`

### DIFF
--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -1542,8 +1542,7 @@ class ModeratorRelationship(SubredditRelationship):
            reddit.subreddit('subredditname').moderator.leave()
 
         """
-        self.subreddit._reddit.post(API_PATH['leavemoderator'],
-                                    data={'id': self.subreddit.fullname})
+        self.remove(self.subreddit._reddit.config.username)
 
     def remove_invite(self, redditor):
         """Remove the moderator invite for ``redditor``.


### PR DESCRIPTION
Replace the deprecated `api/leavemoderator` endpoint.

## Feature Summary and Justification
Using `/api/unfriend` instead.

## References

* https://www.reddit.com/r/redditdev/comments/adrztg/what_happened_to_apileavemoderator/edkqyxg/ 
*
