### PR TITLE
Candidate patch for #1043

### DIFF
--- a/praw/models/util.py
+++ b/praw/models/util.py
@@ -77,7 +77,11 @@ def permissions_string(permissions, known_permissions):
 
 
 def stream_generator(
-    function, pause_after=None, skip_existing=False, attribute_name="fullname"
+    function,
+    pause_after=None,
+    skip_existing=False,
+    attribute_name="fullname",
+    before_adjusting=True,
 ):
     """Yield new items from ListingGenerators and ``None`` when paused.
 
@@ -164,10 +168,8 @@ def stream_generator(
     while True:
         found = False
         newest_attribute = None
-        limit = 100
-        if before_attribute is None:
-            limit -= without_before_counter
-            without_before_counter = (without_before_counter + 1) % 30
+        limit = 100 - without_before_counter
+        without_before_counter = (without_before_counter + 1) % 6
         for item in reversed(
             list(function(limit=limit, params={"before": before_attribute}))
         ):
@@ -179,7 +181,8 @@ def stream_generator(
             newest_attribute = attribute
             if not skip_existing:
                 yield item
-        before_attribute = newest_attribute
+        if before_adjusting:
+            before_attribute = newest_attribute
         skip_existing = False
         if valid_pause_after and pause_after < 0:
             yield None


### PR DESCRIPTION
This PR introduces a `before_adjusting=True` parameter on `stream_generator()`, and makes `before_adjusting=False` when r/all is the target of a stream, in an attempt to patch issue #1043.

This solution is an alternative to removing before adjusting altogether.

Some cassettes need to be updated before all tests can pass.
