### PR TITLE
Require Python >=3.4 in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
     name=PACKAGE_NAME,
     author="Bryce Boe",
     author_email="bbzbryce@gmail.com",
+    python_requires=">=3.4",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console",


### PR DESCRIPTION
## Feature Summary and Justification

This feature provides an official minimum Python version for PRAW in `setup.py`. This will prevent users on Python <3.4 from upgrading to an incompatible version.

This change uses the `python_requires` keyword, which was introduced in pip 9.0.0, released in November 2016. There's a chance that some users will have pip <9.0.0, and this fix will not function for them (installation will still be allowed). I don't know a great way to address this. [This site](https://hynek.me/articles/conditional-python-dependencies/) claims that `wheels` installs Python packages without executing any code (including `setup.py`), which could mean that attempting to dynamically determine the interpreter version would not work.

For the rest of the users, this is the experience of trying to install/upgrade to a version that doesn't support the user's Python version:

```shell
$ python -m pip install --user git+https://github.com/jarhill0/praw.git@pip-version-restrict
Collecting git+https://github.com/jarhill0/praw.git@pip-version-restrict
  Cloning https://github.com/jarhill0/praw.git (to revision pip-version-restrict) to /private/var/folders/9f/xp2kwvcj3sdd0msr_v7grzjw0000gn/T/pip-req-build-AYNErP
  Installing build dependencies ... done
praw requires Python '>=3.4' but the running Python is 2.7.10
You are using pip version 10.0.1, however version 19.2.3 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
```

In case you missed it, the key error was `praw requires Python '>=3.4' but the running Python is 2.7.10`.

Why 3.4? Currently PRAW only tests on Python 3.5-3.7 inclusive:

https://github.com/praw-dev/praw/blob/7273165c3cb2cdf32088060da19ffabb4769515d/.travis.yml#L18-L20

However, close to 200 daily users are on Python 3.4 (and around 1000 on 3.5), and (though I may be wrong — @bboe can you fact check this?) I don't believe the removal of Python 2 support affects them at all, so I see no reason to break compatibility with their Python versions.

## References

* https://pip.pypa.io/en/stable/news/#id184
* https://stackoverflow.com/a/48777286/
