### PR TITLE
Move the snake case functions into their own module

### DIFF
--- a/praw/util/__init__.py
+++ b/praw/util/__init__.py
@@ -1,4 +1,4 @@
 """Package imports for utilities."""
 
-from .cache import cachedproperty # noqa: F401
-from .snake import camel_to_snake, snake_case_keys # noqa: F401
+from .cache import cachedproperty  # noqa: F401
+from .snake import camel_to_snake, snake_case_keys  # noqa: F401

--- a/praw/util/__init__.py
+++ b/praw/util/__init__.py
@@ -2,4 +2,3 @@
 
 from .cache import cachedproperty  # noqa: F401
 from .snake import camel_to_snake, snake_case_keys  # noqa: F401
-

--- a/praw/util/__init__.py
+++ b/praw/util/__init__.py
@@ -3,4 +3,3 @@
 from .cache import cachedproperty  # noqa: F401
 from .snake import camel_to_snake, snake_case_keys  # noqa: F401
 
-__all__ = ("cache", "camel_to_snake", "snake_case_keys")

--- a/praw/util/__init__.py
+++ b/praw/util/__init__.py
@@ -2,3 +2,5 @@
 
 from .cache import cachedproperty  # noqa: F401
 from .snake import camel_to_snake, snake_case_keys  # noqa: F401
+
+__all__ = ("cache", "camel_to_snake", "snake_case_keys")

--- a/praw/util/__init__.py
+++ b/praw/util/__init__.py
@@ -1,4 +1,4 @@
 """Package imports for utilities."""
 
-from .cache import cachedproperty
-from .snake import camel_to_snake, snake_case_keys
+from .cache import cachedproperty # noqa: F401
+from .snake import camel_to_snake, snake_case_keys # noqa: F401

--- a/praw/util/__init__.py
+++ b/praw/util/__init__.py
@@ -1,21 +1,4 @@
 """Package imports for utilities."""
 
-import re
-
-__all__ = ("cache", "camel_to_snake", "snake_case_keys")
-
-_re_camel_to_snake = re.compile(r"([a-z0-9](?=[A-Z])|[A-Z](?=[A-Z][a-z]))")
-
-
-def camel_to_snake(name):
-    """Convert `name` from camelCase to snake_case."""
-    return _re_camel_to_snake.sub(r"\1_", name).lower()
-
-
-def snake_case_keys(dictionary):
-    """Return a new dictionary with keys converted to snake_case.
-
-    :param dictionary: The dict to be corrected.
-
-    """
-    return {camel_to_snake(k): v for k, v in dictionary.items()}
+from .cache import cachedproperty
+from .snake import camel_to_snake, snake_case_keys

--- a/praw/util/snake.py
+++ b/praw/util/snake.py
@@ -1,4 +1,4 @@
-"""Contains functions dealing with snake case conversions"""
+"""Contains functions dealing with snake case conversions."""
 
 import re
 

--- a/praw/util/snake.py
+++ b/praw/util/snake.py
@@ -1,0 +1,19 @@
+"""Contains functions dealing with snake case conversions"""
+
+import re
+
+_re_camel_to_snake = re.compile(r"([a-z0-9](?=[A-Z])|[A-Z](?=[A-Z][a-z]))")
+
+
+def camel_to_snake(name):
+    """Convert `name` from camelCase to snake_case."""
+    return _re_camel_to_snake.sub(r"\1_", name).lower()
+
+
+def snake_case_keys(dictionary):
+    """Return a new dictionary with keys converted to snake_case.
+
+    :param dictionary: The dict to be corrected.
+
+    """
+    return {camel_to_snake(k): v for k, v in dictionary.items()}


### PR DESCRIPTION
The util package has a bunch of functions in the __init__.py file, and I thought that this was weird, since it breaks the existing norms for seperating. In this PR, I propose putting them into their own file and then importing the functions, so everything is compatible with previous versions.