### PR TITLE
Added limit documentation for reddit.user.moderator_subreddits()

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -32,7 +32,7 @@ to you, it likely is not to the person asking the question.
    commenting on the issue. This act will hopefully minimize any duplicate
    work.
 
-0. Prior to creating a pull request run the `pre_push.sh` script. This script
+0. Prior to creating a pull request run the `pre_push.py` script. This script
    depends on the tools `black` `flake8`, `pylint`, and `pydocstyle`. They can
    be installed via `pip install black flake8 pydocstyle pylint`.
 

--- a/praw/models/user.py
+++ b/praw/models/user.py
@@ -106,8 +106,8 @@ class User(PRAWBase):
         :class:`.ListingGenerator`.
 
         .. note:: This method will return a maximum of 100 moderated
-        subreddits, ordered by subscriber count. To retrieve more than
-        100 subreddits, use :meth:`.Redditor.moderated`.
+           subreddits, ordered by subscriber count. To retrieve more than
+           100 moderated subreddits, please see :meth:`.Redditor.moderated`.
 
         Usage:
 

--- a/praw/models/user.py
+++ b/praw/models/user.py
@@ -109,6 +109,8 @@ class User(PRAWBase):
         subreddits, ordered by subscriber count. To retrieve more than
         100 subreddits, use :meth:`.Redditor.moderated`.
 
+        Usage:
+
         .. code-block:: python
 
            for subreddit in reddit.user.moderator_subreddits():

--- a/praw/models/user.py
+++ b/praw/models/user.py
@@ -105,12 +105,12 @@ class User(PRAWBase):
         Additional keyword arguments are passed in the initialization of
         :class:`.ListingGenerator`.
 
-        .. note:: This method will return a maximum of 100 moderated 
+        .. note:: This method will return a maximum of 100 moderated
         subreddits, ordered by subscriber count. To retrieve more than
         100 subreddits, use :meth:`.Redditor.moderated`.
-        
+
         .. code-block:: python
-        
+
                 for subreddit in reddit.user.moderator_subreddits():
                     print(subreddit.display_name)
 

--- a/praw/models/user.py
+++ b/praw/models/user.py
@@ -106,8 +106,7 @@ class User(PRAWBase):
         :class:`.ListingGenerator`.
 
         .. note:: This method will return a maximum of 100 moderated
-        subreddits, ordered by subscriber count. To retrieve more than
-        100 subreddits, use :meth:`.Redditor.moderated`.
+        subreddits, ordered by subscriber count.
 
         .. code-block:: python
 

--- a/praw/models/user.py
+++ b/praw/models/user.py
@@ -111,8 +111,8 @@ class User(PRAWBase):
 
         .. code-block:: python
 
-            for subreddit in reddit.user.moderator_subreddits():
-                print(subreddit.display_name)
+           for subreddit in reddit.user.moderator_subreddits():
+               print(subreddit.display_name)
 
 
         """

--- a/praw/models/user.py
+++ b/praw/models/user.py
@@ -114,6 +114,7 @@ class User(PRAWBase):
                 for subreddit in reddit.user.moderator_subreddits():
                     print(subreddit.display_name)
 
+
         """
         return ListingGenerator(
             self._reddit, API_PATH["my_moderator"], **generator_kwargs

--- a/praw/models/user.py
+++ b/praw/models/user.py
@@ -105,6 +105,15 @@ class User(PRAWBase):
         Additional keyword arguments are passed in the initialization of
         :class:`.ListingGenerator`.
 
+        .. note:: This method will return a maximum of 100 moderated 
+        subreddits, ordered by subscriber count. To retrieve more than
+        100 subreddits, use :meth:`.Redditor.moderated`.
+        
+        .. code-block:: python
+        
+                for subreddit in reddit.user.moderator_subreddits():
+                    print(subreddit.display_name)
+
         """
         return ListingGenerator(
             self._reddit, API_PATH["my_moderator"], **generator_kwargs

--- a/praw/models/user.py
+++ b/praw/models/user.py
@@ -111,8 +111,8 @@ class User(PRAWBase):
 
         .. code-block:: python
 
-                for subreddit in reddit.user.moderator_subreddits():
-                    print(subreddit.display_name)
+            for subreddit in reddit.user.moderator_subreddits():
+                print(subreddit.display_name)
 
 
         """

--- a/praw/models/user.py
+++ b/praw/models/user.py
@@ -106,7 +106,8 @@ class User(PRAWBase):
         :class:`.ListingGenerator`.
 
         .. note:: This method will return a maximum of 100 moderated
-        subreddits, ordered by subscriber count.
+        subreddits, ordered by subscriber count. To retrieve more than
+        100 subreddits, use :meth:`.Redditor.moderated`.
 
         .. code-block:: python
 


### PR DESCRIPTION
Fixes #1142

`reddit.user.moderator_subreddits()` is a method for `reddit.user` that [returns a ListingGenerator of the subreddits that the currently authenticated user is a moderator of](https://praw.readthedocs.io/en/latest/code_overview/reddit/user.html). It works fine, but there is actually a **hard limit of 100 subreddits returned** through this method, and that limit is currently not documented for the method. I tested this with my bot u/AssistantBOT, which is currently moderating 600+ public and private subreddits, and the method only returns the top 100 subreddits it's a mod of, sorted by most subscribers to least subscribers. 

(Copied over from #1142)

This PR documents this limit and also notes the `moderated()` method as an alternative for users who need to grab more than a hundred moderated subreddits. It also adds an example for the method per #924. 

There's also a fix for a small typo in `CONTRIBUTING.MD` - `pre_push.py` instead of `pre_push.sh`. 

## Feature Summary and Justification

No new features. Just documentation and examples per #924 and #1142. 