### PR TITLE
Add the ability to immediately mark submissions as NSFW

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -45,4 +45,5 @@ Source Contributors
 - Amanda O'Neal <amanda.oneal.dev@gmail.com> `@amandaoneal <https://github.com/amandaoneal>`_
 - Gourari Oussama <gourari.ouss@gmail.com> `@O-Gourari <https://github.com/O-Gourari>`_
 - Declan Hoare <declanhoare@exemail.com.au> `@NetwideRogue <https://github.com/NetwideRogue>`_
+- Elaina Martineau `@CrackedP0t <https://github.com/CrackedP0t>`_
 - Add "Name <email (optional)> and github profile link" above this line.

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,9 +5,10 @@ Unreleased
 ----------
 
 **Added**
+
 * :meth:`~.Subreddit.submit`, :meth:`~.Subreddit.submit_image`, and
   :meth:`~.Subreddit.submit_video` support parameter ``nsfw`` to
-  mark the submission NSFW immediately upon posting
+  mark the submission NSFW immediately upon posting.
 
 **Other**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,11 @@ Change Log
 Unreleased
 ----------
 
+**Added**
+* :meth:`~.Subreddit.submit`, :meth:`~.Subreddit.submit_image`, and
+  :meth:`~.Subreddit.submit_video` support parameter ``nsfw`` to
+  mark the submission NSFW immediately upon posting
+
 **Other**
 
 * Bumped minimum prawcore version to 1.0.1.

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -553,7 +553,7 @@ class Subreddit(RedditBase, MessageableMixin, SubredditListingMixin):
         return self._submission_class(self._reddit, url=urljoin(
             self._reddit.config.reddit_url, path))
 
-    def submit(self, title, selftext=None, url=None, flair_id=None,
+    def submit(self, title, selftext=None, url=None, flair_id=None, nsfw=False,
                flair_text=None, resubmit=True, send_replies=True):
         """Add a submission to the subreddit.
 
@@ -569,6 +569,8 @@ class Subreddit(RedditBase, MessageableMixin, SubredditListingMixin):
             been submitted (default: True).
         :param send_replies: When True, messages will be sent to the submission
             author when comments are made to the submission (default: True).
+        :param nsfw: Whether or not the submission should be marked NSFW
+            (default: False).
         :returns: A :class:`~.Submission` object for the newly created
             submission.
 
@@ -591,7 +593,7 @@ class Subreddit(RedditBase, MessageableMixin, SubredditListingMixin):
         if (bool(selftext) or selftext == '') == bool(url):
             raise TypeError('Either `selftext` or `url` must be provided.')
 
-        data = {'sr': str(self), 'resubmit': bool(resubmit),
+        data = {'sr': str(self), 'resubmit': bool(resubmit), 'nsfw': bool(nsfw),
                 'sendreplies': bool(send_replies), 'title': title}
         for key, value in (('flair_id', flair_id), ('flair_text', flair_text)):
             if value is not None:
@@ -600,6 +602,7 @@ class Subreddit(RedditBase, MessageableMixin, SubredditListingMixin):
             data.update(kind='self', text=selftext)
         else:
             data.update(kind='link', url=url)
+
         return self._reddit.post(API_PATH['submit'], data=data)
 
     def submit_image(self, title, image_path, flair_id=None,

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -553,8 +553,8 @@ class Subreddit(RedditBase, MessageableMixin, SubredditListingMixin):
         return self._submission_class(self._reddit, url=urljoin(
             self._reddit.config.reddit_url, path))
 
-    def submit(self, title, selftext=None, url=None, flair_id=None, nsfw=False,
-               flair_text=None, resubmit=True, send_replies=True):
+    def submit(self, title, selftext=None, url=None, flair_id=None,
+               flair_text=None, resubmit=True, send_replies=True, nsfw=False):
         """Add a submission to the subreddit.
 
         :param title: The title of the submission.
@@ -606,8 +606,9 @@ class Subreddit(RedditBase, MessageableMixin, SubredditListingMixin):
 
         return self._reddit.post(API_PATH['submit'], data=data)
 
-    def submit_image(self, title, image_path, flair_id=None, nsfw=False,
-                     flair_text=None, resubmit=True, send_replies=True):
+    def submit_image(self, title, image_path, flair_id=None,
+                     flair_text=None, resubmit=True, send_replies=True,
+                     nsfw=False):
         """Add an image submission to the subreddit.
 
         :param title: The title of the submission.
@@ -650,9 +651,9 @@ class Subreddit(RedditBase, MessageableMixin, SubredditListingMixin):
         data.update(kind='image', url=self._upload_media(image_path))
         return self._submit_media(data)
 
-    def submit_video(self, title, video_path, videogif=False, nsfw=True,
+    def submit_video(self, title, video_path, videogif=False,
                      thumbnail_path=None, flair_id=None, flair_text=None,
-                     resubmit=True, send_replies=True):
+                     resubmit=True, send_replies=True, nsfw=False):
         """Add a video or videogif submission to the subreddit.
 
         :param title: The title of the submission.

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -593,8 +593,9 @@ class Subreddit(RedditBase, MessageableMixin, SubredditListingMixin):
         if (bool(selftext) or selftext == '') == bool(url):
             raise TypeError('Either `selftext` or `url` must be provided.')
 
-        data = {'sr': str(self), 'resubmit': bool(resubmit), 'nsfw': bool(nsfw),
-                'sendreplies': bool(send_replies), 'title': title}
+        data = {'sr': str(self), 'resubmit': bool(resubmit),
+                'sendreplies': bool(send_replies), 'title': title,
+                'nsfw': bool(nsfw)}
         for key, value in (('flair_id', flair_id), ('flair_text', flair_text)):
             if value is not None:
                 data[key] = value
@@ -640,8 +641,9 @@ class Subreddit(RedditBase, MessageableMixin, SubredditListingMixin):
            reddit.subreddit('reddit_api_test').submit_image(title, image)
 
         """
-        data = {'sr': str(self), 'resubmit': bool(resubmit), 'nsfw': bool(nsfw),
-                'sendreplies': bool(send_replies), 'title': title}
+        data = {'sr': str(self), 'resubmit': bool(resubmit),
+                'sendreplies': bool(send_replies), 'title': title,
+                'nsfw': bool(nsfw)}
         for key, value in (('flair_id', flair_id), ('flair_text', flair_text)):
             if value is not None:
                 data[key] = value
@@ -691,8 +693,9 @@ class Subreddit(RedditBase, MessageableMixin, SubredditListingMixin):
            reddit.subreddit('reddit_api_test').submit_video(title, video)
 
         """
-        data = {'sr': str(self), 'resubmit': bool(resubmit), 'nsfw': bool(nsfw),
-                'sendreplies': bool(send_replies), 'title': title}
+        data = {'sr': str(self), 'resubmit': bool(resubmit),
+                'sendreplies': bool(send_replies), 'title': title,
+                'nsfw': bool(nsfw)}
         for key, value in (('flair_id', flair_id), ('flair_text', flair_text)):
             if value is not None:
                 data[key] = value

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -605,7 +605,7 @@ class Subreddit(RedditBase, MessageableMixin, SubredditListingMixin):
 
         return self._reddit.post(API_PATH['submit'], data=data)
 
-    def submit_image(self, title, image_path, flair_id=None,
+    def submit_image(self, title, image_path, flair_id=None, nsfw=False,
                      flair_text=None, resubmit=True, send_replies=True):
         """Add an image submission to the subreddit.
 
@@ -618,6 +618,8 @@ class Subreddit(RedditBase, MessageableMixin, SubredditListingMixin):
             been submitted (default: True).
         :param send_replies: When True, messages will be sent to the submission
             author when comments are made to the submission (default: True).
+        :param nsfw: Whether or not the submission should be marked NSFW
+            (default: False).
 
         .. note::
 
@@ -638,7 +640,7 @@ class Subreddit(RedditBase, MessageableMixin, SubredditListingMixin):
            reddit.subreddit('reddit_api_test').submit_image(title, image)
 
         """
-        data = {'sr': str(self), 'resubmit': bool(resubmit),
+        data = {'sr': str(self), 'resubmit': bool(resubmit), 'nsfw': bool(nsfw),
                 'sendreplies': bool(send_replies), 'title': title}
         for key, value in (('flair_id', flair_id), ('flair_text', flair_text)):
             if value is not None:
@@ -646,7 +648,7 @@ class Subreddit(RedditBase, MessageableMixin, SubredditListingMixin):
         data.update(kind='image', url=self._upload_media(image_path))
         return self._submit_media(data)
 
-    def submit_video(self, title, video_path, videogif=False,
+    def submit_video(self, title, video_path, videogif=False, nsfw=True,
                      thumbnail_path=None, flair_id=None, flair_text=None,
                      resubmit=True, send_replies=True):
         """Add a video or videogif submission to the subreddit.
@@ -667,6 +669,8 @@ class Subreddit(RedditBase, MessageableMixin, SubredditListingMixin):
         :param send_replies: When True, messages will be sent to the submission
             author when comments are made to the submission
             (default: ``True``).
+        :param nsfw: Whether or not the submission should be marked NSFW
+            (default: False).
 
         .. note::
 
@@ -687,7 +691,7 @@ class Subreddit(RedditBase, MessageableMixin, SubredditListingMixin):
            reddit.subreddit('reddit_api_test').submit_video(title, video)
 
         """
-        data = {'sr': str(self), 'resubmit': bool(resubmit),
+        data = {'sr': str(self), 'resubmit': bool(resubmit), 'nsfw': bool(nsfw),
                 'sendreplies': bool(send_replies), 'title': title}
         for key, value in (('flair_id', flair_id), ('flair_text', flair_text)):
             if value is not None:

--- a/tests/integration/cassettes/TestSubreddit.test_submit__nsfw.json
+++ b/tests/integration/cassettes/TestSubreddit.test_submit__nsfw.json
@@ -1,0 +1,343 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2019-02-21T03:04:13",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "59"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.1.2.dev0 prawcore/1.0.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "118"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 21 Feb 2019 03:04:13 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "edgebucket=zoOlAtvsQBOZlj1krt; Domain=reddit.com; Max-Age=63071999; Path=/;  secure"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-den19639-DEN"
+          ],
+          "X-Timer": [
+            "S1550718253.323082,VS0,VE348"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2019-02-21T03:04:14",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&kind=self&nsfw=True&resubmit=True&sendreplies=True&sr=<TEST_SUBREDDIT>&text=Test+text.&title=Test+Title"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "116"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "edgebucket=zoOlAtvsQBOZlj1krt"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.1.2.dev0 prawcore/1.0.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/submit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [], \"data\": {\"url\": \"https://www.reddit.com/r/<TEST_SUBREDDIT>/comments/asxv46/test_title/\", \"drafts_count\": 0, \"id\": \"asxv46\", \"name\": \"t3_asxv46\"}}}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "169"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 21 Feb 2019 03:04:14 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-den19632-DEN"
+          ],
+          "X-Timer": [
+            "S1550718254.895266,VS0,VE293"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "set-cookie": [
+            "loid=00000000001shfezdd.2.1531787773573.Z0FBQUFBQmNiaFV1a0haM0lzeUtpSjVjcHFqRGFmMWM3MUpCSUN0a2lmZ1RydWlkbXZmQ0VhSkVaeGFmTzVhMFk2Q1R1bER1RWRsVklON29ZN1BKY2ZKbzFzOVNJMmNCZFMtUm9TTTlzNWhvNzF5cXNQUDVBVkRVMUN5ZmYwQWtFdGRVc0kxVEJ3ajc; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Sat, 20-Feb-2021 03:04:14 GMT; secure",
+            "redesign_optout=true; Domain=reddit.com; Max-Age=94607999; Path=/; expires=Sun, 20-Feb-2022 03:04:13 GMT; secure",
+            "session_tracker=HPHgDXmAoChgRb2VEz.0.1550718253953.Z0FBQUFBQmNiaFV1QUEtRnBfU0Z2dFJtZlJVTzZJS25SNWJmaDNWS05Sem15d0RpT2VQVXE4Z1NEdXRhQ2F6MjV0ZHdZSm5fMDE4UGpTbnlkZkVJR043SV9pM09XcFpHcXdpazRhdmZoSk8xRFJSWG5sbEdHRFAxR2pMa3cwWG1VWUo3Mnl4VzZCSW8; Domain=reddit.com; Max-Age=7199; Path=/; expires=Thu, 21-Feb-2019 05:04:14 GMT; secure"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "599.0"
+          ],
+          "x-ratelimit-reset": [
+            "347"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/submit/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2019-02-21T03:04:14",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "edgebucket=zoOlAtvsQBOZlj1krt; loid=00000000001shfezdd.2.1531787773573.Z0FBQUFBQmNiaFV1a0haM0lzeUtpSjVjcHFqRGFmMWM3MUpCSUN0a2lmZ1RydWlkbXZmQ0VhSkVaeGFmTzVhMFk2Q1R1bER1RWRsVklON29ZN1BKY2ZKbzFzOVNJMmNCZFMtUm9TTTlzNWhvNzF5cXNQUDVBVkRVMUN5ZmYwQWtFdGRVc0kxVEJ3ajc; redesign_optout=true; session_tracker=HPHgDXmAoChgRb2VEz.0.1550718253953.Z0FBQUFBQmNiaFV1QUEtRnBfU0Z2dFJtZlJVTzZJS25SNWJmaDNWS05Sem15d0RpT2VQVXE4Z1NEdXRhQ2F6MjV0ZHdZSm5fMDE4UGpTbnlkZkVJR043SV9pM09XcFpHcXdpazRhdmZoSk8xRFJSWG5sbEdHRFAxR2pMa3cwWG1VWUo3Mnl4VzZCSW8"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.1.2.dev0 prawcore/1.0.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/comments/asxv46/?limit=2048&sort=best&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"dist\": 1, \"children\": [{\"kind\": \"t3\", \"data\": {\"approved_at_utc\": null, \"subreddit\": \"<TEST_SUBREDDIT>\", \"selftext\": \"Test text.\", \"user_reports\": [], \"saved\": false, \"mod_reason_title\": null, \"gilded\": 0, \"clicked\": false, \"title\": \"Test Title\", \"link_flair_richtext\": [], \"subreddit_name_prefixed\": \"r/<TEST_SUBREDDIT>\", \"hidden\": false, \"pwls\": null, \"link_flair_css_class\": null, \"downs\": 0, \"thumbnail_height\": null, \"parent_whitelist_status\": null, \"hide_score\": false, \"name\": \"t3_asxv46\", \"quarantine\": false, \"link_flair_text_color\": \"dark\", \"upvote_ratio\": 1.0, \"author_flair_background_color\": null, \"subreddit_type\": \"public\", \"ups\": 1, \"domain\": \"self.<TEST_SUBREDDIT>\", \"media_embed\": {}, \"thumbnail_width\": null, \"author_flair_template_id\": null, \"is_original_content\": false, \"author_fullname\": \"t2_1shfezdd\", \"secure_media\": null, \"is_reddit_media_domain\": false, \"is_meta\": false, \"category\": null, \"secure_media_embed\": {}, \"link_flair_text\": null, \"can_mod_post\": false, \"score\": 1, \"approved_by\": null, \"thumbnail\": \"self\", \"edited\": false, \"author_flair_css_class\": null, \"author_flair_richtext\": [], \"gildings\": {\"gid_1\": 0, \"gid_2\": 0, \"gid_3\": 0}, \"content_categories\": null, \"is_self\": true, \"mod_note\": null, \"created\": 1550718253.0, \"link_flair_type\": \"text\", \"wls\": null, \"banned_by\": null, \"author_flair_type\": \"text\", \"contest_mode\": false, \"selftext_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003ETest text.\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"likes\": true, \"suggested_sort\": null, \"banned_at_utc\": null, \"view_count\": null, \"archived\": false, \"no_follow\": false, \"is_crosspostable\": true, \"pinned\": false, \"over_18\": true, \"media\": null, \"media_only\": false, \"link_flair_template_id\": null, \"can_gild\": false, \"spoiler\": false, \"locked\": false, \"author_flair_text\": null, \"rte_mode\": \"markdown\", \"visited\": false, \"num_reports\": null, \"distinguished\": null, \"subreddit_id\": \"t5_2t5o6\", \"mod_reason_by\": null, \"removal_reason\": null, \"link_flair_background_color\": \"\", \"id\": \"asxv46\", \"is_robot_indexable\": true, \"report_reasons\": null, \"author\": \"<USERNAME>\", \"num_crossposts\": 0, \"num_comments\": 0, \"send_replies\": true, \"author_patreon_flair\": false, \"author_flair_text_color\": null, \"permalink\": \"/r/<TEST_SUBREDDIT>/comments/asxv46/test_title/\", \"whitelist_status\": null, \"stickied\": false, \"url\": \"https://www.reddit.com/r/<TEST_SUBREDDIT>/comments/asxv46/test_title/\", \"subreddit_subscribers\": 37, \"created_utc\": 1550718253.0, \"mod_reports\": [], \"is_video\": false}}], \"after\": null, \"before\": null}}, {\"kind\": \"Listing\", \"data\": {\"modhash\": null, \"dist\": null, \"children\": [], \"after\": null, \"before\": null}}]"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2741"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 21 Feb 2019 03:04:14 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Vary": [
+            "accept-encoding"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-den19632-DEN"
+          ],
+          "X-Timer": [
+            "S1550718254.251460,VS0,VE106"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "set-cookie": [
+            "session_tracker=HPHgDXmAoChgRb2VEz.0.1550718254297.Z0FBQUFBQmNiaFV1dXpqZTdOdmtuVDFNaVk2QUVKMEZER3FqV1ZyYlpHRkFKTVhLak1qYnk1dXpFMXhvMFpIMUFnNkc1bVVYdW13ZTM1aTNFVHctYnVpdDY4cWNoLXI5ZGZnRmU2S1lRaklKbUFnd2ZQWFhTaXY5YWp0VG9LRmo1a0ViRnRJTk1wWDI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Thu, 21-Feb-2019 05:04:14 GMT; secure"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "598.0"
+          ],
+          "x-ratelimit-reset": [
+            "346"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/comments/asxv46/?limit=2048&sort=best&raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/integration/models/reddit/test_subreddit.py
+++ b/tests/integration/models/reddit/test_subreddit.py
@@ -183,6 +183,16 @@ class TestSubreddit(IntegrationTest):
             assert submission.title == 'Test Title'
 
     @mock.patch('time.sleep', return_value=None)
+    def test_submit__nsfw(self, _):
+        self.reddit.read_only = False
+        with self.recorder.use_cassette('TestSubreddit.test_submit__nsfw'):
+            subreddit = self.subreddit = self.reddit.subreddit(
+                pytest.placeholders.test_subreddit)
+            submission = subreddit.submit('Test Title', selftext='Test text.',
+                                          nsfw=True)
+            assert submission.over_18 is True
+
+    @mock.patch('time.sleep', return_value=None)
     @mock.patch('websocket.create_connection',
                 return_value=WebsocketMock('ahf0uh',  # update with cassette
                                            'ahf0uq',  # update with cassette


### PR DESCRIPTION
## Feature Summary and Justification

The Reddit API has the parameter `nsfw` in /api/submit, which immediately marks the submission as NSFW. However, PRAW currently requires you to call `Submission.nsfw`, which works via the `/api/marknsfw` endpoint. This requires the `modposts` scope. This pull request adds the parameter to the `submit`, `submit_image`, and `submit_video` methods via a new keyword argument.

P.S. Another good addition might be the spoiler parameter, which is basically the same situation.

## References

* https://www.reddit.com/dev/api/oauth#POST_api_submit
* https://www.reddit.com/dev/api/oauth#POST_api_marknsfw
