### PR TITLE
Allow use of refresh token instead of username/password in tests

### DIFF
--- a/docs/package_info/contributing.rst
+++ b/docs/package_info/contributing.rst
@@ -68,9 +68,12 @@ in the cassettes. The environment variables are (listed in bash export format):
    export prawtest_user_agent=praw_pytest
 
 By setting these environment variables prior to running ``python setup.py
-test``, when adding or updating cassettes, instances of ``mypassword`` we be
+test``, when adding or updating cassettes, instances of ``mypassword`` will be
 replaced by the placeholder text ``<PASSWORD>`` and similar for the other
 environment variables.
+
+To use tokens instead of username/password set ``prawtest_refresh_token``
+instead of ``prawtest_password`` and ``prawtest_username``.
 
 When adding or updating a cassette, you will likely want to force requests to
 occur again rather than using an existing cassette. The simplest way to rebuild

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,15 @@
 """Prepare py.test."""
+from base64 import b64encode
+from functools import wraps
 import json
 import os
 import socket
 import sys
-import time
-from base64 import b64encode
 from sys import platform
+import time
 
 import betamax
+from betamax.cassette.cassette import dispatch_hooks, Cassette
 import pytest
 from betamax_serializers import pretty_json
 
@@ -67,7 +69,7 @@ placeholders = {
     x: env_default(x)
     for x in (
         "auth_code client_id client_secret password redirect_uri "
-        "test_subreddit user_agent username"
+        "test_subreddit user_agent username refresh_token"
     ).split()
 }
 placeholders["basic_auth"] = b64_string(
@@ -84,6 +86,28 @@ with betamax.Betamax.configure() as config:
         if key == "password":
             value = quote_plus(value)
         config.define_cassette_placeholder("<{}>".format(key.upper()), value)
+
+
+def add_init_hook(original_init):
+    """Wrap an __init__ method to also call some hooks."""
+
+    @wraps(original_init)
+    def wrapper(self, *args, **kwargs):
+        original_init(self, *args, **kwargs)
+        dispatch_hooks("after_init", self)
+
+    return wrapper
+
+
+Cassette.__init__ = add_init_hook(Cassette.__init__)
+
+
+def init_hook(cassette):
+    if cassette.is_recording():
+        pytest.set_up_record()  # dynamically defined in __init__.py
+
+
+Cassette.hooks["after_init"].append(init_hook)
 
 
 class Placeholders:

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -1,7 +1,9 @@
 """PRAW Integration test suite."""
-import pytest
+
 from betamax import Betamax
 from praw import Reddit
+import pytest
+import requests
 
 
 class IntegrationTest:
@@ -9,6 +11,7 @@ class IntegrationTest:
 
     def setup(self):
         """Setup runs before all test cases."""
+        self._overrode_reddit_setup = True
         self.setup_reddit()
         self.setup_betamax()
 
@@ -24,11 +27,32 @@ class IntegrationTest:
         # Require tests to explicitly disable read_only mode.
         self.reddit.read_only = True
 
+        pytest.set_up_record = self.set_up_record  # used in conftest.py
+
     def setup_reddit(self):
+        self._overrode_reddit_setup = False
+
+        self._session = requests.Session()
+
         self.reddit = Reddit(
+            requestor_kwargs={"session": self._session},
             client_id=pytest.placeholders.client_id,
             client_secret=pytest.placeholders.client_secret,
             password=pytest.placeholders.password,
             user_agent=pytest.placeholders.user_agent,
             username=pytest.placeholders.username,
         )
+
+    def set_up_record(self):
+        if not self._overrode_reddit_setup:
+            if (
+                pytest.placeholders.refresh_token
+                != "placeholder_refresh_token"
+            ):
+                self.reddit = Reddit(
+                    requestor_kwargs={"session": self._session},
+                    client_id=pytest.placeholders.client_id,
+                    client_secret=pytest.placeholders.client_secret,
+                    user_agent=pytest.placeholders.user_agent,
+                    refresh_token=pytest.placeholders.refresh_token,
+                )


### PR DESCRIPTION
## Feature Summary and Justification

This feature provides the ability to use a refresh token instead of username/password auth for tests.