### PR TITLE
Fix a small formatting error in documentation

### DIFF
--- a/praw/models/reddit/mixins/__init__.py
+++ b/praw/models/reddit/mixins/__init__.py
@@ -102,6 +102,8 @@ class ThingModerationMixin:
 
         Example usage:
 
+        .. code:: python
+
            # lock a comment:
            comment = reddit.comment('dkk4qjd')
            comment.mod.lock()


### PR DESCRIPTION
The code block for locking a comment/submission is incorrectly
formatted and appears as plain text. This fixes that.

[Here is the current documentation showing the error](https://praw.readthedocs.io/en/latest/code_overview/other/commentmoderation.html#praw.models.reddit.comment.CommentModeration.lock).

Since this is such a small change, I didn't think it was necessary to create an issue or add myself to the `AUTHORS.rst`.

This is my first contribution to someone else's project, so I hope I did it right.