### PR TITLE
Remove `FullnameMixin.kind`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,13 @@
 Change Log
 ==========
 
+Unreleased
+----------
+
+**Changed**
+
+* Removed ``FullnameMixin.kind``
+
 6.3.0 (2019/06/09)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Unreleased
 **Changed**
 
 * Removed ``FullnameMixin.kind``
+* Removed ``SubredditListingMixin.gilded()``
 
 6.3.0 (2019/06/09)
 ------------------

--- a/praw/models/listing/mixins/subreddit.py
+++ b/praw/models/listing/mixins/subreddit.py
@@ -64,18 +64,3 @@ class CommentHelper(PRAWBase):
 
         """
         return ListingGenerator(self._reddit, self._path, **generator_kwargs)
-
-    def gilded(self, **generator_kwargs):
-        """Deprecated.
-
-        .. warning:: (Deprecated) This method will be removed in PRAW 6 because
-                     it doesn't actually restrict the results to gilded
-                     Comments. Use ``subreddit.gilded`` instead.
-
-        Additional keyword arguments are passed in the initialization of
-        :class:`.ListingGenerator`.
-
-        """
-        return ListingGenerator(
-            self._reddit, urljoin(self._path, "gilded"), **generator_kwargs
-        )

--- a/praw/models/reddit/comment.py
+++ b/praw/models/reddit/comment.py
@@ -75,7 +75,7 @@ class Comment(InboxableMixin, UserContentMixin, FullnameMixin, RedditBase):
         return parts[-1]
 
     @property
-    def kind(self):
+    def _kind(self):
         """Return the class's kind."""
         return self._reddit.config.kinds["comment"]
 

--- a/praw/models/reddit/live.py
+++ b/praw/models/reddit/live.py
@@ -565,7 +565,7 @@ class LiveUpdate(FullnameMixin, RedditBase):
     """
 
     STR_FIELD = "id"
-    kind = "LiveUpdate"
+    _kind = "LiveUpdate"
 
     @cachedproperty
     def contrib(self):

--- a/praw/models/reddit/message.py
+++ b/praw/models/reddit/message.py
@@ -72,7 +72,7 @@ class Message(InboxableMixin, ReplyableMixin, FullnameMixin, RedditBase):
         return cls(reddit, _data=data)
 
     @property
-    def kind(self):
+    def _kind(self):
         """Return the class's kind."""
         return self._reddit.config.kinds["message"]
 

--- a/praw/models/reddit/mixins/fullname.py
+++ b/praw/models/reddit/mixins/fullname.py
@@ -4,7 +4,7 @@
 class FullnameMixin(object):
     """Interface for classes that have a fullname."""
 
-    kind = None
+    _kind = None
 
     @property
     def fullname(self):
@@ -14,4 +14,4 @@ class FullnameMixin(object):
         underscore and the object's base36 ID, e.g., ``t1_c5s96e0``.
 
         """
-        return "{}_{}".format(self.kind, self.id)
+        return "{}_{}".format(self._kind, self.id)

--- a/praw/models/reddit/redditor.py
+++ b/praw/models/reddit/redditor.py
@@ -98,7 +98,7 @@ class Redditor(
         return RedditorStream(self)
 
     @property
-    def kind(self):
+    def _kind(self):
         """Return the class's kind."""
         return self._reddit.config.kinds["redditor"]
 

--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -99,7 +99,7 @@ class Submission(
         return submission_id
 
     @property
-    def kind(self):
+    def _kind(self):
         """Return the class's kind."""
         return self._reddit.config.kinds["submission"]
 

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -189,7 +189,7 @@ class Subreddit(
         return str(subreddit)
 
     @property
-    def kind(self):
+    def _kind(self):
         """Return the class's kind."""
         return self._reddit.config.kinds["subreddit"]
 

--- a/tests/integration/models/reddit/test_subreddit.py
+++ b/tests/integration/models/reddit/test_subreddit.py
@@ -861,15 +861,6 @@ class TestSubredditListings(IntegrationTest):
             comments = list(subreddit.comments())
         assert len(comments) == 100
 
-    def test_comments_gilded(self):
-        with self.recorder.use_cassette(
-            "TestSubredditListings.test_comments_gilded"
-        ):
-            subreddit = self.reddit.subreddit("askreddit")
-            comments = list(subreddit.comments.gilded())
-        assert any(isinstance(x, Submission) for x in comments)
-        assert len(comments) == 100
-
     def test_controversial(self):
         with self.recorder.use_cassette(
             "TestSubredditListings.test_controversial"


### PR DESCRIPTION
The value of `.kind` is an implementation detail of the API.

Prefer `comment is Comment` instead of `comment.kind == "t1"`.
