### PR TITLE
Add `Redditors.user_data_by_account_ids()`

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -3,7 +3,6 @@ Maintainers
 
 - Bryce Boe <bbzbryce@gmail.com> `@bboe <https://github.com/bboe>`_
 - Joe RH <jarhill0@gmail.com> `@jarhill0 <https://github.com/jarhill0>`_
-- Daniel P. <pyprohly@outlook.com> `@Pyprohly <https://github.com/Pyprohly>`_
 
 
 Documentation Contributors
@@ -48,6 +47,7 @@ Source Contributors
 - Declan Hoare <declanhoare@exemail.com.au> `@NetwideRogue <https://github.com/NetwideRogue>`_
 - Elaina Martineau `@CrackedP0t <https://github.com/CrackedP0t>`_
 - Rob Curtis <BourbonInExile@gmail.com> `@waab76 <https://github.com/waab76>`_
+- Pyprohly <pyprohly@outlook.com> `@Pyprohly <https://github.com/Pyprohly>`_
 - LilSpazJoekp `@LilSpazJoekp <https://github.com/LilSpazJoekp>`_
 - Timendum `@timendum <https://github.com/timendum>`_
 - vaclav-2012 `@vaclav-2012 <https://github.com/vaclav-2012>`_

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,9 @@ Unreleased
 
 * ``config_interpolation`` parameter for :class:`.Reddit` supporting basic and
   extended modes.
+* Add :meth:`.Redditors.partial_redditors` that returns lightweight redditor
+  objects that contain only a few fields. This is useful for resolving
+  Redditor IDs to their usernames in bulk.
 
 **Removed**
 

--- a/praw/reddit.py
+++ b/praw/reddit.py
@@ -2,7 +2,7 @@
 import configparser
 import os
 from itertools import islice
-from typing import IO, Any, Dict, Generator, Optional, Sequence, Type, Union
+from typing import IO, Any, Dict, Generator, Iterable, Optional, Type, Union
 
 from prawcore import (
     Authorizer,
@@ -461,7 +461,7 @@ class Reddit:
 
     def info(
         self,
-        fullnames: Optional[Sequence[str]] = None,
+        fullnames: Optional[Iterable[str]] = None,
         url: Optional[str] = None,
     ) -> Generator[Union[Subreddit, Comment, Submission], None, None]:
         """Fetch information about each item in ``fullnames`` or from ``url``.
@@ -485,7 +485,7 @@ class Reddit:
                   different set of submissions.
 
         """
-        none_count = [fullnames, url].count(None)
+        none_count = (fullnames, url).count(None)
         if none_count > 1:
             raise TypeError("Either `fullnames` or `url` must be provided.")
         if none_count < 1:

--- a/tests/integration/cassettes/TestRedditors.test_partial_redditors.json
+++ b/tests/integration/cassettes/TestRedditors.test_partial_redditors.json
@@ -1,0 +1,217 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2020-01-22T07:03:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=client_credentials"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "29"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.6.0.dev0 prawcore/1.0.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "106"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 22 Jan 2020 07:03:23 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "edgebucket=uEYL1E6wOOoyxs0uHn; Domain=reddit.com; Max-Age=63071999; Path=/;  secure"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd10122-SYD"
+          ],
+          "X-Timer": [
+            "S1579676603.104078,VS0,VE263"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-reddit-loid": [
+            "00000000005i13mf72.2.1579676603239.Z0FBQUFBQmVKX083c00tRUtIc3dKTms1d29CZWJOaktINVpiT210ZjBVazBpVkQ1c3VIdk4ybk91MU1ybVA5NUFEcE9ENEJrMy1sQS1OUWZ2LVBZakpWaFNLVXRXa0o2WTBIXzk0dG1CdEtGZjUtdENNU0lVZ3hpV3FVM2xtZmlzOU12YkFPdU5QU00"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2020-01-22T07:03:23",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "edgebucket=uEYL1E6wOOoyxs0uHn"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.6.0.dev0 prawcore/1.0.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/api/user_data_by_account_ids?ids=t2_1w72%2Ct2_4x25quk&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"t2_1w72\": {\"name\": \"spez\", \"created_utc\": 1118030400.0, \"link_karma\": 115239, \"comment_karma\": 692419, \"profile_img\": \"https://b.thumbs.redditmedia.com/d7Sw-O_AOlxEtKEeMTrH0xcy9LbLOy0j_KrWGbOFB9w.png\", \"profile_color\": \"\", \"profile_over_18\": false}, \"t2_4x25quk\": {\"name\": \"<USERNAME>\", \"created_utc\": 1498231550.0, \"link_karma\": 55, \"comment_karma\": 729, \"profile_img\": \"https://www.redditstatic.com/avatars/avatar_default_01_A5A4A4.png\", \"profile_color\": \"\", \"profile_over_18\": false}}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "487"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 22 Jan 2020 07:03:23 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd10146-SYD"
+          ],
+          "X-Timer": [
+            "S1579676604.537315,VS0,VE300"
+          ],
+          "access-control-allow-origin": [
+            "*"
+          ],
+          "access-control-expose-headers": [
+            "X-Moose"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "set-cookie": [
+            "loid=00000000005i13mf72.2.1579676603239.Z0FBQUFBQmVKX083bmdYbVhkRmtOclBBdktDYmFpcF9haTFjU3d2QzRJTzJ0WjdhX1lZczgwVjE0aUFFZTlNTXdLTEU3R1ljYUxQU0hsZUJIMTlfaGQwNkp5WVROYmZHRlI4Zy1tZ2NhaE4xd20tNmZycHlIN0k0aUNWU291S1AyQ1QzQzdsQVIwZ2M; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Fri, 21-Jan-2022 07:03:23 GMT; secure",
+            "session_tracker=nO5fdVoP4GWR9mGZwg.0.1579676603720.Z0FBQUFBQmVKX083dUNKeHF0aTdCVURyOTROczNiLW5UZDBobFBSOC1lMFN1YkdtSjAtZ2wxNGNvVDlzc2NzQWkyVERWWW9EMVYzNzlhaTZvb3hoeF9OeEF0dEtZZkdaal9DNnhTZS12elJrNmdSY1RMNHdLQm85MHh0V1UzQnVXbEd5ZWJ2eHBUb2I; Domain=reddit.com; Max-Age=7199; Path=/; expires=Wed, 22-Jan-2020 09:03:23 GMT; secure"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/user_data_by_account_ids?ids=t2_1w72%2Ct2_4x25quk&raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/integration/cassettes/TestRedditors.test_partial_redditors__not_found.json
+++ b/tests/integration/cassettes/TestRedditors.test_partial_redditors__not_found.json
@@ -1,0 +1,434 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2020-01-22T07:03:24",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=client_credentials"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "29"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.6.0.dev0 prawcore/1.0.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "106"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 22 Jan 2020 07:03:24 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "edgebucket=GCjJkq4KHt84yDLC8W; Domain=reddit.com; Max-Age=63071999; Path=/;  secure"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd10149-SYD"
+          ],
+          "X-Timer": [
+            "S1579676604.983707,VS0,VE255"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-reddit-loid": [
+            "00000000005i13mj7t.2.1579676604107.Z0FBQUFBQmVKX084S2pZcWJYQlFoT0ZBdU1aSlpad3Blb29DeldXWXBjcHNmbWpRSHhLME8zbnF6aDNoRTlGVHRONXZPYTdSZW8xQWh2ZjlKeEJBYjc0dHpPUEl6ODNEYTZyRFBtaU1oOXotYkVQbTV4ZlV3dTVWNmxINFZWZ0VmVU40dEhnaXlyZk4"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2020-01-22T07:03:24",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "edgebucket=GCjJkq4KHt84yDLC8W"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.6.0.dev0 prawcore/1.0.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/api/user_data_by_account_ids?ids=t2_invalid_abc%2Ct2_invalid_123&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"message\": \"Not Found\", \"error\": 404}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "38"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 22 Jan 2020 07:03:24 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd10140-SYD"
+          ],
+          "X-Timer": [
+            "S1579676605.531629,VS0,VE314"
+          ],
+          "access-control-allow-origin": [
+            "*"
+          ],
+          "access-control-expose-headers": [
+            "X-Moose"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "set-cookie": [
+            "loid=00000000005i13mj7t.2.1579676604107.Z0FBQUFBQmVKX084UXZlRjdLSWZmVWdvWjczUEhpNi1VajA5bTJrVTlINXBCZFlKUmVBSzdfSUJOX3RDYlUtRVRFQzIxS3gzTTZFYmJkcVpOV0E1anJTbVdaTnhlT1lQRGFqTGlyVXBtY204Vmw0SXlYWVhTdmNoX1gyWWhWUXJKWVB6LThfMmxKSXI; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Fri, 21-Jan-2022 07:03:24 GMT; secure",
+            "session_tracker=o9T1QN6E77HOK7GbnI.0.1579676604713.Z0FBQUFBQmVKX084TEhQbktrakV0a2hzOEIwbm9kTldpUTREeE9YdXRhV1Y0bk9UbHM0TlQzRkg0dW1kYlg5U0VsOVliSUNtU2NCZGE5N1JFUnFyZDd4WFJ2YUgyN294cVFBZ1ZOUzM3LXIxZ0pPZ0twWnUwZjJYSnJRaGdfYmF4bWZnY0dFSXpvWk8; Domain=reddit.com; Max-Age=7199; Path=/; expires=Wed, 22-Jan-2020 09:03:24 GMT; secure",
+            "loid=00000000005i13mm4p.2.1579676604725.Z0FBQUFBQmVKX084YjJ1dGMzaXpMLUNHU1h1c2c4eU92OE5GMjhwZk9SdlBCTmtURXZ5WVhESU9WUTIzZC15N3ZYZGcyZklySEJkcTBIaTRFVXZkcmtBOHZYT2hQdFFPcklmT0tUNkVlQWpDOVpyS2NJVjhNcFcwaU5hS0VoQU5sU2hjTUFNUGhOZ1c; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Fri, 21-Jan-2022 07:03:24 GMT; secure",
+            "session_tracker=vAYY3WpsbFHNEV0Na6.0.1579676604725.Z0FBQUFBQmVKX084RFZBSDJVU2E1b0FwU1IwZU0tdFI5WGNJRU1UeE03MHRmM094d3pkb0c0bFFUbXdfUVpWYXhfWVRNX3RsTkZXNGhKU3ROamYzLW5xNGJBaHQ3RnFSYVpjS2FveDBQem16UzkzbjlBXy1BTW4yZUFlLS1oeUpTUEVtekFZRU12b28; Domain=reddit.com; Max-Age=7199; Path=/; expires=Wed, 22-Jan-2020 09:03:24 GMT; secure"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 404,
+          "message": "Not Found"
+        },
+        "url": "https://oauth.reddit.com/api/user_data_by_account_ids?ids=t2_invalid_abc%2Ct2_invalid_123&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-01-22T07:03:25",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "edgebucket=GCjJkq4KHt84yDLC8W; loid=00000000005i13mm4p.2.1579676604725.Z0FBQUFBQmVKX084YjJ1dGMzaXpMLUNHU1h1c2c4eU92OE5GMjhwZk9SdlBCTmtURXZ5WVhESU9WUTIzZC15N3ZYZGcyZklySEJkcTBIaTRFVXZkcmtBOHZYT2hQdFFPcklmT0tUNkVlQWpDOVpyS2NJVjhNcFcwaU5hS0VoQU5sU2hjTUFNUGhOZ1c; session_tracker=vAYY3WpsbFHNEV0Na6.0.1579676604725.Z0FBQUFBQmVKX084RFZBSDJVU2E1b0FwU1IwZU0tdFI5WGNJRU1UeE03MHRmM094d3pkb0c0bFFUbXdfUVpWYXhfWVRNX3RsTkZXNGhKU3ROamYzLW5xNGJBaHQ3RnFSYVpjS2FveDBQem16UzkzbjlBXy1BTW4yZUFlLS1oeUpTUEVtekFZRU12b28"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.6.0.dev0 prawcore/1.0.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/api/user_data_by_account_ids?ids=t2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"message\": \"Not Found\", \"error\": 404}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "38"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 22 Jan 2020 07:03:25 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd10140-SYD"
+          ],
+          "X-Timer": [
+            "S1579676605.901993,VS0,VE263"
+          ],
+          "access-control-allow-origin": [
+            "*"
+          ],
+          "access-control-expose-headers": [
+            "X-Moose"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "set-cookie": [
+            "session_tracker=vAYY3WpsbFHNEV0Na6.0.1579676605038.Z0FBQUFBQmVKX085RldlR213aW5yeU1MTmhBUVNnenRIbWx4cWpHN01MbGYxa3V2TTZPYTRud2M0UHZ6YjF6ZVZPYzlGQVF2eEgwZ2doNmdqOV9ITkVwaWVjRUZnTXhNTmNOQ2d3dDRWQkdrY0gtbTB4Zjl4SVJFczJCUTJRX2FkM0ZtVVdOSlYzcHk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Wed, 22-Jan-2020 09:03:25 GMT; secure",
+            "session_tracker=vAYY3WpsbFHNEV0Na6.0.1579676605047.Z0FBQUFBQmVKX085WlFsYlRtQlJJb05jSEd1T0lvaXFKb3Q2Rm9LOTFreXVCQjB5SnRkVHlUZHJwQjBHUVRHcXdKQTZYSjZDN00yX2dieFB6QXo0SjVKNWRDS2g4YndhSjdHVGRjWWtkajhORTBwYVkweU1JU0tkSHdxSHc2QTFRdGJwRHJZV0Y2NUU; Domain=reddit.com; Max-Age=7199; Path=/; expires=Wed, 22-Jan-2020 09:03:25 GMT; secure"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 404,
+          "message": "Not Found"
+        },
+        "url": "https://oauth.reddit.com/api/user_data_by_account_ids?ids=t2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc%2Ct2_invalid_abc&raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-01-22T07:03:25",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "edgebucket=GCjJkq4KHt84yDLC8W; loid=00000000005i13mm4p.2.1579676604725.Z0FBQUFBQmVKX084YjJ1dGMzaXpMLUNHU1h1c2c4eU92OE5GMjhwZk9SdlBCTmtURXZ5WVhESU9WUTIzZC15N3ZYZGcyZklySEJkcTBIaTRFVXZkcmtBOHZYT2hQdFFPcklmT0tUNkVlQWpDOVpyS2NJVjhNcFcwaU5hS0VoQU5sU2hjTUFNUGhOZ1c; session_tracker=vAYY3WpsbFHNEV0Na6.0.1579676605047.Z0FBQUFBQmVKX085WlFsYlRtQlJJb05jSEd1T0lvaXFKb3Q2Rm9LOTFreXVCQjB5SnRkVHlUZHJwQjBHUVRHcXdKQTZYSjZDN00yX2dieFB6QXo0SjVKNWRDS2g4YndhSjdHVGRjWWtkajhORTBwYVkweU1JU0tkSHdxSHc2QTFRdGJwRHJZV0Y2NUU"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.6.0.dev0 prawcore/1.0.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/api/user_data_by_account_ids?ids=t2_4x25quk&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"t2_4x25quk\": {\"name\": \"<USERNAME>\", \"created_utc\": 1498231550.0, \"link_karma\": 55, \"comment_karma\": 729, \"profile_img\": \"https://www.redditstatic.com/avatars/avatar_default_01_A5A4A4.png\", \"profile_color\": \"\", \"profile_over_18\": false}}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "236"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 22 Jan 2020 07:03:25 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-syd10140-SYD"
+          ],
+          "X-Timer": [
+            "S1579676605.202035,VS0,VE328"
+          ],
+          "access-control-allow-origin": [
+            "*"
+          ],
+          "access-control-expose-headers": [
+            "X-Moose"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "set-cookie": [
+            "session_tracker=vAYY3WpsbFHNEV0Na6.0.1579676605411.Z0FBQUFBQmVKX085SVRCY3lveGI5YjlaY0RhbDdLT2tEVTh5ZzZPOEhuODg4VEJOSjA2QlJNLUs3NXVUMHh2b2R0TFRKdHlydFhkVWd4bjdaNWtUeDI0NXRiMkl3S3E5cDdkZUxDQ1BPMzB6UjNNcHJmemVlaTU4amczZk1fTEVvTU1ud2JMTDFodno; Domain=reddit.com; Max-Age=7199; Path=/; expires=Wed, 22-Jan-2020 09:03:25 GMT; secure"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/user_data_by_account_ids?ids=t2_4x25quk&raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/integration/models/test_redditors.py
+++ b/tests/integration/models/test_redditors.py
@@ -34,3 +34,31 @@ class TestRedditors(IntegrationTest):
             generator = self.reddit.redditors.stream()
             for i in range(101):
                 assert isinstance(next(generator), Subreddit)
+
+    def test_partial_redditors(self):
+        with self.recorder.use_cassette(
+            "TestRedditors.test_partial_redditors"
+        ):
+            gen = self.reddit.redditors.partial_redditors(
+                ["t2_1w72", "t2_4x25quk"]
+            )
+            user_data = list(gen)
+
+        fullnames = [user.fullname for user in user_data]
+        assert fullnames == ["t2_1w72", "t2_4x25quk"]
+        assert user_data[0].fullname == "t2_1w72"
+        assert user_data[0].name == "spez"
+
+    def test_partial_redditors__not_found(self):
+        with self.recorder.use_cassette(
+            "TestRedditors.test_partial_redditors__not_found"
+        ):
+            gen = self.reddit.redditors.partial_redditors(
+                ["t2_invalid_abc", "t2_invalid_123"]
+            )
+            assert list(gen) == []
+
+            gen = self.reddit.redditors.partial_redditors(
+                ["t2_invalid_abc" for _ in range(100)] + ["t2_4x25quk"]
+            )
+            assert [user.fullname for user in gen] == ["t2_4x25quk"]

--- a/tests/unit/models/test_redditors.py
+++ b/tests/unit/models/test_redditors.py
@@ -1,5 +1,7 @@
 """Test praw.models.redditors."""
 
+import mock
+
 from .. import UnitTest
 
 
@@ -9,3 +11,29 @@ class TestRedditors(UnitTest):
         generator = self.reddit.redditors.search(None, params=params)
         assert generator.params["dummy"] == "value"
         assert params == {"dummy": "value"}
+
+    def test_partial_redditors(self):
+        with mock.patch.object(self.reddit, "request") as mock_method:
+            in_ids_list = [("t2_%d" % n) for n in range(100)]
+            list(self.reddit.redditors.partial_redditors(in_ids_list))
+
+            assert mock_method.call_count == 1
+            assert mock_method.call_args[1]["params"]["ids"] == ",".join(
+                in_ids_list
+            )
+
+        with mock.patch.object(self.reddit, "request") as mock_method:
+            in_ids_list = [("t2_%d" % n) for n in range(102)]
+            list(self.reddit.redditors.partial_redditors(in_ids_list))
+
+            assert mock_method.call_count == 2
+            cal = mock_method.call_args_list
+            assert cal[0][1]["params"]["ids"] == ",".join(in_ids_list[:100])
+            assert cal[1][1]["params"]["ids"] == ",".join(in_ids_list[-2:])
+
+    def test_partial_redditors__no_typeerror(self):
+        func = self.reddit.redditors.partial_redditors
+        with mock.patch.object(self.reddit, "request"):
+            func(list("abc"))
+            func(tuple("abc"))
+            func(c for c in "abc")


### PR DESCRIPTION
Relevant: issue #1108.

The new `Redditors.user_data_by_account_ids()` method hits up the `/api/user_data_by_account_ids` endpoint.

I anticipate the only use case of this method would be to bulk convert Redditor ids to usernames, so I’ve decided to have it just return raw dictionaries rather than redditor instances.
