### PR TITLE
Add support for building on python3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ install:
 jobs:
   include:
     - install: pip install black flake8 pydocstyle sphinx sphinx_rtd_theme .
-      python: 3.7
+      python: 3.8
       script:
         - black --check --verbose *.py docs praw tests
         - flake8 --exclude=.eggs,build,docs
@@ -18,6 +18,7 @@ python:
   - 3.5
   - 3.6
   - 3.7
+  - 3.8
 script:
   - coverage run --source=praw setup.py test
   - coveralls

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: Implementation :: CPython",
         "Topic :: Utilities",
     ],


### PR DESCRIPTION
Python 3.8 should be back-compatible with everything on the previous versions, furthermore, I have run the pre_push checks and the unit tests on 3.8 without any new syntax errors or DeprecationWarnings.