### PR TITLE
Remove unicode string indicatiors

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,6 +34,11 @@ Unreleased
 * :meth:`.moderator_subreddits` as :meth:`.Redditor.moderated` provides more
   functionality.
 
+**Removed**
+
+* Converting :class:`.APIException` to string will no longer escape unicode
+  characters.
+
 6.4.0 (2019/09/21)
 ------------------
 

--- a/praw/exceptions.py
+++ b/praw/exceptions.py
@@ -20,18 +20,10 @@ class APIException(PRAWException):
         :param error_type: The error type set on Reddit's end.
         :param message: The associated message for the error.
         :param field: The input field associated with the error if available.
-
-        .. note:: Calling ``str()`` on the instance returns
-            ``unicode_escape``-d ASCII string because the message may be
-            localized and may contain UNICODE characters. If you want a
-            non-escaped message, access the ``message`` attribute on
-            the instance.
-
         """
         error_str = "{}: '{}'".format(error_type, message)
         if field:
             error_str += " on field '{}'".format(field)
-        error_str = error_str.encode("unicode_escape").decode("ascii")
 
         super(APIException, self).__init__(error_str)
         self.error_type = error_type

--- a/praw/exceptions.py
+++ b/praw/exceptions.py
@@ -28,9 +28,9 @@ class APIException(PRAWException):
             the instance.
 
         """
-        error_str = u"{}: '{}'".format(error_type, message)
+        error_str = "{}: '{}'".format(error_type, message)
         if field:
-            error_str += u" on field '{}'".format(field)
+            error_str += " on field '{}'".format(field)
         error_str = error_str.encode("unicode_escape").decode("ascii")
 
         super(APIException, self).__init__(error_str)

--- a/tests/integration/models/reddit/test_widgets.py
+++ b/tests/integration/models/reddit/test_widgets.py
@@ -975,4 +975,4 @@ class TestWidget(IntegrationTest):
             assert len(widgets.sidebar) >= 2
         assert widgets.sidebar[0] != widgets.sidebar[1]
         assert widgets.sidebar[0] != widgets.sidebar[1].id
-        assert u"\xf0\x9f\x98\x80" != widgets.sidebar[0]  # for python 2
+        assert "\xf0\x9f\x98\x80" != widgets.sidebar[0]  # for python 2

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -24,7 +24,7 @@ class TestAPIException:
         )
 
     def test_str_for_localized_error_string(self):
-        exception = APIException("RATELIMIT", u"実行回数が多すぎます", u"フィールド")
+        exception = APIException("RATELIMIT", "実行回数が多すぎます", "フィールド")
         assert str(exception) == (
             "RATELIMIT: '\\u5b9f\\u884c\\u56de\\u6570\\u304c\\u591a"
             "\\u3059\\u304e\\u307e\\u3059' on field "

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -23,14 +23,6 @@ class TestAPIException:
             "BAD_SOMETHING: 'invalid something' on field 'some_field'"
         )
 
-    def test_str_for_localized_error_string(self):
-        exception = APIException("RATELIMIT", "実行回数が多すぎます", "フィールド")
-        assert str(exception) == (
-            "RATELIMIT: '\\u5b9f\\u884c\\u56de\\u6570\\u304c\\u591a"
-            "\\u3059\\u304e\\u307e\\u3059' on field "
-            "'\\u30d5\\u30a3\\u30fc\\u30eb\\u30c9'"
-        )
-
 
 class TestClientException:
     def test_inheritance(self):


### PR DESCRIPTION
While writing stubs, I was looking through the code and realized there is still a lot of Python2 compliant code. This was a simple fix to remove unicode prefixes on a bunch of items. However, several things still do a whole bunch of weird things to deal with unicode. An example is the Praw API Exception, which escapes unicode characters. In Python3, this should not be done, and I will implement a fix for that later. 