### PR TITLE
Added endpoint for setting a post as "OC"

### DIFF
--- a/praw/endpoints.py
+++ b/praw/endpoints.py
@@ -141,6 +141,7 @@ API_PATH = {
     "select_flair":            "r/{subreddit}/api/selectflair/",
     "sendreplies":             "api/sendreplies",
     "sent":                    "message/sent/",
+    "set_original_content":    "api/set_original_content",
     "setpermissions":          "r/{subreddit}/api/setpermissions/",
     "site_admin":              "api/site_admin/",
     "spoiler":                 "api/spoiler/",


### PR DESCRIPTION
Not yet fully documented in the API, but the endpoint does exist. There does not seem to be a opposite endpoint for `set_original_content` - rather, `should_set_oc` needs to be set to `False` to un-set a post as OC.

## Feature Summary and Justification

This feature adds the API endpoint for marking a submission as original content.

## References

* [Announcement](https://www.reddit.com/r/redesign/comments/8a48uv/moderators_try_marking_posts_as_oc_on_the_redesign/)