### PR TITLE
Add Github Actions CI Testing

### DIFF
--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -3,13 +3,12 @@ name: Python package
 on: [push, pull_request]
 
 jobs:
-  lint:
+  lint-multi-os:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        python-version: [3.6, 3.7, 3.8]
-
+        python-version: [3.8]
     steps:
     - uses: actions/checkout@v1
     - name: Set up Python ${{ matrix.python-version }}
@@ -30,12 +29,12 @@ jobs:
       run: pydocstyle praw
     - name: Build Sphinx files
       run: sphinx-build -W docs/ /tmp/foo
-  test:
+  test-multi-os:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.8]
     steps:
       - uses: actions/checkout@v1
       - name: Set up Python ${{ matrix.python-version }}
@@ -58,5 +57,60 @@ jobs:
           pip install "betamax-serializers >=0.2, <0.3"
       - name: Run tests
         run: python -m coverage run ./setup.py test 
+      - name: Print coverage
+        run: coverage report --include "praw/*" --fail-under=100
+  lint-multi-python:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.5, 3.6, 3.7, 3.8]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Upgrade all installed pip packages (setuptools, pip, etc.)
+        run: pip install --upgrade setuptools
+      - name: Install project dependencies
+        run: pip install .
+      - name: Install test dependencies
+        run: pip install black flake8 pydocstyle sphinx sphinx_rtd_theme
+      - name: Check code formatting with black
+        run: black --check --verbose .
+      - name: Lint with flake8
+        run: flake8 --exclude=.eggs,build,docs
+      - name: Check docstyle with pydocstyle
+        run: pydocstyle praw
+      - name: Build Sphinx files
+        run: sphinx-build -W docs/ /tmp/foo
+  test-multi-python:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        python-version: [3.5, 3.6, 3.7, 3.8]
+    steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Upgrade all installed pip packages (setuptools, pip, etc.)
+        run: pip install --upgrade setuptools
+      - name: Get wheel
+        run: pip install wheel
+      - name: Install project dependencies
+        run: pip install .
+      - name: Install test dependencies
+        run: pip install pytest coverage
+      - name: Install betamax and plugins
+        run: |
+          pip install "betamax >=0.8, <0.9"
+          pip install "betamax-matchers >=0.3.0, <0.5"
+          pip install "betamax-serializers >=0.2, <0.3"
+      - name: Run tests
+        run: python -m coverage run ./setup.py test
       - name: Print coverage
         run: coverage report --include "praw/*" --fail-under=100

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -52,6 +52,12 @@ jobs:
         run: python setup.py install
       - name: Install test dependencies
         run: pip install pytest coverage
+      - name: Install betamax and plugins 
+        # Windows + Python 3.8 bypass attempts
+        run: |
+          pip install "betamax >=0.8, <0.9"
+          pip install "betamax-matchers >=0.3.0, <0.5"
+          pip install "betamax-serializers >=0.2, <0.3"
       - name: Run tests
         run: python -m coverage run ./setup.py test 
       - name: Print coverage

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -18,9 +18,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install pip install black flake8 pydocstyle sphinx sphinx_rtd_theme
+      run: pip install pip install black flake8 pydocstyle sphinx sphinx_rtd_theme
     - name: Check code formatting with black
       run: black --check --verbose *.py docs praw tests
     - name: Lint with flake8
@@ -40,6 +38,6 @@ jobs:
       - name: Install test dependencies
         run: pip install pytest coverage
       - name: Run tests
-        run: coverage run setup.py test 
+        run: python -m coverage run setup.py test 
       - name: Print coverage
         run: coverage report --include "praw/*" --fail-under=100

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -35,6 +35,11 @@ jobs:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         python-version: [3.5, 3.6, 3.7, 3.8]
     steps:
+      - uses: actions/checkout@v1
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
       - name: Install test dependencies
         run: pip install pytest coverage
       - name: Run tests

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -6,7 +6,6 @@ jobs:
   lint:
     runs-on: ${{ matrix.os }}
     strategy:
-      max-parallel: 3
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         python-version: [3.6, 3.7, 3.8]
@@ -34,7 +33,6 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
-      max-parallel: 4
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         python-version: [3.5, 3.6, 3.7, 3.8]

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -18,7 +18,7 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
-      run: pip install pip install black flake8 pydocstyle sphinx sphinx_rtd_theme
+      run: pip install black flake8 pydocstyle sphinx sphinx_rtd_theme
     - name: Check code formatting with black
       run: black --check --verbose *.py docs praw tests
     - name: Lint with flake8
@@ -38,6 +38,6 @@ jobs:
       - name: Install test dependencies
         run: pip install pytest coverage
       - name: Run tests
-        run: python -m coverage run setup.py test 
+        run: python -m coverage run ./setup.py test 
       - name: Print coverage
         run: coverage report --include "praw/*" --fail-under=100

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -46,6 +46,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Upgrade all installed pip packages (setuptools, pip, etc.)
         run: pip list --outdated --format=freeze | grep -v '^\-e' | cut -d = -f 1  | xargs -n1 pip install -U
+      - name: Get wheel
+        run: pip instal wheel
       - name: Install project dependencies
         run: python setup.py install
       - name: Install test dependencies

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -24,7 +24,7 @@ jobs:
     - name: Install test dependencies
       run: pip install black flake8 pydocstyle sphinx sphinx_rtd_theme
     - name: Check code formatting with black
-      run: black --check --verbose *.py docs praw tests
+      run: black --check --verbose .
     - name: Lint with flake8
       run: flake8 --exclude=.eggs,build,docs
     - name: Check docstyle with pydocstyle

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Upgrade all installed pip packages (setuptools, pip, etc.)
         run: pip list --outdated --format=freeze | grep -v '^\-e' | cut -d = -f 1  | xargs -n1 pip install -U
       - name: Get wheel
-        run: pip instal wheel
+        run: pip install wheel
       - name: Install project dependencies
         run: python setup.py install
       - name: Install test dependencies

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,0 +1,45 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  lint:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      max-parallel: 4
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        python-version: [3.6, 3.7, 3.8]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install pip install black flake8 pydocstyle sphinx sphinx_rtd_theme
+    - name: Check code formatting with black
+      run: black --check --verbose *.py docs praw tests
+    - name: Lint with flake8
+      run: flake8 --exclude=.eggs,build,docs
+    - name: Check docstyle with pydocstyle
+      run: pydocstyle praw
+    - name: Build Sphinx files
+      run: sphinx-build -W docs/ /tmp/foo
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      max-parallel: 4
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        python-version: [3.5, 3.6, 3.7, 3.8]
+    steps:
+      - name: Install test dependencies
+        run: pip install pytest coverage
+      - name: Run tests
+        run: coverage run setup.py test 
+      - name: Print coverage
+        run: coverage report --include "praw/*" --fail-under=100

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,7 +17,9 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+    - name: Install project dependencies
+      run: python setup.py install
+    - name: Install test dependencies
       run: pip install black flake8 pydocstyle sphinx sphinx_rtd_theme
     - name: Check code formatting with black
       run: black --check --verbose *.py docs praw tests
@@ -40,6 +42,8 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Install project dependencies
+        run: python setup.py install
       - name: Install test dependencies
         run: pip install pytest coverage
       - name: Run tests

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -17,6 +17,8 @@ jobs:
       uses: actions/setup-python@v1
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Upgrade all installed pip packages (setuptools, pip, etc.)
+      run: pip list --outdated --format=freeze | grep -v '^\-e' | cut -d = -f 1  | xargs -n1 pip install -U
     - name: Install project dependencies
       run: python setup.py install
     - name: Install test dependencies
@@ -42,6 +44,8 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
+      - name: Upgrade all installed pip packages (setuptools, pip, etc.)
+        run: pip list --outdated --format=freeze | grep -v '^\-e' | cut -d = -f 1  | xargs -n1 pip install -U
       - name: Install project dependencies
         run: python setup.py install
       - name: Install test dependencies

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -1,6 +1,6 @@
 name: Python package
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   lint:

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -6,7 +6,7 @@ jobs:
   lint:
     runs-on: ${{ matrix.os }}
     strategy:
-      max-parallel: 3 # We need this limit or else the tests fail
+      max-parallel: 3
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         python-version: [3.6, 3.7, 3.8]
@@ -18,9 +18,9 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
     - name: Upgrade all installed pip packages (setuptools, pip, etc.)
-      run: pip list --outdated --format=freeze | grep -v '^\-e' | cut -d = -f 1  | xargs -n1 pip install -U
+      run: pip install --upgrade setuptools
     - name: Install project dependencies
-      run: python setup.py install
+      run: pip install .
     - name: Install test dependencies
       run: pip install black flake8 pydocstyle sphinx sphinx_rtd_theme
     - name: Check code formatting with black
@@ -34,7 +34,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
-      max-parallel: 4 # We need this limit or else the tests fail
+      max-parallel: 4
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         python-version: [3.5, 3.6, 3.7, 3.8]
@@ -45,15 +45,15 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
       - name: Upgrade all installed pip packages (setuptools, pip, etc.)
-        run: pip list --outdated --format=freeze | grep -v '^\-e' | cut -d = -f 1  | xargs -n1 pip install -U
+        run: pip install --upgrade setuptools
       - name: Get wheel
         run: pip install wheel
       - name: Install project dependencies
-        run: python setup.py install
+        run: pip install .
       - name: Install test dependencies
         run: pip install pytest coverage
       - name: Install betamax and plugins 
-        # Windows + Python 3.8 bypass attempts
+        # Windows + Python 3.8 support
         run: |
           pip install "betamax >=0.8, <0.9"
           pip install "betamax-matchers >=0.3.0, <0.5"

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -6,7 +6,7 @@ jobs:
   lint:
     runs-on: ${{ matrix.os }}
     strategy:
-      max-parallel: 4
+      max-parallel: 9
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         python-version: [3.6, 3.7, 3.8]
@@ -34,7 +34,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
-      max-parallel: 4
+      max-parallel: 12
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         python-version: [3.5, 3.6, 3.7, 3.8]

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -6,7 +6,7 @@ jobs:
   lint:
     runs-on: ${{ matrix.os }}
     strategy:
-      max-parallel: 9
+      max-parallel: 3 # We need this limit or else the tests fail
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         python-version: [3.6, 3.7, 3.8]
@@ -34,7 +34,7 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
-      max-parallel: 12
+      max-parallel: 4 # We need this limit or else the tests fail
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
         python-version: [3.5, 3.6, 3.7, 3.8]

--- a/.github/workflows/pythonpackage.yml
+++ b/.github/workflows/pythonpackage.yml
@@ -64,7 +64,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
     steps:
       - uses: actions/checkout@v1
       - name: Set up Python ${{ matrix.python-version }}

--- a/pre_push.py
+++ b/pre_push.py
@@ -37,7 +37,7 @@ def run_static():
     Otherwise, it will return statuscode 1
     """
     success = True
-    success &= do_process(["black *.py docs praw tests"], shell=True)
+    success &= do_process(["black ."], shell=True)
     success &= do_process(["flake8", "--exclude=.eggs,build,dist,docs,.tox"])
     success &= do_process(["pydocstyle", "praw"])
     # success &= do_process(["pylint", "--rcfile=.pylintrc", "praw"])

--- a/pre_push.py
+++ b/pre_push.py
@@ -38,7 +38,7 @@ def run_static():
     """
     success = True
     success &= do_process(["black ."], shell=True)
-    success &= do_process(["flake8", "--exclude=.eggs,build,dist,docs,.tox"])
+    success &= do_process(["flake8", "--exclude=.eggs,build,docs"])
     success &= do_process(["pydocstyle", "praw"])
     # success &= do_process(["pylint", "--rcfile=.pylintrc", "praw"])
 


### PR DESCRIPTION
Addressing #1175 , I came up with a way to make pre_push work for Windows, and to avoid future errors, suggest using Github's Actions (supporting multiple OS architectures) on top of existing CI to make sure that code works perfectly on all OS. Coverage is also tested, although not put into a easy-to-use website like coveralls, so I suggest this supplement our CI, not be a full replacement, although it easily can replace travis.