### PR TITLE
Note for #1145 and style fixes

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -17,6 +17,7 @@ Documentation Contributors
 - theonefoster `@theonefoster <https://github.com/theonefoster>`_
 - Eric Woolard `@ericwoolard <https://github.com/ericwoolard>`_
 - Marc `@PerhapsSomeone <https://github.com/PerhapsSomeone>`_
+- kungming2 `@kungming2 <https://github.com/kungming2>`_
 - Add "Name <email (optional)> and github profile link" above this line.
 
 

--- a/praw/models/reddit/live.py
+++ b/praw/models/reddit/live.py
@@ -447,7 +447,7 @@ class LiveThreadContribution:
     def add(self, body):
         """Add an update to the live thread.
 
-        :param body: The markdown formatted content for the update.
+        :param body: The Markdown formatted content for the update.
 
         Usage:
 

--- a/praw/models/reddit/modmail.py
+++ b/praw/models/reddit/modmail.py
@@ -229,7 +229,7 @@ other_conversations=conversation.user.recent_convos)
     def reply(self, body, author_hidden=False, internal=False):
         """Reply to the conversation.
 
-        :param body: The markdown formatted content for a message.
+        :param body: The Markdown formatted content for a message.
         :param author_hidden: When True, author is hidden from non-moderators
             (default: False).
         :param internal: When True, message is a private moderator note,

--- a/praw/models/reddit/multi.py
+++ b/praw/models/reddit/multi.py
@@ -192,7 +192,7 @@ class Multireddit(SubredditListingMixin, RedditBase):
             longer than 50 characters.
         :param subreddits: Subreddits for this multireddit.
         :param description_md: Description for this multireddit, formatted in
-            markdown.
+            Markdown.
         :param icon_name: Can be one of: ``art and design``, ``ask``,
             ``books``, ``business``, ``cars``, ``comics``, ``cute animals``,
             ``diy``, ``entertainment``, ``food and drink``, ``funny``,

--- a/praw/models/reddit/redditor.py
+++ b/praw/models/reddit/redditor.py
@@ -204,6 +204,9 @@ class Redditor(
         :returns: A ``list`` of :class:`~praw.models.Subreddit` objects.
             Return ``[]`` if the redditor has no moderated subreddits.
 
+        The redditor's own user profile subreddit will not be returned,
+        but other user profile subreddits they moderate will be returned.
+
         Usage:
 
         .. code:: python

--- a/praw/models/reddit/redditor.py
+++ b/praw/models/reddit/redditor.py
@@ -42,7 +42,7 @@ class Redditor(
     ``is_mod``                           Whether or not the Redditor mods any
                                          subreddits.
     ``is_gold``                          Whether or not the Redditor has active
-                                         gold status.
+                                         Reddit Premium status.
     ``link_karma``                       The link karma for the Redditor.
     ``name``                             The Redditor's username.
     ``subreddit``                        If the Redditor has created a
@@ -168,7 +168,7 @@ class Redditor(
         """Friend the Redditor.
 
         :param note: A note to save along with the relationship. Requires
-            reddit Gold (default: None).
+            Reddit Premium (default: None).
 
         Calling this method subsequent times will update the note.
 
@@ -179,7 +179,7 @@ class Redditor(
         """Return a Redditor instance with specific friend-related attributes.
 
         :returns: A :class:`.Redditor` instance with fields ``date``, ``id``,
-            and possibly ``note`` if the authenticated user has reddit Gold.
+            and possibly ``note`` if the authenticated user has Reddit Premium.
 
         """
         return self._reddit.get(API_PATH["friend_v1"].format(user=self))

--- a/praw/models/reddit/redditor.py
+++ b/praw/models/reddit/redditor.py
@@ -204,8 +204,9 @@ class Redditor(
         :returns: A ``list`` of :class:`~praw.models.Subreddit` objects.
             Return ``[]`` if the redditor has no moderated subreddits.
 
-        The redditor's own user profile subreddit will not be returned,
-        but other user profile subreddits they moderate will be returned.
+        .. note:: The redditor's own user profile subreddit will not be
+           returned, but other user profile subreddits they moderate
+           will be returned.
 
         Usage:
 

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -364,7 +364,7 @@ class Subreddit(
 
         Additionally, new submissions can be retrieved via the stream. In the
         following example all submissions are fetched via the special subreddit
-        ``all``:
+        ``r/all``:
 
         .. code:: python
 
@@ -547,7 +547,7 @@ class Subreddit(
         """Return a random Submission.
 
         Returns ``None`` on subreddits that do not support the random feature.
-        One example, at the time of writing, is r/wallpapers.
+        One example, at the time of writing, is ``r/wallpapers``.
         """
         url = API_PATH["subreddit_random"].format(subreddit=self)
         try:
@@ -650,7 +650,7 @@ class Subreddit(
         """Add a submission to the subreddit.
 
         :param title: The title of the submission.
-        :param selftext: The markdown formatted content for a ``text``
+        :param selftext: The Markdown formatted content for a ``text``
             submission. Use an empty string, ``''``, to make a title-only
             submission.
         :param url: The URL for a ``link`` submission.
@@ -2093,7 +2093,7 @@ class ModeratorRelationship(SubredditRelationship):
         user.
 
         For example, to invite ``'spez'`` with ``'posts'`` and ``'mail'``
-            permissions to ``'r/test/``, try:
+            permissions to ``r/test``, try:
 
         .. code:: python
 
@@ -2115,8 +2115,8 @@ class ModeratorRelationship(SubredditRelationship):
             grant. An empty list ``[]`` indicates no permissions, and when not
             provided ``None``, indicates full permissions.
 
-        For example, to invite ``'spez'`` with ``'posts'`` and ``'mail'``
-            permissions to ``'r/test/``, try:
+        For example, to invite ``'spez'`` with ``posts`` and ``mail``
+            permissions to ``r/test``, try:
 
         .. code:: python
 
@@ -2196,8 +2196,8 @@ class ModeratorRelationship(SubredditRelationship):
             grant. An empty list ``[]`` indicates no permissions, and when not
             provided, ``None``, indicates full permissions.
 
-        For example, to grant the flair and mail permissions to the moderator
-        invite, try:
+        For example, to grant the ``flair``` and ``mail``` permissions to
+        the moderator invite, try:
 
         .. code:: python
 
@@ -2933,7 +2933,7 @@ class SubredditWiki:
         :param reason: (Optional) The reason for the creation.
         :param other_settings: Additional keyword arguments to pass.
 
-        To create the wiki page ``'praw_test'`` in ``'r/test'`` try:
+        To create the wiki page ``praw_test`` in ``r/test`` try:
 
         .. code:: python
 
@@ -2952,7 +2952,7 @@ class SubredditWiki:
         Additional keyword arguments are passed in the initialization of
         :class:`.ListingGenerator`.
 
-        To view the wiki revisions for ``'praw_test'`` in ``'r/test'`` try:
+        To view the wiki revisions for ``'praw_test'`` in ``r/test`` try:
 
         .. code:: python
 

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -28,22 +28,22 @@ class Subreddit(
 ):
     """A class for Subreddits.
 
-    To obtain an instance of this class for subreddit ``/r/redditdev`` execute:
+    To obtain an instance of this class for subreddit ``r/redditdev`` execute:
 
     .. code:: python
 
        subreddit = reddit.subreddit('redditdev')
 
-    While ``/r/all`` is not a real subreddit, it can still be treated like
+    While ``r/all`` is not a real subreddit, it can still be treated like
     one. The following outputs the titles of the 25 hottest submissions in
-    ``/r/all``:
+    ``r/all``:
 
     .. code:: python
 
        for submission in reddit.subreddit('all').hot(limit=25):
            print(submission.title)
 
-    Multiple subreddits can be combined like so:
+    Multiple subreddits can be combined with a ``+`` like so:
 
     .. code:: python
 
@@ -547,7 +547,7 @@ class Subreddit(
         """Return a random Submission.
 
         Returns ``None`` on subreddits that do not support the random feature.
-        One example, at the time of writing, is /r/wallpapers.
+        One example, at the time of writing, is r/wallpapers.
         """
         url = API_PATH["subreddit_random"].format(subreddit=self)
         try:
@@ -564,7 +564,7 @@ class Subreddit(
     def rules(self):
         """Return rules for the subreddit.
 
-        For example to show the rules of ``/r/redditdev`` try:
+        For example to show the rules of ``r/redditdev`` try:
 
         .. code:: python
 
@@ -672,7 +672,7 @@ class Subreddit(
 
         Either ``selftext`` or ``url`` can be provided, but not both.
 
-        For example to submit a URL to ``/r/reddit_api_test`` do:
+        For example to submit a URL to ``r/reddit_api_test`` do:
 
         .. code:: python
 
@@ -766,7 +766,7 @@ class Subreddit(
            program in a restricted network environment, or using a proxy
            that doesn't support WebSockets connections.
 
-        For example to submit an image to ``/r/reddit_api_test`` do:
+        For example to submit an image to ``r/reddit_api_test`` do:
 
         .. code:: python
 
@@ -859,7 +859,7 @@ class Subreddit(
            program in a restricted network environment, or using a proxy
            that doesn't support WebSockets connections.
 
-        For example to submit a video to ``/r/reddit_api_test`` do:
+        For example to submit a video to ``r/reddit_api_test`` do:
 
         .. code:: python
 
@@ -922,8 +922,8 @@ class Subreddit(
     def unsubscribe(self, other_subreddits=None):
         """Unsubscribe from the subreddit.
 
-        :param other_subreddits: When provided, also unsubscribe to the
-            provided list of subreddits.
+        :param other_subreddits: When provided, also unsubscribe from
+            the provided list of subreddits.
 
         """
         data = {
@@ -984,7 +984,7 @@ class SubredditFilters:
         :param subreddit: The subreddit to add to the filter list.
 
         Items from subreddits added to the filtered list will no longer be
-        included when obtaining listings for ``/r/all``.
+        included when obtaining listings for ``r/all``.
 
         Alternatively, you can filter a subreddit temporarily from a special
         listing in a manner like so:
@@ -1781,7 +1781,7 @@ class SubredditModeration:
             image hosting. Only applies to link-only subreddits.
         :param allow_post_crossposts: Allow users to crosspost submissions from
             other subreddits.
-        :param allow_top: Allow the subreddit to appear on ``/r/all`` as well
+        :param allow_top: Allow the subreddit to appear on ``r/all`` as well
             as the default and trending lists.
         :param collapse_deleted_comments: Collapse deleted and removed comments
             on comments pages by default.
@@ -1797,7 +1797,7 @@ class SubredditModeration:
             from modqueue/unmoderated.
         :param header_hover_text: The text seen when hovering over the snoo.
         :param hide_ads: Don't show ads within this subreddit. Only applies to
-            gold-user only subreddits.
+            Premium-user only subreddits.
         :param key_color: A 6-digit rgb hex color (e.g. ``'#AABBCC'``), used as
             a thematic color for your subreddit on mobile.
         :param lang: A valid IETF language tag (underscore separated).
@@ -2093,7 +2093,7 @@ class ModeratorRelationship(SubredditRelationship):
         user.
 
         For example, to invite ``'spez'`` with ``'posts'`` and ``'mail'``
-            permissions to ``'/r/test/``, try:
+            permissions to ``'r/test/``, try:
 
         .. code:: python
 
@@ -2116,7 +2116,7 @@ class ModeratorRelationship(SubredditRelationship):
             provided ``None``, indicates full permissions.
 
         For example, to invite ``'spez'`` with ``'posts'`` and ``'mail'``
-            permissions to ``'/r/test/``, try:
+            permissions to ``'r/test/``, try:
 
         .. code:: python
 
@@ -2933,7 +2933,7 @@ class SubredditWiki:
         :param reason: (Optional) The reason for the creation.
         :param other_settings: Additional keyword arguments to pass.
 
-        To create the wiki page ``'praw_test'`` in ``'/r/test'`` try:
+        To create the wiki page ``'praw_test'`` in ``'r/test'`` try:
 
         .. code:: python
 
@@ -2952,7 +2952,7 @@ class SubredditWiki:
         Additional keyword arguments are passed in the initialization of
         :class:`.ListingGenerator`.
 
-        To view the wiki revisions for ``'praw_test'`` in ``'/r/test'`` try:
+        To view the wiki revisions for ``'praw_test'`` in ``'r/test'`` try:
 
         .. code:: python
 

--- a/praw/models/reddit/wikipage.py
+++ b/praw/models/reddit/wikipage.py
@@ -109,7 +109,7 @@ class WikiPage(RedditBase):
     def edit(self, content, reason=None, **other_settings):
         """Edit this WikiPage's contents.
 
-        :param content: The updated markdown content of the page.
+        :param content: The updated Markdown content of the page.
         :param reason: (Optional) The reason for the revision.
         :param other_settings: Additional keyword arguments to pass.
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
     name=PACKAGE_NAME,
     author="Bryce Boe",
     author_email="bbzbryce@gmail.com",
-    python_requires=">=3.4",
+    python_requires=">=3.5",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Environment :: Console",


### PR DESCRIPTION
Fixes #1145 and others within `models/reddit`.

Added a notice per #1145 of the behavior of `.moderated()` not returning the user's own profile subreddit (`u_USERNAME`). Style fixes for remaining references to Reddit Gold, which is now called Reddit Premium (note that the attribute for a Redditor is still called `is_gold`). Also standardizing subreddit prefixes from the legacy `/r/` to the official `r/`. 

Standardized the capitalization of Markdown as per [the site](https://www.reddit.com/wiki/markdown). 

Also updated an oversight in `setup.py` that says that the minimum is Python 3.4 when it is actually 3.5 per the README. Let me know if I did that wrong.

Also, r/wallpapers still doesn't support the `.random()` feature. Verified that.