### PR TITLE
Expand on and restructure pre_push.py

### DIFF
--- a/pre_push.py
+++ b/pre_push.py
@@ -58,7 +58,9 @@ def run_unit():
     where any failed tests cause pre_push.py to fail.
     """
     curdir = path.abspath(path.join(__file__, ".."))
-    return do_process([sys.executable, "{dir}/setup.py".format(dir=curdir), "test"])
+    return do_process(
+        [sys.executable, "{dir}/setup.py".format(dir=curdir), "test"]
+    )
 
 
 def main():

--- a/pre_push.py
+++ b/pre_push.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
 """Run static analysis on the project."""
+
+from os import path
+
 import sys
 from shutil import rmtree
 from subprocess import CalledProcessError, check_call
@@ -24,11 +27,14 @@ def do_process(args, shell=False):
     except Exception as exc:
         sys.stderr.write(str(exc) + "\n")
         sys.exit(1)
-    return True
+    else:
+        return True
 
 
 def main():
-    """Entry point to pre_push.py."""
+    """Entry point to pre_push.py.
+    Returns a statuscode of 0 if everything ran correctly.
+    Otherwise, it will return statuscode 1"""
     success = True
     success &= do_process(["black *.py docs praw tests"], shell=True)
     success &= do_process(["flake8", "--exclude=.eggs,build,dist,docs,.tox"])
@@ -41,11 +47,14 @@ def main():
     finally:
         rmtree(tmp_dir)
 
-    return 0 if success else 1
+    curdir = path.abspath(path.join(__file__, ".."))
+    success &= do_process([sys.executable, curdir + "/setup.py", "test"])
+
+    return int(not success)
 
 
 if __name__ == "__main__":
     exit_code = main()
-    print()
-    print("pre_push.py: Success!" if exit_code == 0 else "pre_push.py: Fail")
+    print("\npre_push.py: Success!" if not exit_code else "pre_push.py: Fail")
     sys.exit(exit_code)
+

--- a/pre_push.py
+++ b/pre_push.py
@@ -1,12 +1,14 @@
 #!/usr/bin/env python3
 """Run static analysis on the project."""
 
-from os import path
-
 import sys
+
+from os import path
 from shutil import rmtree
 from subprocess import CalledProcessError, check_call
 from tempfile import mkdtemp
+
+import argparse
 
 
 def do_process(args, shell=False):
@@ -27,14 +29,15 @@ def do_process(args, shell=False):
     except Exception as exc:
         sys.stderr.write(str(exc) + "\n")
         sys.exit(1)
-    else:
-        return True
+    return True
 
 
-def main():
-    """Entry point to pre_push.py.
+def run_static():
+    """Runs the static tests.
+
     Returns a statuscode of 0 if everything ran correctly.
-    Otherwise, it will return statuscode 1"""
+    Otherwise, it will return statuscode 1
+    """
     success = True
     success &= do_process(["black *.py docs praw tests"], shell=True)
     success &= do_process(["flake8", "--exclude=.eggs,build,dist,docs,.tox"])
@@ -47,14 +50,67 @@ def main():
     finally:
         rmtree(tmp_dir)
 
-    curdir = path.abspath(path.join(__file__, ".."))
-    success &= do_process([sys.executable, curdir + "/setup.py", "test"])
+    return success
 
+
+def run_unit():
+    """Runs the unit-tests.
+
+    Follows the behavior of the static tests,
+    where any failed tests cause pre_push.py to fail.
+    """
+    curdir = path.abspath(path.join(__file__, ".."))
+    return do_process([sys.executable, curdir + "/setup.py", "test"])
+
+
+def main():
+    """Runs the main function.
+
+    usage: pre_push.py [-h] [-n] [-u] [-a]
+
+    Run static and/or unit-tests
+    """
+    parser = argparse.ArgumentParser(
+        description="Run static and/or unit-tests"
+    )
+    parser.add_argument(
+        "-n",
+        "--unstatic",
+        action="store_true",
+        help="Do not run static tests (black/flake8/pydocstyle/sphinx-build)",
+        default=False,
+    )
+    parser.add_argument(
+        "-u",
+        "--unit-tests",
+        "--unit",
+        action="store_true",
+        default=False,
+        help="Run the unit tests",
+    )
+    parser.add_argument(
+        "-a",
+        "--all",
+        action="store_true",
+        default=False,
+        help="Run all of the tests (static and unit). "
+        "Overrides the unstatic argument.",
+    )
+    args = parser.parse_args()
+    success = True
+    try:
+        if not args.unstatic or args.all:
+            success &= run_static()
+        if args.all or args.unit_tests:
+            success &= run_unit()
+    except KeyboardInterrupt:
+        return int(not False)
     return int(not success)
 
 
 if __name__ == "__main__":
     exit_code = main()
-    print("\npre_push.py: Success!" if not exit_code else "pre_push.py: Fail")
+    print(
+        "\npre_push.py: Success!" if not exit_code else "\npre_push.py: Fail"
+    )
     sys.exit(exit_code)
-

--- a/pre_push.py
+++ b/pre_push.py
@@ -1,9 +1,9 @@
 #!/usr/bin/env python3
 """Run static analysis on the project."""
+import sys
 from shutil import rmtree
 from subprocess import CalledProcessError, check_call
 from tempfile import mkdtemp
-import sys
 
 
 def do_process(args, shell=False):

--- a/pre_push.py
+++ b/pre_push.py
@@ -1,14 +1,12 @@
 #!/usr/bin/env python3
 """Run static analysis on the project."""
 
+import argparse
 import sys
-
 from os import path
 from shutil import rmtree
 from subprocess import CalledProcessError, check_call
 from tempfile import mkdtemp
-
-import argparse
 
 
 def do_process(args, shell=False):
@@ -60,7 +58,7 @@ def run_unit():
     where any failed tests cause pre_push.py to fail.
     """
     curdir = path.abspath(path.join(__file__, ".."))
-    return do_process([sys.executable, curdir + "/setup.py", "test"])
+    return do_process([sys.executable, "{dir}/setup.py".format(dir=curdir), "test"])
 
 
 def main():


### PR DESCRIPTION
I feel that there is no reason for pre_push.py to not run the unit tests, so I added in a command to run the unit tests. 

I also moved around imports and changed the return of the main function to be the int of the opposite of the value of success (True=0 and False=1).