### PR TITLE
Bump minimum version of prawcore

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Change Log
 ==========
 
+Unreleased
+----------
+
+**Other**
+
+* Bumped minimum prawcore version to 1.0.1.
+
 6.1.1 (2019/01/29)
 ------------------
 

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(name=PACKAGE_NAME,
       description=('PRAW, an acronym for `Python Reddit API Wrapper`, is a '
                    'python package that allows for simple access to '
                    'reddit\'s API.'),
-      install_requires=['prawcore >=1.0.0, <2.0',
+      install_requires=['prawcore >=1.0.1, <2.0',
                         'update_checker >=0.16',
                         'websocket-client >=0.54.0'],
       keywords='reddit api wrapper',


### PR DESCRIPTION
Strictly speaking, this minimum version bump isn't necessary, however, I want
to ensure if people update PRAW that they also pull in the latest prawcore.