### PR TITLE
Raise and customize timeout when submitting images and videos

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -18,6 +18,9 @@ Unreleased
 * :meth:`~.Subreddit.submit`, :meth:`~.Subreddit.submit_image`, and
   :meth:`~.Subreddit.submit_video` support parameter ``spoiler`` to
   mark the submission as a spoiler immediately upon posting.
+* :meth:`~.Subreddit.submit_image` and `~.Subreddit.submit_video` support
+  parameter ``timeout``. Default timeout has been raised from 2 seconds to
+  10 seconds.
 
 **Other**
 

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -665,8 +665,8 @@ class Subreddit(RedditBase, MessageableMixin, SubredditListingMixin):
         :param title: The title of the submission.
         :param video_path: The path to a video, to upload and post.
         :param videogif: A ``bool`` value. If ``True``, the video is
-            uploaded as a videogif, which is essentially a silent video (
-            default: ``False``).
+            uploaded as a videogif, which is essentially a silent video
+            (default: ``False``).
         :param thumbnail_path: (Optional) The path to an image, to be uploaded
             and used as the thumbnail for this video. If not provided, the
             PRAW logo will be used as the thumbnail.


### PR DESCRIPTION
Fixes #1028

## Feature Summary and Justification

This feature provides a higher default websocket timeout in the image and video submission methods, and allows it to be customized.

I chose 10 as the new default because it should allow most images to be submitted without timeout. Some very large images, such as the example in #1028, will still require manually higher timeout values. The downside is that, when there are errors, code may essentially hang for 10 seconds.

I also [removed the timeout of 2](https://github.com/praw-dev/praw/commit/16ae17d3eb77673f25f5b17cd6ed76615a3b352b#diff-a6c46ac5ed8df35e279b7cd7973765fcR453) from the `socket.close()` call. It will use the default websocket client value, [which is 3](https://github.com/websocket-client/websocket-client/blob/66081be8e0523c9dfaffcb18ba1c8e4765e2288e/websocket/_core.py#L392).
