### PR TITLE
Add Py35 compatible type hints

### DIFF
--- a/praw/config.py
+++ b/praw/config.py
@@ -3,7 +3,6 @@ import configparser
 import os
 import sys
 from threading import Lock
-from typing import Any, Union
 
 from .exceptions import ClientException
 
@@ -57,7 +56,7 @@ class Config:
             raise ClientException("No short domain specified.")
         return self._short_url
 
-    def __init__(self, site_name: str, **settings: Union[str, Any]):
+    def __init__(self, site_name: str, **settings: str):
         """Initialize a Config instance."""
         with Config.LOCK:
             if Config.CONFIG is None:

--- a/praw/config.py
+++ b/praw/config.py
@@ -1,13 +1,11 @@
 """Provides the code to load PRAW's configuration file `praw.ini`."""
-from threading import Lock
 import configparser
 import os
 import sys
-from typing import Any, ClassVar, Dict, Optional, Union, TypeVar
+from threading import Lock
+from typing import Any, Union
 
 from .exceptions import ClientException
-
-_T = TypeVar("_T")
 
 
 class _NotSet:
@@ -23,24 +21,9 @@ class _NotSet:
 class Config:
     """A class containing the configuration for a reddit site."""
 
-    CONFIG: ClassVar[_T] = None
-    CONFIG_NOT_SET: ClassVar[_T] = _NotSet()
-    # Represents a config value that is not set.
-    LOCK: ClassVar[Lock] = Lock()
-
-    custom: Dict[Union[str, Any], Union[str, Any]]
-    client_id: ClassVar[Optional[str]]
-    client_secret: ClassVar[Optional[str]]
-    oauth_url: ClassVar[Optional[str]]
-    reddit_url: ClassVar[Optional[str]]
-    refresh_token: ClassVar[Optional[str]]
-    redirect_uri: ClassVar[Optional[str]]
-    password: ClassVar[Optional[str]]
-    user_agent: ClassVar[Optional[str]]
-    username: ClassVar[Optional[str]]
-
-    check_for_updates: ClassVar[bool] = ...
-    kinds: ClassVar[Dict[str, Any]] = ...
+    CONFIG = None
+    CONFIG_NOT_SET = _NotSet()  # Represents a config value that is not set.
+    LOCK = Lock()
 
     @staticmethod
     def _config_boolean(item):

--- a/praw/const.py
+++ b/praw/const.py
@@ -1,5 +1,5 @@
 """PRAW constants."""
-from .endpoints import API_PATH  # noqa
+from .endpoints import API_PATH  # noqa: F401
 
 __version__ = "6.4.1.dev0"
 

--- a/praw/const.py
+++ b/praw/const.py
@@ -1,14 +1,13 @@
 """PRAW constants."""
+from .endpoints import API_PATH  # noqa
 
-from .endpoints import API_PATH  # noqa: F401
+__version__ = "6.4.1.dev0"
 
-__version__: str = "6.4.1.dev0"
+USER_AGENT_FORMAT = "{} PRAW/" + __version__
 
-USER_AGENT_FORMAT: str = "{} PRAW/" + __version__
+MAX_IMAGE_SIZE = 512000
+MIN_JPEG_SIZE = 128
+MIN_PNG_SIZE = 67
 
-MAX_IMAGE_SIZE: int = 512000
-MIN_JPEG_SIZE: int = 128
-MIN_PNG_SIZE: int = 67
-
-JPEG_HEADER: bytes = b"\xff\xd8\xff"
-PNG_HEADER: bytes = b"\x89\x50\x4e\x47\x0d\x0a\x1a\x0a"
+JPEG_HEADER = b"\xff\xd8\xff"
+PNG_HEADER = b"\x89\x50\x4e\x47\x0d\x0a\x1a\x0a"

--- a/praw/endpoints.py
+++ b/praw/endpoints.py
@@ -2,7 +2,7 @@
 
 # flake8: noqa
 # fmt: off
-API_PATH= {
+API_PATH = {
     "about_edited":            "r/{subreddit}/about/edited/",
     "about_log":               "r/{subreddit}/about/log/",
     "about_modqueue":          "r/{subreddit}/about/modqueue/",

--- a/praw/endpoints.py
+++ b/praw/endpoints.py
@@ -1,10 +1,8 @@
 """List of API endpoints PRAW knows about."""
 
-from typing import Dict
-
 # flake8: noqa
 # fmt: off
-API_PATH: Dict[str, str] = {
+API_PATH= {
     "about_edited":            "r/{subreddit}/about/edited/",
     "about_log":               "r/{subreddit}/about/log/",
     "about_modqueue":          "r/{subreddit}/about/modqueue/",

--- a/praw/exceptions.py
+++ b/praw/exceptions.py
@@ -6,8 +6,6 @@ wrong on the client side. Both of these classes extend :class:`.PRAWException`.
 
 """
 
-from typing import ClassVar
-
 
 class PRAWException(Exception):
     """The base PRAW Exception that all other exception classes extend."""
@@ -15,10 +13,6 @@ class PRAWException(Exception):
 
 class APIException(PRAWException):
     """Indicate exception that involve responses from Reddit's API."""
-
-    error_type: ClassVar[str] = ...
-    message: ClassVar[str] = ...
-    field: ClassVar[str] = ...
 
     def __init__(self, error_type: str, message: str, field: str):
         """Initialize an instance of APIException.

--- a/praw/exceptions.py
+++ b/praw/exceptions.py
@@ -6,6 +6,8 @@ wrong on the client side. Both of these classes extend :class:`.PRAWException`.
 
 """
 
+from typing import ClassVar
+
 
 class PRAWException(Exception):
     """The base PRAW Exception that all other exception classes extend."""
@@ -14,7 +16,11 @@ class PRAWException(Exception):
 class APIException(PRAWException):
     """Indicate exception that involve responses from Reddit's API."""
 
-    def __init__(self, error_type, message, field):
+    error_type: ClassVar[str] = ...
+    message: ClassVar[str] = ...
+    field: ClassVar[str] = ...
+
+    def __init__(self, error_type: str, message: str, field: str):
         """Initialize an instance of APIException.
 
         :param error_type: The error type set on Reddit's end.


### PR DESCRIPTION
Fixes # (provide issue number of applicable)

Parent PR: #1164 

Combines:

- #1169 
- #1170 
- #1171 

This PR adds type hints and makes them compatible for Python 3.5, which supports type hinting in functions only.

Py 3.5 compatible:

```python
def test_function(arg1: str, arg2: str) -> Dict[str, str]:
    return {arg1: arg2}
```

Py 3.6+ compatible:
```python
class Test:
    classDict: Dict[str, str]
    def test_function(self, arg1: str, arg2: str) -> None:
        self.classDict = {**self.classDict, **{arg1: arg2}}
```