### PR TITLE
Standardize refresh tokens (#1051)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,7 +66,7 @@ os.environ["praw_check_for_updates"] = "False"
 placeholders = {
     x: env_default(x)
     for x in (
-        "auth_code client_id client_secret password redirect_uri "
+        "auth_code client_id client_secret refresh_token redirect_uri "
         "test_subreddit user_agent username"
     ).split()
 }

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -25,10 +25,17 @@ class IntegrationTest:
         self.reddit.read_only = True
 
     def setup_reddit(self):
-        self.reddit = Reddit(
+        login_data = dict(
             client_id=pytest.placeholders.client_id,
             client_secret=pytest.placeholders.client_secret,
-            password=pytest.placeholders.password,
+            refresh_token=pytest.placeholders.refresh_token,
             user_agent=pytest.placeholders.user_agent,
             username=pytest.placeholders.username,
         )
+        if (
+            login_data["username"] == "placeholder_username"
+            and login_data["refresh_token"] != "placeholder_refresh_token"
+        ):
+            # Some refresh tokens do not require a username to be given
+            login_data.pop("username")
+        self.reddit = Reddit(**login_data)


### PR DESCRIPTION
If it proceeds, allows the usage of refresh tokens with/without usernames.