### PR TITLE
Updating References

### DIFF
--- a/docs/package_info/references.rst
+++ b/docs/package_info/references.rst
@@ -7,10 +7,10 @@ References
 * `Reddit's API Wiki Page <https://github.com/reddit/reddit/wiki/API>`_
 * `Reddit's API Documentation <https://www.reddit.com/dev/api>`_
 
+* `Reddit Help <https://www.reddithelp.com/en>`_
 * `Reddit Markdown Primer
   <https://www.reddit.com/wiki/markdown>`_
-* `reddit.com's FAQ <https://www.reddit.com/wiki/faq>`_
-* `reddit.com's Status <https://reddit.statuspage.io/>`_.
+* `Reddit Status <https://reddit.statuspage.io/>`_.
   Indicates when Reddit is up or down.
 * `r/changelog <https://www.reddit.com/r/changelog/>`_. Significant changes to
   Reddit's codebase will be announced here in non-developer speak.

--- a/docs/package_info/references.rst
+++ b/docs/package_info/references.rst
@@ -3,15 +3,16 @@ References
 
 * `PRAW's Source Code <https://github.com/praw-dev/praw>`_
 * `Reddit's Source Code <https://github.com/reddit/reddit>`_
+  This repository has been archived and is no longer updated.
 * `Reddit's API Wiki Page <https://github.com/reddit/reddit/wiki/API>`_
 * `Reddit's API Documentation <https://www.reddit.com/dev/api>`_
 
 * `Reddit Markdown Primer
   <https://www.reddit.com/wiki/markdown>`_
 * `reddit.com's FAQ <https://www.reddit.com/wiki/faq>`_
-* `reddit.com's Status Twitterbot <https://twitter.com/redditstatus/>`_.
-  Tweets when Reddit goes up or down
+* `reddit.com's Status <https://reddit.statuspage.io/>`_.
+  Indicates when Reddit is up or down.
 * `r/changelog <https://www.reddit.com/r/changelog/>`_. Significant changes to
-  Reddit's codebase will be announced here in non-developer speak
+  Reddit's codebase will be announced here in non-developer speak.
 * `r/redditdev <https://www.reddit.com/r/redditdev>`_. Ask questions about
-  Reddit's codebase, PRAW and other API clients here
+  Reddit's codebase, PRAW, and other API clients here.

--- a/docs/package_info/references.rst
+++ b/docs/package_info/references.rst
@@ -2,7 +2,7 @@ References
 ==========
 
 * `PRAW's Source Code <https://github.com/praw-dev/praw>`_
-* `Reddit's Source Code <https://github.com/reddit/reddit>`_
+* `Reddit's Source Code. <https://github.com/reddit/reddit>`_
   This repository has been archived and is no longer updated.
 * `Reddit's API Wiki Page <https://github.com/reddit/reddit/wiki/API>`_
 * `Reddit's API Documentation <https://www.reddit.com/dev/api>`_

--- a/docs/package_info/references.rst
+++ b/docs/package_info/references.rst
@@ -1,15 +1,15 @@
 References
 ==========
 
-* `PRAW's Source Code <https://github.com/praw-dev/praw>`_
-* `Reddit's Source Code. <https://github.com/reddit/reddit>`_
+* `PRAW Source Code <https://github.com/praw-dev/praw>`_.
+* `Reddit Source Code <https://github.com/reddit/reddit>`_.
   This repository has been archived and is no longer updated.
-* `Reddit's API Wiki Page <https://github.com/reddit/reddit/wiki/API>`_
-* `Reddit's API Documentation <https://www.reddit.com/dev/api>`_
+* `Reddit API Wiki Page <https://github.com/reddit/reddit/wiki/API>`_.
+* `Reddit API Documentation <https://www.reddit.com/dev/api>`_.
 
-* `Reddit Help <https://www.reddithelp.com/en>`_
+* `Reddit Help <https://www.reddithelp.com/en>`_. Frequently asked questions and a knowledge base for the site.
 * `Reddit Markdown Primer
-  <https://www.reddit.com/wiki/markdown>`_
+  <https://www.reddit.com/wiki/markdown>`_. A guide to the Markdown formatting used on the site.
 * `Reddit Status <https://reddit.statuspage.io/>`_.
   Indicates when Reddit is up or down.
 * `r/changelog <https://www.reddit.com/r/changelog/>`_. Significant changes to


### PR DESCRIPTION
## Feature Summary and Justification

Just general clean-up for the references file. 

- Noting that the Reddit source code on GitHub [has been archived and is no longer reflective of the current state](https://www.reddit.com/r/changelog/comments/6xfyfg/an_update_on_the_state_of_the_redditreddit_and/).
- Updating from the old FAQ link to the current knowledge base.
- Updating the Reddit Status Twitter link directly to the Reddit Status site.