### PR TITLE
 Properly JSONize Subreddit objects for widget updates. 

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,8 @@ Unreleased
 
 * :meth:`.add_community_list` has parameter ``description`` to support
   unannounced upstream Reddit API changes.
+* :meth:`~.WidgetModeration.update` supports passing a list of
+  :class:`.Subreddit` objects.
 
 **Changed**
 

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -18,7 +18,7 @@ from .base import RedditBase
 from .emoji import SubredditEmoji
 from .mixins import FullnameMixin, MessageableMixin
 from .modmail import ModmailConversation
-from .widgets import SubredditWidgets
+from .widgets import SubredditWidgets, WidgetEncoder
 from .wikipage import WikiPage
 
 
@@ -903,6 +903,9 @@ class Subreddit(
             "sr_name": self._subreddit_list(self, other_subreddits),
         }
         self._reddit.post(API_PATH["subscribe"], data=data)
+
+
+WidgetEncoder._subreddit_class = Subreddit
 
 
 class SubredditFilters:

--- a/praw/models/reddit/widgets.py
+++ b/praw/models/reddit/widgets.py
@@ -351,7 +351,9 @@ class SubredditWidgetsModeration:
 
     def _create_widget(self, payload):
         path = API_PATH["widget_create"].format(subreddit=self._subreddit)
-        widget = self._reddit.post(path, data={"json": dumps(payload)})
+        widget = self._reddit.post(
+            path, data={"json": dumps(payload, cls=WidgetEncoder)}
+        )
         widget.subreddit = self._subreddit
         return widget
 
@@ -585,7 +587,7 @@ class SubredditWidgetsModeration:
 
         """
         community_list = {
-            "data": [str(datum) for datum in data],
+            "data": data,
             "kind": "community-list",
             "shortName": short_name,
             "styles": styles,

--- a/praw/models/reddit/widgets.py
+++ b/praw/models/reddit/widgets.py
@@ -1720,7 +1720,9 @@ class WidgetEncoder(JSONEncoder):
 
     def default(self, o):  # pylint: disable=E0202
         """Serialize ``PRAWBase`` objects."""
-        if isinstance(o, PRAWBase):
+        if isinstance(o, self._subreddit_class):
+            return str(o)
+        elif isinstance(o, PRAWBase):
             return {
                 key: val
                 for key, val in vars(o).items()

--- a/tests/unit/models/reddit/test_widgets.py
+++ b/tests/unit/models/reddit/test_widgets.py
@@ -33,8 +33,9 @@ class TestWidgetEncoder(UnitTest):
             1,
             "two",
             PRAWBase(self.reddit, _data={"_secret": "no", "3": 3}),
+            self.reddit.subreddit("four"),
         ]
-        assert '[1, "two", {"3": 3}]' == dumps(data, cls=WidgetEncoder)
+        assert '[1, "two", {"3": 3}, "four"]' == dumps(data, cls=WidgetEncoder)
 
 
 class TestWidgets(UnitTest):


### PR DESCRIPTION
## Feature Summary and Justification

This fix allows the `WidgetEncoder` class to properly JSON-encode `Subreddit` objects, which previously were special-cased in `add_community_list` but not in `update`, which meant that one could create a community list with data that contained `Subreddit` objects, but not update community lists containing the same.

## References

* https://www.reddit.com/r/redditdev/comments/cldr9x/widgets_updating_communitylist_errors_out/
