### PR TITLE
Add FullnameMixin to separate fullname functionality from RedditBase

### DIFF
--- a/praw/models/reddit/base.py
+++ b/praw/models/reddit/base.py
@@ -1,8 +1,7 @@
 """Provide the RedditBase class."""
 
 from ...compat import string_types, urlparse
-from ...const import API_PATH
-from ...exceptions import ClientException, PRAWException
+from ...exceptions import ClientException
 from ..base import PRAWBase
 
 
@@ -15,18 +14,6 @@ class RedditBase(PRAWBase):
         if not parsed.netloc:
             raise ClientException("Invalid URL: {}".format(url))
         return parsed.path.rstrip("/").split("/")
-
-    @property
-    def fullname(self):
-        """Return the object's fullname.
-
-        A fullname is an object's kind mapping like ``t3`` followed by an
-        underscore and the object's base36 ID, e.g., ``t1_c5s96e0``.
-
-        """
-        return "{}_{}".format(
-            self._reddit._objector.kind(self), self.id
-        )  # pylint: disable=invalid-name
 
     def __eq__(self, other):
         """Return whether the other instance equals the current."""
@@ -77,22 +64,8 @@ class RedditBase(PRAWBase):
         return not self == other
 
     def _fetch(self):
-        if "_info_path" in dir(self):
-            other = self._reddit.get(
-                self._info_path(), params=self._info_params
-            )
-        else:
-            self._info_params["id"] = self.fullname
-            children = self._reddit.get(
-                API_PATH["info"], params=self._info_params
-            ).children
-            if not children:
-                raise PRAWException(
-                    "No {!r} data returned for thing {}".format(
-                        self.__class__.__name__, self.fullname
-                    )
-                )
-            other = children[0]
+        other = self._reddit.get(self._info_path(), params=self._info_params)
+
         self.__dict__.update(other.__dict__)
         self._fetched = True
 

--- a/praw/models/reddit/comment.py
+++ b/praw/models/reddit/comment.py
@@ -2,11 +2,16 @@
 from ...exceptions import ClientException
 from ..comment_forest import CommentForest
 from .base import RedditBase
-from .mixins import InboxableMixin, ThingModerationMixin, UserContentMixin
+from .mixins import (
+    FullnameMixin,
+    InboxableMixin,
+    ThingModerationMixin,
+    UserContentMixin,
+)
 from .redditor import Redditor
 
 
-class Comment(InboxableMixin, UserContentMixin, RedditBase):
+class Comment(InboxableMixin, UserContentMixin, FullnameMixin, RedditBase):
     """A class that represents a reddit comments.
 
     **Typical Attributes**

--- a/praw/models/reddit/live.py
+++ b/praw/models/reddit/live.py
@@ -3,6 +3,7 @@ from ...const import API_PATH
 from ..listing.generator import ListingGenerator
 from ..list.redditor import RedditorList
 from .base import RedditBase
+from .mixins import FullnameMixin
 from .redditor import Redditor
 
 
@@ -531,7 +532,7 @@ class LiveThreadContribution(object):
         self.thread._reset_attributes(*data.keys())
 
 
-class LiveUpdate(RedditBase):
+class LiveUpdate(FullnameMixin, RedditBase):
     """An individual :class:`.LiveUpdate` object.
 
     **Typical Attributes**

--- a/praw/models/reddit/message.py
+++ b/praw/models/reddit/message.py
@@ -1,12 +1,12 @@
 """Provide the Message class."""
 from ...const import API_PATH
 from .base import RedditBase
-from .mixins import InboxableMixin, ReplyableMixin
+from .mixins import FullnameMixin, InboxableMixin, ReplyableMixin
 from .redditor import Redditor
 from .subreddit import Subreddit
 
 
-class Message(InboxableMixin, ReplyableMixin, RedditBase):
+class Message(InboxableMixin, ReplyableMixin, FullnameMixin, RedditBase):
     """A class for private messages.
 
     **Typical Attributes**

--- a/praw/models/reddit/mixins/__init__.py
+++ b/praw/models/reddit/mixins/__init__.py
@@ -2,6 +2,7 @@
 from json import dumps
 from ....const import API_PATH
 from .editable import EditableMixin
+from .fullname import FullnameMixin
 from .gildable import GildableMixin
 from .inboxable import InboxableMixin
 from .inboxtoggleable import InboxToggleableMixin

--- a/praw/models/reddit/mixins/fullname.py
+++ b/praw/models/reddit/mixins/fullname.py
@@ -1,0 +1,37 @@
+"""Provide the FullnameMixin class."""
+from ....const import API_PATH
+from ....exceptions import PRAWException
+
+
+class FullnameMixin(object):
+    """Interface for classes that have a fullname."""
+
+    @property
+    def fullname(self):
+        """Return the object's fullname.
+
+        A fullname is an object's kind mapping like ``t3`` followed by an
+        underscore and the object's base36 ID, e.g., ``t1_c5s96e0``.
+
+        """
+        return "{}_{}".format(
+            self._reddit._objector.kind(self), self.id
+        )  # pylint: disable=invalid-name
+
+    def _fetch(self):
+        if "_info_path" in dir(self):
+            super(FullnameMixin, self)._fetch()
+        else:
+            self._info_params["id"] = self.fullname
+            children = self._reddit.get(
+                API_PATH["info"], params=self._info_params
+            ).children
+            if not children:
+                raise PRAWException(
+                    "No {!r} data returned for thing {}".format(
+                        self.__class__.__name__, self.fullname
+                    )
+                )
+            other = children[0]
+            self.__dict__.update(other.__dict__)
+            self._fetched = True

--- a/praw/models/reddit/redditor.py
+++ b/praw/models/reddit/redditor.py
@@ -5,10 +5,12 @@ from ...const import API_PATH
 from ..listing.mixins import RedditorListingMixin
 from ..util import stream_generator
 from .base import RedditBase
-from .mixins import MessageableMixin
+from .mixins import FullnameMixin, MessageableMixin
 
 
-class Redditor(MessageableMixin, RedditorListingMixin, RedditBase):
+class Redditor(
+    MessageableMixin, RedditorListingMixin, FullnameMixin, RedditBase
+):
     """A class representing the users of reddit.
 
     **Typical Attributes**

--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -5,12 +5,14 @@ from ...exceptions import ClientException
 from ..comment_forest import CommentForest
 from ..listing.mixins import SubmissionListingMixin
 from .base import RedditBase
-from .mixins import ThingModerationMixin, UserContentMixin
+from .mixins import FullnameMixin, ThingModerationMixin, UserContentMixin
 from .redditor import Redditor
 from .subreddit import Subreddit
 
 
-class Submission(SubmissionListingMixin, UserContentMixin, RedditBase):
+class Submission(
+    SubmissionListingMixin, UserContentMixin, FullnameMixin, RedditBase
+):
     """A class for submissions to reddit.
 
     **Typical Attributes**

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -15,13 +15,15 @@ from ..listing.generator import ListingGenerator
 from ..listing.mixins import SubredditListingMixin
 from .base import RedditBase
 from .emoji import SubredditEmoji
-from .mixins import MessageableMixin
+from .mixins import FullnameMixin, MessageableMixin
 from .modmail import ModmailConversation
 from .widgets import SubredditWidgets
 from .wikipage import WikiPage
 
 
-class Subreddit(MessageableMixin, SubredditListingMixin, RedditBase):
+class Subreddit(
+    MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBase
+):
     """A class for Subreddits.
 
     To obtain an instance of this class for subreddit ``/r/redditdev`` execute:


### PR DESCRIPTION
## Feature Summary and Justification

This feature separates out behaviors related to `fullname` from `RedditBase`, because there are many objects which benefit from the `RedditBase` model but do not have fullnames.

This PR is related to [conversation](https://github.com/praw-dev/praw/issues/1053#issuecomment-487463864) in #1053 about proper inheritance.

All tests pass without modification; all code is formatted by `black`.

### Regarding naming

@Pyprohly said:
> Hey, what about `AttributeMixins.Fullname`? Define a whole namespace for attribute mixins.
>
> `fullname` is the only custom attribute on PRAW objects at the moment, but it might be useful to add more to `AttributeMixins` in future.

I think this is worth exploring, but we should consider this once we have other custom attributes to put in the namespace.