### PR TITLE
Initialise `.replies` to an empty list

### DIFF
--- a/praw/models/reddit/comment.py
+++ b/praw/models/reddit/comment.py
@@ -142,10 +142,11 @@ class Comment(InboxableMixin, UserContentMixin, FullnameMixin, RedditBase):
             raise TypeError(
                 "Exactly one of `id`, `url`, or `_data` must be provided."
             )
-        self._replies = self._submission = None
+        self._replies = []
+        self._submission = None
         super(Comment, self).__init__(reddit, _data=_data)
         if id:
-            self.id = id  # pylint: disable=invalid-name
+            self.id = id
         elif url:
             self.id = self.id_from_url(url)
         else:

--- a/praw/models/reddit/live.py
+++ b/praw/models/reddit/live.py
@@ -346,7 +346,7 @@ class LiveThread(RedditBase):
             raise TypeError("Either `id` or `_data` must be provided.")
         super(LiveThread, self).__init__(reddit, _data=_data)
         if id:
-            self.id = id  # pylint: disable=invalid-name
+            self.id = id
 
     def _fetch_info(self):
         return ("liveabout", {"id": self.id}, None)
@@ -617,7 +617,7 @@ class LiveUpdate(FullnameMixin, RedditBase):
         elif thread_id and update_id:
             super(LiveUpdate, self).__init__(reddit, _data=None)
             self._thread = LiveThread(self._reddit, thread_id)
-            self.id = update_id  # pylint: disable=invalid-name
+            self.id = update_id
         else:
             raise TypeError(
                 "Either `thread_id` and `update_id`, or "

--- a/praw/models/reddit/modmail.py
+++ b/praw/models/reddit/modmail.py
@@ -141,7 +141,7 @@ class ModmailConversation(RedditBase):
             raise TypeError("Either `id` or `_data` must be provided.")
 
         if id:
-            self.id = id  # pylint: disable=invalid-name
+            self.id = id
 
         self._info_params = {"markRead": True} if mark_read else None
 

--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -196,7 +196,7 @@ class Submission(
         self.comment_sort = "best"
 
         if id is not None:
-            self.id = id  # pylint: disable=invalid-name
+            self.id = id
         elif url is not None:
             self.id = self.id_from_url(url)
 

--- a/tests/integration/models/reddit/test_comment.py
+++ b/tests/integration/models/reddit/test_comment.py
@@ -153,9 +153,11 @@ class TestComment(IntegrationTest):
         assert parent.fullname == comment.parent_id
 
     def test_refresh(self):
+        comment = Comment(self.reddit, "d81vwef")
         with self.recorder.use_cassette("TestComment.test_refresh"):
-            comment = Comment(self.reddit, "d81vwef").refresh()
-        assert len(comment.replies) > 0
+            assert len(comment.replies) == 0
+            comment.refresh()
+            assert len(comment.replies) > 0
 
     def test_refresh__raises_exception(self):
         with self.recorder.use_cassette(


### PR DESCRIPTION
The `Comment.replies` attribute begins as `None` and transitions to an empty list after a fetch. The fetch doesn’t retrieve the comment’s replies, retrieving replies is what `.refresh()` is for hence the transition to a list can be confusing.

This PR makes it so that `.replies` is initialised as an empty list so that its value doesn’t change after a fetch. I’ve chosen an empty list instead of `None` so that its type is consistent.
