### PR TITLE
Remove non-project gitignore patterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,16 +1,9 @@
-*.bak
 *.egg
 *.egg-info/
 *.eggs/
 *.pyc
-*.pyproj
-*.sln
-*.vs/
-*~
-.DS_Store
 .cache/
 .coverage
-.idea/
 .pytest_cache/
 .tox/
 _build/


### PR DESCRIPTION
Such patterns should be placed in a global gitignore:
https://help.github.com/en/github/using-git/ignoring-files#create-a-global-gitignore


Fixes # (provide issue number of applicable)

## Feature Summary and Justification

This feature provides ...

## References

* 
*