### PR TITLE
Temp-fix travis config by limiting pydocstyle version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,8 @@ install:
   - pip install coveralls
 jobs:
   include:
-    - install: pip install black flake8 pydocstyle sphinx sphinx_rtd_theme .
+    - install: pip install black flake8 sphinx sphinx_rtd_theme
+        'pydocstyle<4' .
       python: 3.7
       script:
         - black --check --verbose *.py docs praw tests


### PR DESCRIPTION
As of `pydocstyle` version 4.0.0, running `pydocstyle praw` results in many `D412` errors such as 

```
praw/models/inbox.py:154 in public method `message`:
        D412: No blank lines allowed between a section header and its content ('Example')
```

I think we should fix or maybe ignore these, but for now we can avoid them by limiting the version of `pydocstyle`.