### PR TITLE
Document known attributes on LiveThread, LiveUpdate, Multireddit, and WikiPage

### DIFF
--- a/praw/models/reddit/live.py
+++ b/praw/models/reddit/live.py
@@ -235,7 +235,30 @@ class LiveContributorRelationship(object):
 
 
 class LiveThread(RedditBase):
-    """An individual LiveThread object."""
+    """An individual LiveThread object.
+
+    **Typical Attributes**
+
+    This table describes attributes that typically belong to objects of this
+    class. Since attributes are dynamically provided (see
+    :ref:`determine-available-attributes-of-an-object`), there is not a
+    guarantee that these attributes will always be present, nor is this list
+    necessarily comprehensive.
+
+    ======================= ===================================================
+    Attribute               Description
+    ======================= ===================================================
+    ``created_utc``         The creation time of the live thread, in `Unix
+                            Time`_.
+    ``description``         Description of the live thread, as Markdown.
+    ``description_html``    Description of the live thread, as HTML.
+    ``id``                  The ID of the live thread.
+    ``nsfw``                A ``bool`` representing whether or not the live
+                            thread is marked as NSFW.
+    ======================= ===================================================
+
+    .. _Unix Time: https://en.wikipedia.org/wiki/Unix_time
+    """
 
     STR_FIELD = 'id'
 
@@ -492,7 +515,29 @@ class LiveThreadContribution(object):
 
 
 class LiveUpdate(RedditBase):
-    """An individual :class:`.LiveUpdate` object."""
+    """An individual :class:`.LiveUpdate` object.
+
+    **Typical Attributes**
+
+    This table describes attributes that typically belong to objects of this
+    class. Since attributes are dynamically provided (see
+    :ref:`determine-available-attributes-of-an-object`), there is not a
+    guarantee that these attributes will always be present, nor is this list
+    necessarily comprehensive.
+
+    ======================= ===================================================
+    Attribute               Description
+    ======================= ===================================================
+    ``author``              The :class:`.Redditor` who made the update.
+    ``body``                Body of the update, as Markdown.
+    ``body_html``           Body of the update, as HTML.
+    ``created_utc``         The time the update was created, as `Unix Time`_.
+    ``stricken``            A ``bool`` representing whether or not the update
+                            was stricken (see :meth:`.strike`).
+    ======================= ===================================================
+
+    .. _Unix Time: https://en.wikipedia.org/wiki/Unix_time
+    """
 
     STR_FIELD = 'id'
 

--- a/praw/models/reddit/multi.py
+++ b/praw/models/reddit/multi.py
@@ -10,7 +10,38 @@ from .subreddit import Subreddit, SubredditStream
 
 
 class Multireddit(RedditBase, SubredditListingMixin):
-    """A class for users' Multireddits."""
+    r"""A class for users' Multireddits.
+
+    **Typical Attributes**
+
+    This table describes attributes that typically belong to objects of this
+    class. Since attributes are dynamically provided (see
+    :ref:`determine-available-attributes-of-an-object`), there is not a
+    guarantee that these attributes will always be present, nor is this list
+    necessarily comprehensive.
+
+    ======================= ===================================================
+    Attribute               Description
+    ======================= ===================================================
+    ``can_edit``            A ``bool`` representing whether or not the
+                            authenticated user may edit the multireddit.
+    ``copied_from``         The multireddit that the multireddit was copied
+                            from, if it exists, otherwise ``None``.
+    ``created_utc``         When the multireddit was created, in `Unix Time`_.
+    ``description_html``    The description of the multireddit, as HTML.
+    ``description_md``      The description of the multireddit, as Markdown.
+    ``display_name``        The display name of the multireddit.
+    ``name``                The name of the multireddit.
+    ``over_18``             A ``bool`` representing whether or not the
+                            multireddit is restricted for users over 18.
+    ``subreddits``          A ``list`` of :class:`.Subreddit`\ s that make up
+                            the multireddit.
+    ``visibility``          The visibility of the multireddit, either
+                            ``private``, ``public``, or ``hidden``.
+    ======================= ===================================================
+
+    .. _Unix Time: https://en.wikipedia.org/wiki/Unix_time
+    """
 
     STR_FIELD = 'path'
     RE_INVALID = re.compile(r'(\s|\W|_)+', re.UNICODE)

--- a/praw/models/reddit/wikipage.py
+++ b/praw/models/reddit/wikipage.py
@@ -6,7 +6,32 @@ from .redditor import Redditor
 
 
 class WikiPage(RedditBase):
-    """An individual WikiPage object."""
+    """An individual WikiPage object.
+
+    **Typical Attributes**
+
+    This table describes attributes that typically belong to objects of this
+    class. Since attributes are dynamically provided (see
+    :ref:`determine-available-attributes-of-an-object`), there is not a
+    guarantee that these attributes will always be present, nor is this list
+    necessarily comprehensive.
+
+    ======================= ===================================================
+    Attribute               Description
+    ======================= ===================================================
+    ``content_html``        The contents of the wiki page, as HTML.
+    ``content_md``          The contents of the wiki page, as Markdown.
+    ``may_revise``          A ``bool`` representing whether or not the
+                            authenticated user may edit the wiki page.
+    ``name``                The name of the wiki page.
+    ``revision_by``         The :class:`.Redditor` who authored this
+                            revision of the wiki page.
+    ``revision_date``       The time of this revision, in `Unix Time`_.
+    ``subreddit``           The :class:`.Subreddit` this wiki page belongs to.
+    ======================= ===================================================
+
+    .. _Unix Time: https://en.wikipedia.org/wiki/Unix_time
+    """
 
     __hash__ = RedditBase.__hash__
 


### PR DESCRIPTION
See #917.

## Feature Summary and Justification

This feature provides attribute documentation for the `LiveThread`, `LiveUpdate`, `Multireddit`, and `WikiPage` classes.

As with #1008, the issue says 

> please make a pull request for each model at a time, rather than attempting to complete for all models at once

but I figured it might be alright for three small commits to be together in one PR. I can split it up if need be.

## References

* #917