### PR TITLE
Document known attributes on Emoji, Stylesheet, and Trophy

### DIFF
--- a/praw/models/reddit/emoji.py
+++ b/praw/models/reddit/emoji.py
@@ -7,7 +7,23 @@ from .base import RedditBase
 
 
 class Emoji(RedditBase):
-    """An individual Emoji object."""
+    """An individual Emoji object.
+
+    **Typical Attributes**
+
+    This table describes attributes that typically belong to objects of this
+    class. Since attributes are dynamically provided (see
+    :ref:`determine-available-attributes-of-an-object`), there is not a
+    guarantee that these attributes will always be present, nor is this list
+    necessarily comprehensive.
+
+    ======================= ===================================================
+    Attribute               Description
+    ======================= ===================================================
+    ``name``                The name of the emoji.
+    ``url``                 The URL of the emoji image.
+    ======================= ===================================================
+    """
 
     STR_FIELD = 'name'
 

--- a/praw/models/stylesheet.py
+++ b/praw/models/stylesheet.py
@@ -4,4 +4,20 @@ from .base import PRAWBase
 
 
 class Stylesheet(PRAWBase):
-    """Represent a stylesheet."""
+    """Represent a stylesheet.
+
+    **Typical Attributes**
+
+    This table describes attributes that typically belong to objects of this
+    class. Since attributes are dynamically provided (see
+    :ref:`determine-available-attributes-of-an-object`), there is not a
+    guarantee that these attributes will always be present, nor is this list
+    necessarily comprehensive.
+
+    ======================= ===================================================
+    Attribute               Description
+    ======================= ===================================================
+    ``images``              A ``list`` of images used by the stylesheet.
+    ``stylesheet``          The contents of the stylesheet, as CSS.
+    ======================= ===================================================
+    """

--- a/praw/models/trophy.py
+++ b/praw/models/trophy.py
@@ -9,6 +9,25 @@ class Trophy(PRAWBase):
     :meth:`.Redditor.trophies` can be used to get a list
     of the redditor's trophies.
 
+
+    **Typical Attributes**
+
+    This table describes attributes that typically belong to objects of this
+    class. Since attributes are dynamically provided (see
+    :ref:`determine-available-attributes-of-an-object`), there is not a
+    guarantee that these attributes will always be present, nor is this list
+    necessarily comprehensive.
+
+    ======================= ===================================================
+    Attribute               Description
+    ======================= ===================================================
+    ``award_id``            The ID of the trophy (sometimes ``None``).
+    ``description``         The description of the trophy (sometimes ``None``).
+    ``icon_40``             The URL of a 41x41 px icon for the trophy.
+    ``icon_70``             The URL of a 71x71 px icon for the trophy.
+    ``name``                The name of the trophy.
+    ``url``                 A relevant URL (sometimes ``None``).
+    ======================= ===================================================
     """
 
     def __init__(self, reddit, _data):


### PR DESCRIPTION
See #917.

## Feature Summary and Justification

This feature provides attribute documentation for the `Emoji`, `Stylesheet`, and `Trophy` classes.

The issue says 

> please make a pull request for each model at a time, rather than attempting to complete for all models at once

but I figured it might be alright for three small commits to be together in one PR. I can split it up if need be.

## References

* #917