### PR TITLE
Fix class references in Reddit class documentation

### DIFF
--- a/docs/code_overview/other.rst
+++ b/docs/code_overview/other.rst
@@ -87,6 +87,7 @@ instances of them bound to an attribute of one of the PRAW models.
    other/button
    other/commentforest
    other/commenthelper
+   other/config
    other/domainlisting
    other/emoji
    other/listinggenerator

--- a/docs/code_overview/other/config.rst
+++ b/docs/code_overview/other/config.rst
@@ -1,0 +1,5 @@
+Config
+======
+
+.. autoclass:: praw.config.Config
+   :inherited-members:

--- a/praw/reddit.py
+++ b/praw/reddit.py
@@ -90,7 +90,7 @@ class Reddit(object):
         requestor_class=None,
         requestor_kwargs=None,
         **config_settings
-    ):
+    ):  # noqa: D207, D301
         """Initialize a Reddit instance.
 
         :param site_name: The name of a section in your ``praw.ini`` file from
@@ -107,7 +107,7 @@ class Reddit(object):
             used to initialize the requestor (default: None).
 
         Additional keyword arguments will be used to initialize the
-        :class`.Config` object. This can be used to specify configuration
+        :class:`.Config` object. This can be used to specify configuration
         settings during instantiation of the :class:`.Reddit` instance. For
         more details please see :ref:`configuration`.
 
@@ -118,9 +118,13 @@ class Reddit(object):
         * user_agent
 
         The ``requestor_class`` and ``requestor_kwargs`` allow for
-        customization of the requestor :class`.Reddit` will use. This allows,
+        customization of the requestor :class:`.Reddit` will use. This allows,
         e.g., easily adding behavior to the requestor or wrapping its
-        :class`Session` in a caching layer. Example usage:
+        |Session|_ in a caching layer. Example usage:
+
+        .. |Session| replace:: ``Session``
+        .. _Session: https://2.python-requests.org/en/master/api/\
+#requests.Session
 
         .. code-block:: python
 


### PR DESCRIPTION
## Feature Summary and Justification

This fix removes three incorrect class references. The `Session` class from Requests is mentioned, so I linked to their documentation. The `Config` class from PRAW didn't have a documentation page, so I added that at @bboe's request. The last reference is formatted incorrectly, so I fixed that.

## References

* https://praw.readthedocs.io/en/v6.3.1/code_overview/reddit_instance.html#praw.Reddit.__init__
