### PR TITLE
Add inline types to const.py and endpoints.py

### DIFF
--- a/praw/const.py
+++ b/praw/const.py
@@ -2,13 +2,13 @@
 
 from .endpoints import API_PATH  # noqa: F401
 
-__version__ = "6.4.1.dev0"
+__version__: str = "6.4.1.dev0"
 
-USER_AGENT_FORMAT = "{} PRAW/" + __version__
+USER_AGENT_FORMAT: str = "{} PRAW/" + __version__
 
-MAX_IMAGE_SIZE = 512000
-MIN_JPEG_SIZE = 128
-MIN_PNG_SIZE = 67
+MAX_IMAGE_SIZE: int = 512000
+MIN_JPEG_SIZE: int = 128
+MIN_PNG_SIZE: int = 67
 
-JPEG_HEADER = b"\xff\xd8\xff"
-PNG_HEADER = b"\x89\x50\x4e\x47\x0d\x0a\x1a\x0a"
+JPEG_HEADER: bytes = b"\xff\xd8\xff"
+PNG_HEADER: bytes = b"\x89\x50\x4e\x47\x0d\x0a\x1a\x0a"

--- a/praw/endpoints.py
+++ b/praw/endpoints.py
@@ -1,8 +1,10 @@
 """List of API endpoints PRAW knows about."""
 
+from typing import Dict
+
 # flake8: noqa
 # fmt: off
-API_PATH = {
+API_PATH: Dict[str, str] = {
     "about_edited":            "r/{subreddit}/about/edited/",
     "about_log":               "r/{subreddit}/about/log/",
     "about_modqueue":          "r/{subreddit}/about/modqueue/",


### PR DESCRIPTION
As per #1164, instead of creating stubs, inline types will be added. In order to make it easy to review, each file or few files will get their own PR (linked to #1164).

This file adds types for:

- ~/praw/const.py
- ~/praw/endpoints.py