### PR TITLE
Check fetched status before creating comment.replies

### DIFF
--- a/praw/models/reddit/comment.py
+++ b/praw/models/reddit/comment.py
@@ -107,6 +107,8 @@ class Comment(InboxableMixin, UserContentMixin, FullnameMixin, RedditBase):
            replies = comment.replies
 
         """
+        if not self._fetched:
+            self._fetch()
         if isinstance(self._replies, list):
             self._replies = CommentForest(self.submission, self._replies)
         return self._replies


### PR DESCRIPTION
## Feature Summary and Justification

Before the fix, if I create the Comment by id and then invoke replies, None would be returned.

Now the method check if the data is already fetched, if not invoke the _fetch method.