### PR TITLE
Replace py2-style `class Foo(object):` with `class Foo:`

### DIFF
--- a/praw/config.py
+++ b/praw/config.py
@@ -7,7 +7,7 @@ import sys
 from .exceptions import ClientException
 
 
-class _NotSet(object):
+class _NotSet:
     def __bool__(self):
         return False
 
@@ -17,7 +17,7 @@ class _NotSet(object):
         return "NotSet"
 
 
-class Config(object):
+class Config:
     """A class containing the configuration for a reddit site."""
 
     CONFIG = None

--- a/praw/models/base.py
+++ b/praw/models/base.py
@@ -2,7 +2,7 @@
 from copy import deepcopy
 
 
-class PRAWBase(object):
+class PRAWBase:
     """Superclass for all models in PRAW."""
 
     @staticmethod

--- a/praw/models/comment_forest.py
+++ b/praw/models/comment_forest.py
@@ -4,7 +4,7 @@ from heapq import heappop, heappush
 from .reddit.more import MoreComments
 
 
-class CommentForest(object):
+class CommentForest:
     """A forest of comments starts with multiple top-level comments.
 
     Each of these comments can be a tree of replies.

--- a/praw/models/preferences.py
+++ b/praw/models/preferences.py
@@ -4,7 +4,7 @@ from json import dumps
 from ..const import API_PATH
 
 
-class Preferences(object):
+class Preferences:
     """A class for Reddit preferences.
 
     The Preferences class provides access to the Reddit preferences of the

--- a/praw/models/reddit/emoji.py
+++ b/praw/models/reddit/emoji.py
@@ -79,7 +79,7 @@ class Emoji(RedditBase):
         self._reddit.request("DELETE", url)
 
 
-class SubredditEmoji(object):
+class SubredditEmoji:
     """Provides a set of functions to a Subreddit for emoji."""
 
     def __getitem__(self, name):

--- a/praw/models/reddit/live.py
+++ b/praw/models/reddit/live.py
@@ -8,7 +8,7 @@ from .mixins import FullnameMixin
 from .redditor import Redditor
 
 
-class LiveContributorRelationship(object):
+class LiveContributorRelationship:
     """Provide methods to interact with live threads' contributors."""
 
     @staticmethod
@@ -425,7 +425,7 @@ class LiveThread(RedditBase):
             yield update
 
 
-class LiveThreadContribution(object):
+class LiveThreadContribution:
     """Provides a set of contribution functions to a LiveThread."""
 
     def __init__(self, thread):
@@ -639,7 +639,7 @@ class LiveUpdate(FullnameMixin, RedditBase):
         self._fetched = True
 
 
-class LiveUpdateContribution(object):
+class LiveUpdateContribution:
     """Provides a set of contribution functions to LiveUpdate."""
 
     def __init__(self, update):

--- a/praw/models/reddit/mixins/__init__.py
+++ b/praw/models/reddit/mixins/__init__.py
@@ -13,7 +13,7 @@ from .savable import SavableMixin
 from .votable import VotableMixin
 
 
-class ThingModerationMixin(object):
+class ThingModerationMixin:
     """Provides moderation methods for Comments and Submissions."""
 
     REMOVAL_MESSAGE_API = None

--- a/praw/models/reddit/mixins/editable.py
+++ b/praw/models/reddit/mixins/editable.py
@@ -2,7 +2,7 @@
 from ....const import API_PATH
 
 
-class EditableMixin(object):
+class EditableMixin:
     """Interface for classes that can be edited and deleted."""
 
     def delete(self):

--- a/praw/models/reddit/mixins/fullname.py
+++ b/praw/models/reddit/mixins/fullname.py
@@ -1,7 +1,7 @@
 """Provide the FullnameMixin class."""
 
 
-class FullnameMixin(object):
+class FullnameMixin:
     """Interface for classes that have a fullname."""
 
     _kind = None

--- a/praw/models/reddit/mixins/gildable.py
+++ b/praw/models/reddit/mixins/gildable.py
@@ -2,7 +2,7 @@
 from ....const import API_PATH
 
 
-class GildableMixin(object):
+class GildableMixin:
     """Interface for classes that can be gilded."""
 
     def gild(self):

--- a/praw/models/reddit/mixins/inboxable.py
+++ b/praw/models/reddit/mixins/inboxable.py
@@ -3,7 +3,7 @@
 from ....const import API_PATH
 
 
-class InboxableMixin(object):
+class InboxableMixin:
     """Interface for RedditBase classes that originate from the inbox."""
 
     def block(self):

--- a/praw/models/reddit/mixins/inboxtoggleable.py
+++ b/praw/models/reddit/mixins/inboxtoggleable.py
@@ -2,7 +2,7 @@
 from ....const import API_PATH
 
 
-class InboxToggleableMixin(object):
+class InboxToggleableMixin:
     """Interface for classes that can optionally receive inbox replies."""
 
     def disable_inbox_replies(self):

--- a/praw/models/reddit/mixins/messageable.py
+++ b/praw/models/reddit/mixins/messageable.py
@@ -2,7 +2,7 @@
 from ....const import API_PATH
 
 
-class MessageableMixin(object):
+class MessageableMixin:
     """Interface for classes that can be messaged."""
 
     def message(self, subject, message, from_subreddit=None):

--- a/praw/models/reddit/mixins/replyable.py
+++ b/praw/models/reddit/mixins/replyable.py
@@ -2,7 +2,7 @@
 from ....const import API_PATH
 
 
-class ReplyableMixin(object):
+class ReplyableMixin:
     """Interface for RedditBase classes that can be replied to."""
 
     def reply(self, body):

--- a/praw/models/reddit/mixins/reportable.py
+++ b/praw/models/reddit/mixins/reportable.py
@@ -2,7 +2,7 @@
 from ....const import API_PATH
 
 
-class ReportableMixin(object):
+class ReportableMixin:
     """Interface for RedditBase classes that can be reported."""
 
     def report(self, reason):

--- a/praw/models/reddit/mixins/savable.py
+++ b/praw/models/reddit/mixins/savable.py
@@ -2,7 +2,7 @@
 from ....const import API_PATH
 
 
-class SavableMixin(object):
+class SavableMixin:
     """Interface for RedditBase classes that can be saved."""
 
     def save(self, category=None):

--- a/praw/models/reddit/mixins/votable.py
+++ b/praw/models/reddit/mixins/votable.py
@@ -2,7 +2,7 @@
 from ....const import API_PATH
 
 
-class VotableMixin(object):
+class VotableMixin:
     """Interface for RedditBase classes that can be voted on."""
 
     def _vote(self, direction):

--- a/praw/models/reddit/redditor.py
+++ b/praw/models/reddit/redditor.py
@@ -218,7 +218,7 @@ class Redditor(
         self._friend(method="DELETE", data={"id": str(self)})
 
 
-class RedditorStream(object):
+class RedditorStream:
     """Provides submission and comment streams."""
 
     def __init__(self, redditor):

--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -364,7 +364,7 @@ class Submission(
         return self._reddit.post(API_PATH["submit"], data=data)
 
 
-class SubmissionFlair(object):
+class SubmissionFlair:
     """Provide a set of functions pertaining to Submission flair."""
 
     def __init__(self, submission):

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -905,7 +905,7 @@ class Subreddit(
         self._reddit.post(API_PATH["subscribe"], data=data)
 
 
-class SubredditFilters(object):
+class SubredditFilters:
     """Provide functions to interact with the special Subreddit's filters.
 
     Members of this class should be utilized via ``Subreddit.filters``. For
@@ -990,7 +990,7 @@ class SubredditFilters(object):
         self.subreddit._reddit.request("DELETE", url, data={})
 
 
-class SubredditFlair(object):
+class SubredditFlair:
     """Provide a set of functions to interact with a Subreddit's flair."""
 
     @cachedproperty
@@ -1203,7 +1203,7 @@ class SubredditFlair(object):
         return response
 
 
-class SubredditFlairTemplates(object):
+class SubredditFlairTemplates:
     """Provide functions to interact with a Subreddit's flair templates."""
 
     @staticmethod
@@ -1510,7 +1510,7 @@ class SubredditLinkFlairTemplates(SubredditFlairTemplates):
         self._clear(is_link=True)
 
 
-class SubredditModeration(object):
+class SubredditModeration:
     """Provides a set of moderation functions to a Subreddit."""
 
     @staticmethod
@@ -1828,7 +1828,7 @@ class SubredditModeration(object):
         )
 
 
-class SubredditQuarantine(object):
+class SubredditQuarantine:
     """Provides subreddit quarantine related methods."""
 
     def __init__(self, subreddit):
@@ -1884,7 +1884,7 @@ class SubredditQuarantine(object):
             pass
 
 
-class SubredditRelationship(object):
+class SubredditRelationship:
     """Represents a relationship between a redditor and subreddit.
 
     Instances of this class can be iterated through in order to discover the
@@ -2164,7 +2164,7 @@ class ModeratorRelationship(SubredditRelationship):
         self.subreddit._reddit.post(url, data=data)
 
 
-class Modmail(object):
+class Modmail:
     """Provides modmail functions for a subreddit."""
 
     def __call__(self, id=None, mark_read=False):  # noqa: D207, D301
@@ -2383,7 +2383,7 @@ state='mod')
         return self.subreddit._reddit.get(API_PATH["modmail_unread_count"])
 
 
-class SubredditStream(object):
+class SubredditStream:
     """Provides submission and comment streams."""
 
     def __init__(self, subreddit):
@@ -2441,7 +2441,7 @@ class SubredditStream(object):
         return stream_generator(self.subreddit.new, **stream_options)
 
 
-class SubredditStylesheet(object):
+class SubredditStylesheet:
     """Provides a set of stylesheet functions to a Subreddit."""
 
     def __call__(self):
@@ -2831,7 +2831,7 @@ class SubredditStylesheet(object):
         return self._upload_image(image_path, {"upload_type": "icon"})
 
 
-class SubredditWiki(object):
+class SubredditWiki:
     """Provides a set of moderation functions to a Subreddit."""
 
     def __getitem__(self, page_name):

--- a/praw/models/reddit/widgets.py
+++ b/praw/models/reddit/widgets.py
@@ -325,7 +325,7 @@ class SubredditWidgets(PRAWBase):
         self._fetched = True
 
 
-class SubredditWidgetsModeration(object):
+class SubredditWidgetsModeration:
     """Class for moderating a subreddit's widgets.
 
     Get an instance of this class from :attr:`.SubredditWidgets.mod`.
@@ -1720,7 +1720,7 @@ class WidgetEncoder(JSONEncoder):
         return JSONEncoder.default(self, o)
 
 
-class WidgetModeration(object):
+class WidgetModeration:
     """Class for moderating a particular widget.
 
     Example usage:

--- a/praw/models/reddit/wikipage.py
+++ b/praw/models/reddit/wikipage.py
@@ -163,7 +163,7 @@ class WikiPage(RedditBase):
         return self._revision_generator(self.subreddit, url, generator_kwargs)
 
 
-class WikiPageModeration(object):
+class WikiPageModeration:
     """Provides a set of moderation functions for a WikiPage."""
 
     def __init__(self, wikipage):

--- a/praw/models/util.py
+++ b/praw/models/util.py
@@ -3,7 +3,7 @@ import random
 import time
 
 
-class BoundedSet(object):
+class BoundedSet:
     """A set with a maximum size that evicts the oldest items when necessary.
 
     This class does not implement the complete set interface.
@@ -27,7 +27,7 @@ class BoundedSet(object):
         self._set.add(item)
 
 
-class ExponentialCounter(object):
+class ExponentialCounter:
     """A class to provide an exponential counter with jitter."""
 
     def __init__(self, max_counter):

--- a/praw/objector.py
+++ b/praw/objector.py
@@ -3,7 +3,7 @@ from .exceptions import APIException, ClientException
 from .util import snake_case_keys
 
 
-class Objector(object):
+class Objector:
     """The objector builds :class:`.RedditBase` objects."""
 
     @classmethod

--- a/praw/reddit.py
+++ b/praw/reddit.py
@@ -30,7 +30,7 @@ from .exceptions import ClientException
 from .objector import Objector
 
 
-class Reddit(object):
+class Reddit:
     """The Reddit class provides convenient access to reddit's API.
 
     Instances of this class are the gateway to interacting with Reddit's API

--- a/praw/util/cache.py
+++ b/praw/util/cache.py
@@ -1,7 +1,7 @@
 """Caching utilities."""
 
 
-class cachedproperty(object):
+class cachedproperty:
     """A decorator for caching a property's result.
 
     Similar to `property`, but the wrapped method's result is cached

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -85,7 +85,7 @@ with betamax.Betamax.configure() as config:
         config.define_cassette_placeholder("<{}>".format(key.upper()), value)
 
 
-class Placeholders(object):
+class Placeholders:
     def __init__(self, _dict):
         self.__dict__ = _dict
 

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -4,7 +4,7 @@ from betamax import Betamax
 from praw import Reddit
 
 
-class IntegrationTest(object):
+class IntegrationTest:
     """Base class for PRAW integration tests."""
 
     def setup(self):

--- a/tests/integration/models/reddit/test_subreddit.py
+++ b/tests/integration/models/reddit/test_subreddit.py
@@ -25,7 +25,7 @@ import websocket
 from ... import IntegrationTest
 
 
-class WebsocketMock(object):
+class WebsocketMock:
     POST_URL = "https://reddit.com/r/<TEST_SUBREDDIT>/comments/{}/test_title/"
 
     @classmethod

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -2,7 +2,7 @@
 from praw import Reddit
 
 
-class UnitTest(object):
+class UnitTest:
     """Base class for PRAW unit tests."""
 
     def setup(self):

--- a/tests/unit/models/list/test_base.py
+++ b/tests/unit/models/list/test_base.py
@@ -4,18 +4,18 @@ import pytest
 from praw.models.list.base import BaseList
 
 
-class DummyObjector(object):
+class DummyObjector:
     @staticmethod
     def objectify(value):
         return value
 
 
-class Dummy(object):
+class Dummy:
     def __init__(self):
         self._objector = DummyObjector
 
 
-class TestBaseList(object):
+class TestBaseList:
     def setup(self):
         self._prev_child_attribute = BaseList.CHILD_ATTRIBUTE
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -7,7 +7,7 @@ from praw.config import Config
 from praw.exceptions import ClientException
 
 
-class TestConfig(object):
+class TestConfig:
     @staticmethod
     def _assert_config_read(environment, mock_config):
         mock_instance = mock_config.return_value

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -2,7 +2,7 @@
 from praw.exceptions import APIException, ClientException, PRAWException
 
 
-class TestPRAWException(object):
+class TestPRAWException:
     def test_inheritance(self):
         assert isinstance(PRAWException(), Exception)
 
@@ -11,7 +11,7 @@ class TestPRAWException(object):
         assert str(PRAWException("foo")) == "foo"
 
 
-class TestAPIException(object):
+class TestAPIException:
     def test_inheritance(self):
         assert isinstance(APIException(None, None, None), PRAWException)
 
@@ -32,7 +32,7 @@ class TestAPIException(object):
         )
 
 
-class TestClientException(object):
+class TestClientException:
     def test_inheritance(self):
         assert isinstance(ClientException(), PRAWException)
 

--- a/tests/unit/util/test_cache.py
+++ b/tests/unit/util/test_cache.py
@@ -6,7 +6,7 @@ from praw.util.cache import cachedproperty
 
 
 class TestCachedProperty(UnitTest):
-    class Klass(object):
+    class Klass:
         @cachedproperty
         def nine(self):
             """Return 9."""


### PR DESCRIPTION
Replace `class Foo(object):` with `class Foo:`, now that we don't have to support Python 2.

This was done automatically with find + sed. ripgrep confirms that I got everything:

    levi@localhost ~/s/praw> rg 'class .*\(object\):
    levi@localhost ~/s/praw>

and the existing tests should confirm well enough that nothing broke.