### PR TITLE
Removal Messages support

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -43,4 +43,5 @@ Source Contributors
 - salehio `@salehio <https://github.com/salehio>`_
 - Amanda O'Neal <amanda.oneal.dev@gmail.com> `@amandaoneal <https://github.com/amandaoneal>`_
 - Gourari Oussama <gourari.ouss@gmail.com> `@O-Gourari <https://github.com/O-Gourari>`_
+- Declan Hoare <declanhoare@exemail.com.au> `@NetwideRogue <https://github.com/NetwideRogue>`_
 - Add "Name <email (optional)> and github profile link" above this line.

--- a/praw/const.py
+++ b/praw/const.py
@@ -122,6 +122,9 @@ API_PATH = {
     'quarantine_opt_in':      'api/quarantine_optin',
     'quarantine_opt_out':     'api/quarantine_optout',
     'read_message':           'api/read_message/',
+    ('removal_comment_'
+     'message'):              'api/v1/modactions/removal_comment_message',
+    'removal_link_message':   'api/v1/modactions/removal_link_message',
     'remove':                 'api/remove/',
     'report':                 'api/report/',
     'rules':                  'r/{subreddit}/about/rules',

--- a/praw/models/reddit/comment.py
+++ b/praw/models/reddit/comment.py
@@ -280,6 +280,8 @@ class CommentModeration(ThingModerationMixin):
 
     """
 
+    REMOVAL_MESSAGE_API = 'removal_comment_message'
+
     def __init__(self, comment):
         """Create a CommentModeration instance.
 

--- a/praw/models/reddit/mixins/__init__.py
+++ b/praw/models/reddit/mixins/__init__.py
@@ -1,4 +1,5 @@
 """Package providing reddit class mixins."""
+from json import dumps
 from ....const import API_PATH
 from .editable import EditableMixin  # NOQA
 from .gildable import GildableMixin  # NOQA
@@ -13,6 +14,8 @@ from .votable import VotableMixin  # NOQA
 
 class ThingModerationMixin(object):
     """Provides moderation methods for Comments and Submissions."""
+
+    REMOVAL_MESSAGE_API = None
 
     def approve(self):
         """Approve a :class:`~.Comment` or :class:`~.Submission`.
@@ -131,7 +134,7 @@ class ThingModerationMixin(object):
         # The API endpoint used to send removal messages is different
         # for posts and comments, so the derived classes specify which one.
         if self.REMOVAL_MESSAGE_API is None:
-            raise NotImplementedError('ThingModerationMixin must be extended.')  # NOQA
+            raise NotImplementedError('ThingModerationMixin must be extended.')
         url = API_PATH[self.REMOVAL_MESSAGE_API]
 
         # Only the first element of the item_id list is used.
@@ -140,9 +143,7 @@ class ThingModerationMixin(object):
                 'title': title,
                 'type': str(type)}
 
-        # Use the core to make the request in order to send the data as
-        # JSON - this endpoint doesn't like URL encoding.
-        ret = self.thing._reddit._core.request('POST', url, json=data)
+        ret = self.thing._reddit.post(url, data={'json': dumps(data)})
         if ret != {}:
             from ..comment import Comment
             return Comment(self.thing._reddit, _data=ret)

--- a/praw/models/reddit/mixins/__init__.py
+++ b/praw/models/reddit/mixins/__init__.py
@@ -115,8 +115,9 @@ class ThingModerationMixin(object):
         data = {'id': self.thing.fullname, 'spam': bool(spam)}
         self.thing._reddit.post(API_PATH['remove'], data=data)
 
-    def send_removal_message(self, type,  # pylint: disable=redefined-builtin
-                             title, message):
+    def send_removal_message(self, message, title='ignored',
+                             type='public'  # pylint: disable=redefined-builtin
+                             ):
         """Send a removal message for a Comment or Submission.
 
         Reddit adds human-readable information about the object to the message.
@@ -141,10 +142,9 @@ class ThingModerationMixin(object):
         data = {'item_id': [self.thing.fullname],
                 'message': message,
                 'title': title,
-                'type': str(type)}
+                'type': type}
 
-        ret = self.thing._reddit.post(url, data={'json': dumps(data)})
-        return None if ret == {} else ret
+        return self.thing._reddit.post(url, data={'json': dumps(data)}) or None
 
     def undistinguish(self):
         """Remove mod, admin, or special distinguishing on object.

--- a/praw/models/reddit/mixins/__init__.py
+++ b/praw/models/reddit/mixins/__init__.py
@@ -144,10 +144,7 @@ class ThingModerationMixin(object):
                 'type': str(type)}
 
         ret = self.thing._reddit.post(url, data={'json': dumps(data)})
-        if ret != {}:
-            from ..comment import Comment
-            return Comment(self.thing._reddit, _data=ret)
-        return None
+        return None if ret == {} else ret
 
     def undistinguish(self):
         """Remove mod, admin, or special distinguishing on object.

--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -371,6 +371,8 @@ class SubmissionModeration(ThingModerationMixin):
 
     """
 
+    REMOVAL_MESSAGE_API = 'removal_link_message'
+
     def __init__(self, submission):
         """Create a SubmissionModeration instance.
 

--- a/praw/objector.py
+++ b/praw/objector.py
@@ -100,6 +100,8 @@ class Objector(object):
         elif {'authorFlairType', 'name'}.issubset(data):
             # discards flair information
             return self._reddit.redditor(data['name'])
+        elif {'parent_id'}.issubset(data):
+            parser = self.parsers[self._reddit.config.kinds['comment']]
         else:
             if 'user' in data:
                 parser = self.parsers[self._reddit.config.kinds['redditor']]

--- a/tests/integration/cassettes/TestCommentModeration.test_send_removal_message.json
+++ b/tests/integration/cassettes/TestCommentModeration.test_send_removal_message.json
@@ -1,0 +1,564 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2019-01-11T21:12:28",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "86"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "118"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 11 Jan 2019 21:12:28 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "edgebucket=QZMtk1SqvajE9ftkIu; Domain=reddit.com; Max-Age=63071999; Path=/;  secure"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18934-SYD"
+          ],
+          "X-Timer": [
+            "S1547241148.403186,VS0,VE513"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2019-01-11T21:12:29",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t1_edu698v&spam=False"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "38"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "edgebucket=QZMtk1SqvajE9ftkIu"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/remove/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 11 Jan 2019 21:12:29 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18934-SYD"
+          ],
+          "X-Timer": [
+            "S1547241149.170196,VS0,VE345"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "599.0"
+          ],
+          "x-ratelimit-reset": [
+            "451"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/remove/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2019-01-11T21:12:29",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"item_id\": [\"t1_edu698v\"], \"message\": \"message\", \"title\": \"title\", \"type\": \"public\"}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "85"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Cookie": [
+            "edgebucket=QZMtk1SqvajE9ftkIu"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/v1/modactions/removal_comment_message?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"subreddit_id\": \"t5_u0gxp\", \"approved_at_utc\": null, \"mod_reason_by\": null, \"banned_by\": null, \"author_flair_type\": \"text\", \"removal_reason\": null, \"link_id\": \"t3_aezo6s\", \"author_flair_template_id\": null, \"likes\": true, \"replies\": \"\", \"user_reports\": [], \"body_html\": \"<div class=\\\"md\\\"><p>message</p>\\n</div>\", \"saved\": false, \"id\": \"edu92zn\", \"banned_at_utc\": null, \"mod_reason_title\": null, \"gilded\": 0, \"archived\": false, \"no_follow\": false, \"author\": \"<USERNAME>\", \"can_mod_post\": true, \"created_utc\": 1547241149.0, \"send_replies\": true, \"parent_id\": \"t1_edu698v\", \"score\": 1, \"author_fullname\": \"t2_2cvck8ii\", \"report_reasons\": [], \"approved_by\": null, \"controversiality\": 0, \"ignore_reports\": false, \"body\": \"message\", \"edited\": false, \"author_flair_css_class\": null, \"is_submitter\": false, \"downs\": 0, \"author_flair_richtext\": [], \"author_patreon_flair\": false, \"collapsed_reason\": null, \"gildings\": {\"gid_1\": 0, \"gid_2\": 0, \"gid_3\": 0}, \"spam\": false, \"stickied\": false, \"subreddit_type\": \"public\", \"can_gild\": false, \"removed\": false, \"approved\": false, \"author_flair_text_color\": null, \"score_hidden\": false, \"permalink\": \"/r/<TEST_SUBREDDIT>/comments/aezo6s/test_post_1/edu92zn/\", \"num_reports\": 0, \"name\": \"t1_edu92zn\", \"created\": 1547269949.0, \"subreddit\": \"<TEST_SUBREDDIT>\", \"author_flair_text\": null, \"rte_mode\": \"markdown\", \"collapsed\": false, \"subreddit_name_prefixed\": \"r/<TEST_SUBREDDIT>\", \"ups\": 1, \"author_flair_background_color\": null, \"mod_reports\": [], \"mod_note\": null, \"distinguished\": \"moderator\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1527"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 11 Jan 2019 21:12:29 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Vary": [
+            "accept-encoding"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18934-SYD"
+          ],
+          "X-Timer": [
+            "S1547241150.570067,VS0,VE363"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "598.0"
+          ],
+          "x-ratelimit-reset": [
+            "451"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/modactions/removal_comment_message?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2019-01-11T21:12:40",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"item_id\": [\"t1_edu698v\"], \"message\": \"message\", \"title\": \"title\", \"type\": \"private\"}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "86"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Cookie": [
+            "edgebucket=QZMtk1SqvajE9ftkIu"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/v1/modactions/removal_comment_message?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 11 Jan 2019 21:12:40 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18934-SYD"
+          ],
+          "X-Timer": [
+            "S1547241150.987250,VS0,VE10072"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "597.0"
+          ],
+          "x-ratelimit-reset": [
+            "450"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/modactions/removal_comment_message?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2019-01-11T21:12:49",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"item_id\": [\"t1_edu698v\"], \"message\": \"message\", \"title\": \"title\", \"type\": \"private_exposed\"}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "94"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Cookie": [
+            "edgebucket=QZMtk1SqvajE9ftkIu"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/v1/modactions/removal_comment_message?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 11 Jan 2019 21:12:49 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18934-SYD"
+          ],
+          "X-Timer": [
+            "S1547241160.113359,VS0,VE9672"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "596.0"
+          ],
+          "x-ratelimit-reset": [
+            "440"
+          ],
+          "x-ratelimit-used": [
+            "4"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/modactions/removal_comment_message?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/integration/cassettes/TestSubmissionModeration.test_send_removal_message.json
+++ b/tests/integration/cassettes/TestSubmissionModeration.test_send_removal_message.json
@@ -1,0 +1,564 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2019-01-11T21:12:56",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "86"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "118"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 11 Jan 2019 21:12:56 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "edgebucket=20cSZuKtEsXbfvGcqj; Domain=reddit.com; Max-Age=63071999; Path=/;  secure"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18929-SYD"
+          ],
+          "X-Timer": [
+            "S1547241176.301399,VS0,VE515"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2019-01-11T21:12:57",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&id=t3_aezo6s&spam=False"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "37"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "edgebucket=20cSZuKtEsXbfvGcqj"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/remove/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 11 Jan 2019 21:12:57 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18925-SYD"
+          ],
+          "X-Timer": [
+            "S1547241177.057608,VS0,VE524"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "595.0"
+          ],
+          "x-ratelimit-reset": [
+            "423"
+          ],
+          "x-ratelimit-used": [
+            "5"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/remove/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2019-01-11T21:12:58",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"item_id\": [\"t3_aezo6s\"], \"message\": \"message\", \"title\": \"title\", \"type\": \"public\"}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "84"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Cookie": [
+            "edgebucket=20cSZuKtEsXbfvGcqj"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/v1/modactions/removal_link_message?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"subreddit_id\": \"t5_u0gxp\", \"approved_at_utc\": null, \"mod_reason_by\": null, \"banned_by\": null, \"author_flair_type\": \"text\", \"removal_reason\": null, \"link_id\": \"t3_aezo6s\", \"author_flair_template_id\": null, \"likes\": true, \"replies\": \"\", \"user_reports\": [], \"body_html\": \"<div class=\\\"md\\\"><p>message</p>\\n</div>\", \"saved\": false, \"id\": \"edu94k9\", \"banned_at_utc\": null, \"mod_reason_title\": null, \"gilded\": 0, \"archived\": false, \"no_follow\": false, \"author\": \"<USERNAME>\", \"can_mod_post\": true, \"created_utc\": 1547241177.0, \"send_replies\": true, \"parent_id\": \"t3_aezo6s\", \"score\": 1, \"author_fullname\": \"t2_2cvck8ii\", \"report_reasons\": [], \"approved_by\": null, \"controversiality\": 0, \"ignore_reports\": false, \"body\": \"message\", \"edited\": false, \"author_flair_css_class\": null, \"is_submitter\": false, \"downs\": 0, \"author_flair_richtext\": [], \"author_patreon_flair\": false, \"collapsed_reason\": null, \"gildings\": {\"gid_1\": 0, \"gid_2\": 0, \"gid_3\": 0}, \"spam\": false, \"stickied\": true, \"subreddit_type\": \"public\", \"can_gild\": false, \"removed\": false, \"approved\": false, \"author_flair_text_color\": null, \"score_hidden\": false, \"permalink\": \"/r/<TEST_SUBREDDIT>/comments/aezo6s/test_post_1/edu94k9/\", \"num_reports\": 0, \"name\": \"t1_edu94k9\", \"created\": 1547269977.0, \"subreddit\": \"<TEST_SUBREDDIT>\", \"author_flair_text\": null, \"rte_mode\": \"markdown\", \"collapsed\": false, \"subreddit_name_prefixed\": \"r/<TEST_SUBREDDIT>\", \"ups\": 1, \"author_flair_background_color\": null, \"mod_reports\": [], \"mod_note\": null, \"distinguished\": \"moderator\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1525"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 11 Jan 2019 21:12:58 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Vary": [
+            "accept-encoding"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18925-SYD"
+          ],
+          "X-Timer": [
+            "S1547241178.633321,VS0,VE495"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "594.0"
+          ],
+          "x-ratelimit-reset": [
+            "423"
+          ],
+          "x-ratelimit-used": [
+            "6"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/modactions/removal_link_message?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2019-01-11T21:13:08",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"item_id\": [\"t3_aezo6s\"], \"message\": \"message\", \"title\": \"title\", \"type\": \"private\"}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "85"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Cookie": [
+            "edgebucket=20cSZuKtEsXbfvGcqj"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/v1/modactions/removal_link_message?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 11 Jan 2019 21:13:08 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18925-SYD"
+          ],
+          "X-Timer": [
+            "S1547241178.185421,VS0,VE10738"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "593.0"
+          ],
+          "x-ratelimit-reset": [
+            "422"
+          ],
+          "x-ratelimit-used": [
+            "7"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/modactions/removal_link_message?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2019-01-11T21:13:19",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"item_id\": [\"t3_aezo6s\"], \"message\": \"message\", \"title\": \"title\", \"type\": \"private_exposed\"}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "93"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Cookie": [
+            "edgebucket=20cSZuKtEsXbfvGcqj"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.0.0 prawcore/1.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/v1/modactions/removal_link_message?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Fri, 11 Jan 2019 21:13:19 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd18925-SYD"
+          ],
+          "X-Timer": [
+            "S1547241189.974786,VS0,VE10115"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "592.0"
+          ],
+          "x-ratelimit-reset": [
+            "411"
+          ],
+          "x-ratelimit-used": [
+            "8"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/modactions/removal_link_message?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/integration/models/reddit/test_comment.py
+++ b/tests/integration/models/reddit/test_comment.py
@@ -260,6 +260,23 @@ class TestCommentModeration(IntegrationTest):
                 'TestCommentModeration.test_remove'):
             self.reddit.comment('da2g5y6').mod.remove(spam=True)
 
+    @mock.patch('time.sleep', return_value=None)
+    def test_send_removal_message(self, _):
+        self.reddit.read_only = False
+        with self.recorder.use_cassette(
+                'TestCommentModeration.test_send_removal_message'):
+            comment = self.reddit.comment('edu698v')
+            mod = comment.mod
+            mod.remove()
+            message = 'message'
+            res = [mod.send_removal_message(t, 'title', message)
+                   for t in ('public', 'private', 'private_exposed')]
+            assert isinstance(res[0], Comment)
+            assert res[0].parent_id == 't1_' + comment.id
+            assert res[0].body == message
+            assert res[1] is None
+            assert res[2] is None
+
     def test_undistinguish(self):
         self.reddit.read_only = False
         with self.recorder.use_cassette(

--- a/tests/integration/models/reddit/test_comment.py
+++ b/tests/integration/models/reddit/test_comment.py
@@ -269,8 +269,8 @@ class TestCommentModeration(IntegrationTest):
             mod = comment.mod
             mod.remove()
             message = 'message'
-            res = [mod.send_removal_message(t, 'title', message)
-                   for t in ('public', 'private', 'private_exposed')]
+            res = [mod.send_removal_message(message, 'title', type)
+                   for type in ('public', 'private', 'private_exposed')]
             assert isinstance(res[0], Comment)
             assert res[0].parent_id == 't1_' + comment.id
             assert res[0].body == message

--- a/tests/integration/models/reddit/test_submission.py
+++ b/tests/integration/models/reddit/test_submission.py
@@ -297,6 +297,24 @@ class TestSubmissionModeration(IntegrationTest):
                 'TestSubmissionModeration.test_remove'):
             self.reddit.submission('4b536h').mod.remove(spam=True)
 
+    @mock.patch('time.sleep', return_value=None)
+    def test_send_removal_message(self, _):
+        self.reddit.read_only = False
+        with self.recorder.use_cassette(
+                'TestSubmissionModeration.test_send_removal_message'):
+            submission = self.reddit.submission('aezo6s')
+            mod = submission.mod
+            mod.remove()
+            message = 'message'
+            res = [mod.send_removal_message(t, 'title', message)
+                   for t in ('public', 'private', 'private_exposed')]
+            assert isinstance(res[0], Comment)
+            assert res[0].parent_id == 't3_' + submission.id
+            assert res[0].stickied
+            assert res[0].body == message
+            assert res[1] is None
+            assert res[2] is None
+
     def test_sfw(self):
         self.reddit.read_only = False
         with self.recorder.use_cassette(

--- a/tests/integration/models/reddit/test_submission.py
+++ b/tests/integration/models/reddit/test_submission.py
@@ -306,8 +306,8 @@ class TestSubmissionModeration(IntegrationTest):
             mod = submission.mod
             mod.remove()
             message = 'message'
-            res = [mod.send_removal_message(t, 'title', message)
-                   for t in ('public', 'private', 'private_exposed')]
+            res = [mod.send_removal_message(type, 'title', message)
+                   for type in ('public', 'private', 'private_exposed')]
             assert isinstance(res[0], Comment)
             assert res[0].parent_id == 't3_' + submission.id
             assert res[0].stickied

--- a/tests/unit/models/reddit/mixins/test__init__.py
+++ b/tests/unit/models/reddit/mixins/test__init__.py
@@ -1,0 +1,11 @@
+import pytest
+from praw.models.reddit.mixins import ThingModerationMixin
+
+from .... import UnitTest
+
+
+class TestThingModerationMixin(UnitTest):
+    def test_must_be_extended(self):
+        with pytest.raises(NotImplementedError):
+            ThingModerationMixin().send_removal_message('public',
+                                                        'title', 'message')


### PR DESCRIPTION
## Feature Summary and Justification

Adds support for the removal message endpoints: `removal_link_message` and `removal_comment_message`.

## References

This is part of #976 rebased.
