### PR TITLE
Add lock and unlock to Comments

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -44,4 +44,5 @@ Source Contributors
 - Elaina Martineau `@CrackedP0t <https://github.com/CrackedP0t>`_
 - Rob Curtis <BourbonInExile@gmail.com> `@waab76 <https://github.com/waab76>`_
 - LilSpazJoekp `@LilSpazJoekp <https://github.com/LilSpazJoekp>`_
+- Timendum `@timendum <https://github.com/timendum>`_
 - Add "Name <email (optional)> and github profile link" above this line.

--- a/praw/models/reddit/mixins/__init__.py
+++ b/praw/models/reddit/mixins/__init__.py
@@ -97,6 +97,25 @@ class ThingModerationMixin(object):
             API_PATH["ignore_reports"], data={"id": self.thing.fullname}
         )
 
+    def lock(self):
+        """Lock the a :class:`~.Comment` or :class:`~.Submission`.
+
+        Example usage:
+
+           # lock a comment:
+           comment = reddit.comment('dkk4qjd')
+           comment.mod.lock()
+           # lock a submission:
+           submission = reddit.submission(id='5or86n')
+           submission.mod.lock()
+
+        See also :meth:`~.unlock`
+
+        """
+        self.thing._reddit.post(
+            API_PATH["lock"], data={"id": self.thing.fullname}
+        )
+
     def remove(self, spam=False):
         """Remove a :class:`~.Comment` or :class:`~.Submission`.
 
@@ -197,6 +216,25 @@ class ThingModerationMixin(object):
         """
         self.thing._reddit.post(
             API_PATH["unignore_reports"], data={"id": self.thing.fullname}
+        )
+
+    def unlock(self):
+        """Unlock the a :class:`~.Comment` or :class:`~.Submission`.
+
+        Example usage:
+
+           # unlock a comment:
+           comment = reddit.comment('dkk4qjd')
+           comment.mod.unlock()
+           # unlock a submission:
+           submission = reddit.submission(id='5or86n')
+           submission.mod.unlock()
+
+        See also :meth:`~.lock`
+
+        """
+        self.thing._reddit.post(
+            API_PATH["unlock"], data={"id": self.thing.fullname}
         )
 
 

--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -465,23 +465,6 @@ class SubmissionModeration(ThingModerationMixin):
         url = API_PATH["flair"].format(subreddit=self.thing.subreddit)
         self.thing._reddit.post(url, data=data)
 
-    def lock(self):
-        """Lock the submission.
-
-        Example usage:
-
-        .. code:: python
-
-           submission = reddit.submission(id='5or86n')
-           submission.mod.lock()
-
-        See also :meth:`~.unlock`
-
-        """
-        self.thing._reddit.post(
-            API_PATH["lock"], data={"id": self.thing.fullname}
-        )
-
     def nsfw(self):
         """Mark as not safe for work.
 
@@ -580,23 +563,6 @@ class SubmissionModeration(ThingModerationMixin):
         self.thing._reddit.post(
             API_PATH["suggested_sort"],
             data={"id": self.thing.fullname, "sort": sort},
-        )
-
-    def unlock(self):
-        """Unlock the submission.
-
-        Example:
-
-        .. code:: python
-
-           submission = reddit.submission(id='5or86n')
-           submission.mod.unlock()
-
-        See also :meth:`~.lock`
-
-        """
-        self.thing._reddit.post(
-            API_PATH["unlock"], data={"id": self.thing.fullname}
         )
 
     def unspoiler(self):

--- a/tests/integration/models/reddit/test_comment.py
+++ b/tests/integration/models/reddit/test_comment.py
@@ -267,10 +267,20 @@ class TestCommentModeration(IntegrationTest):
         ):
             self.reddit.comment("da2g5y6").mod.ignore_reports()
 
+    def test_lock(self):
+        self.reddit.read_only = False
+        with self.recorder.use_cassette("TestCommentModeration.test_lock"):
+            Comment(self.reddit, "da2g6ne").mod.lock()
+
     def test_remove(self):
         self.reddit.read_only = False
         with self.recorder.use_cassette("TestCommentModeration.test_remove"):
             self.reddit.comment("da2g5y6").mod.remove(spam=True)
+
+    def test_unlock(self):
+        self.reddit.read_only = False
+        with self.recorder.use_cassette("TestCommentModeration.test_unlock"):
+            Comment(self.reddit, "da2g6ne").mod.unlock()
 
     @mock.patch("time.sleep", return_value=None)
     def test_send_removal_message(self, _):


### PR DESCRIPTION
Hi,
by moving the `lock` and `unlock` methods from Submission to ThingModerationMixin, they are available also to Comment objects.

I've added the test cases, but I'm not providing a cassette, you can easly generate one by running `pytest`.

The methods are tested anyway, on my test subreddit.

Fixes #1073

## Feature Summary and Justification Comment objects.

This feature provides lock and unlock methods for 

## References

* https://www.reddit.com/r/modnews/comments/brgr8i/moderators_you_may_now_lock_individual_comments/
