### PR TITLE
Standardize usage of code-block

### DIFF
--- a/praw/models/comment_forest.py
+++ b/praw/models/comment_forest.py
@@ -38,14 +38,14 @@ class CommentForest:
 
         This method is to be used like an array access, such as:
 
-        .. code:: python
+        .. code-block:: python
 
            first_comment = submission.comments[0]
 
         Alternatively, the presence of this method enables one to iterate over
         all top_level comments, like so:
 
-        .. code:: python
+        .. code-block:: python
 
            for comment in submission.comments:
                print(comment.body)
@@ -123,7 +123,7 @@ class CommentForest:
         For example, to replace up to 32 :class:`.MoreComments` instances of a
         submission try:
 
-        .. code:: python
+        .. code-block:: python
 
            submission = reddit.submission('3hahrw')
            submission.comments.replace_more()
@@ -131,7 +131,7 @@ class CommentForest:
         Alternatively, to replace :class:`.MoreComments` instances within the
         replies of a single comment try:
 
-        .. code:: python
+        .. code-block:: python
 
            comment = reddit.comment('d8r4im1')
            comment.refresh()
@@ -143,7 +143,7 @@ class CommentForest:
                   looping and handling exceptions until the method returns
                   successfully. For example:
 
-                  .. code:: python
+                  .. code-block:: python
 
                      while True:
                          try:

--- a/praw/models/helpers.py
+++ b/praw/models/helpers.py
@@ -19,7 +19,7 @@ class LiveHelper(PRAWBase):
 
         This method is intended to be used as:
 
-        .. code:: python
+        .. code-block:: python
 
             livethread = reddit.live('ukaeu1ik4sw5')
 
@@ -45,7 +45,7 @@ class LiveHelper(PRAWBase):
 
         Usage:
 
-        .. code:: python
+        .. code-block:: python
 
             ids = ['3rgnbke2rai6hen7ciytwcxadi',
                    'sw7bubeycai6hey4ciytwamw3a',

--- a/praw/models/inbox.py
+++ b/praw/models/inbox.py
@@ -23,7 +23,7 @@ class Inbox(PRAWBase):
 
         To output the type and ID of all items available via this listing do:
 
-        .. code:: python
+        .. code-block:: python
 
            for item in reddit.inbox.all(limit=None):
                print(repr(item))
@@ -42,7 +42,7 @@ class Inbox(PRAWBase):
 
         For example, to collapse all unread Messages, try:
 
-        .. code:: python
+        .. code-block:: python
 
             from praw.models import Message
             unread_messages = []
@@ -71,7 +71,7 @@ class Inbox(PRAWBase):
 
         To output the author of one request worth of comment replies try:
 
-        .. code:: python
+        .. code-block:: python
 
            for reply in reddit.inbox.comment_replies():
                print(reply.author)
@@ -92,7 +92,7 @@ class Inbox(PRAWBase):
 
         For example, to mark all unread Messages as read, try:
 
-        .. code:: python
+        .. code-block:: python
 
             from praw.models import Message
             unread_messages = []
@@ -122,7 +122,7 @@ class Inbox(PRAWBase):
 
         For example, to mark the first 10 items as unread try:
 
-        .. code:: python
+        .. code-block:: python
 
             to_unread = list(reddit.inbox.all(limit=10))
             reddit.inbox.mark_unread(to_unread)
@@ -151,7 +151,7 @@ class Inbox(PRAWBase):
         For example, to output the author and body of the first 25 mentions
         try:
 
-        .. code:: python
+        .. code-block:: python
 
            for mention in reddit.inbox.mentions(limit=25):
                print('{}\n{}\n'.format(mention.author, mention.body))
@@ -168,7 +168,7 @@ class Inbox(PRAWBase):
 
         For example:
 
-        .. code:: python
+        .. code-block:: python
 
            message = reddit.inbox.message('7bnlgu')
 
@@ -190,7 +190,7 @@ class Inbox(PRAWBase):
 
         For example, to output the subject of the most recent 5 messages try:
 
-        .. code:: python
+        .. code-block:: python
 
            for message in reddit.inbox.messages(limit=5):
                print(message.subject)
@@ -211,7 +211,7 @@ class Inbox(PRAWBase):
         For example, to output the recipient of the most recent 15 messages
         try:
 
-        .. code:: python
+        .. code-block:: python
 
            for message in reddit.inbox.sent(limit=15):
                print(message.dest)
@@ -233,7 +233,7 @@ class Inbox(PRAWBase):
 
         For example, to retrieve all new inbox items, try:
 
-        .. code:: python
+        .. code-block:: python
 
            for item in reddit.inbox.stream():
                print(item)
@@ -251,7 +251,7 @@ class Inbox(PRAWBase):
 
         To output the author of one request worth of submission replies try:
 
-        .. code:: python
+        .. code-block:: python
 
            for reply in reddit.inbox.submission_replies():
                print(reply.author)
@@ -270,7 +270,7 @@ class Inbox(PRAWBase):
 
         For example, to uncollapse all unread Messages, try:
 
-        .. code:: python
+        .. code-block:: python
 
             from praw.models import Message
             unread_messages = []
@@ -306,7 +306,7 @@ class Inbox(PRAWBase):
 
         For example, to output the author of unread comments try:
 
-        .. code:: python
+        .. code-block:: python
 
            from praw.models import Comment
            for item in reddit.inbox.unread(limit=None):

--- a/praw/models/listing/mixins/base.py
+++ b/praw/models/listing/mixins/base.py
@@ -46,7 +46,7 @@ class BaseListingMixin(PRAWBase):
 
         This method can be used like:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.domain('imgur.com').controversial('week')
            reddit.multireddit('samuraisam', 'programming').controversial('day')
@@ -71,7 +71,7 @@ class BaseListingMixin(PRAWBase):
 
         This method can be used like:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.domain('imgur.com').hot()
            reddit.multireddit('samuraisam', 'programming').hot()
@@ -95,7 +95,7 @@ class BaseListingMixin(PRAWBase):
 
         This method can be used like:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.domain('imgur.com').new()
            reddit.multireddit('samuraisam', 'programming').new()
@@ -126,7 +126,7 @@ class BaseListingMixin(PRAWBase):
 
         This method can be used like:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.domain('imgur.com').top('week')
            reddit.multireddit('samuraisam', 'programming').top('day')

--- a/praw/models/listing/mixins/redditor.py
+++ b/praw/models/listing/mixins/redditor.py
@@ -37,7 +37,7 @@ class RedditorListingMixin(BaseListingMixin, GildedListingMixin):
         For example, to output the first line of all new comments by
         ``/u/spez`` try:
 
-        .. code:: python
+        .. code-block:: python
 
            for comment in reddit.redditor('spez').comments.new(limit=None):
                print(comment.body.split('\n', 1)[0][:79])
@@ -52,7 +52,7 @@ class RedditorListingMixin(BaseListingMixin, GildedListingMixin):
         For example, to output the title's of top 100 of all time submissions
         for ``/u/spez`` try:
 
-        .. code:: python
+        .. code-block:: python
 
            for submission in reddit.redditor('spez').submissions.top('all'):
                print(submission.title)

--- a/praw/models/listing/mixins/submission.py
+++ b/praw/models/listing/mixins/submission.py
@@ -21,7 +21,7 @@ class SubmissionListingMixin(PRAWBase):
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            submission = reddit.submission(id='5or86n')
 

--- a/praw/models/listing/mixins/subreddit.py
+++ b/praw/models/listing/mixins/subreddit.py
@@ -37,7 +37,7 @@ class CommentHelper(PRAWBase):
 
         This method should be used in a way similar to the example below:
 
-        .. code:: python
+        .. code-block:: python
 
            for comment in reddit.subreddit('redditdev').comments(limit=25):
                print(comment.author)
@@ -58,7 +58,7 @@ class SubredditListingMixin(
         For example, to output the author of the 25 most recent comments of
         ``/r/redditdev`` execute:
 
-        .. code:: python
+        .. code-block:: python
 
            for comment in reddit.subreddit('redditdev').comments(limit=25):
                print(comment.author)

--- a/praw/models/reddit/comment.py
+++ b/praw/models/reddit/comment.py
@@ -110,7 +110,7 @@ class Comment(InboxableMixin, UserContentMixin, FullnameMixin, RedditBase):
         ``reply_limit`` attributes before replies are fetched, including
         any call to :meth:`.refresh`:
 
-        .. code:: python
+        .. code-block:: python
 
            comment.reply_sort = 'new'
            comment.refresh()
@@ -223,7 +223,7 @@ class Comment(InboxableMixin, UserContentMixin, FullnameMixin, RedditBase):
 
         Lazy comment example:
 
-        .. code:: python
+        .. code-block:: python
 
            comment = reddit.comment('cklhv0f')
            parent = comment.parent()
@@ -242,7 +242,7 @@ class Comment(InboxableMixin, UserContentMixin, FullnameMixin, RedditBase):
         successive calls to :meth:`.parent()` with calls to :meth:`.refresh()`
         at every 9 levels. For example:
 
-        .. code:: python
+        .. code-block:: python
 
            comment = reddit.comment('dkk4qjd')
            ancestor = comment
@@ -280,7 +280,7 @@ class Comment(InboxableMixin, UserContentMixin, FullnameMixin, RedditBase):
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            comment = reddit.comment('dkk4qjd')
            comment.refresh()
@@ -329,7 +329,7 @@ class CommentModeration(ThingModerationMixin):
 
     Example usage:
 
-    .. code:: python
+    .. code-block:: python
 
        comment = reddit.comment('dkk4qjd')
        comment.mod.approve()

--- a/praw/models/reddit/emoji.py
+++ b/praw/models/reddit/emoji.py
@@ -79,7 +79,7 @@ class Emoji(RedditBase):
 
         To delete ``'test'`` as an emoji on the subreddit ``'praw_test'`` try:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('praw_test').emoji['test'].delete()
 
@@ -100,7 +100,7 @@ class SubredditEmoji:
 
         This method is to be used to fetch a specific emoji url, like so:
 
-        .. code:: python
+        .. code-block:: python
 
            emoji = reddit.subreddit('praw_test').emoji['test']
            print(emoji)
@@ -122,7 +122,7 @@ class SubredditEmoji:
 
         This method is to be used to discover all emoji for a subreddit:
 
-        .. code:: python
+        .. code-block:: python
 
            for emoji in reddit.subreddit('praw_test').emoji:
                print(emoji)
@@ -147,7 +147,7 @@ class SubredditEmoji:
 
         To add ``'test'`` to the subreddit ``'praw_test'`` try:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('praw_test').emoji.add('test','test.png')
 

--- a/praw/models/reddit/live.py
+++ b/praw/models/reddit/live.py
@@ -191,7 +191,7 @@ class LiveContributorRelationship:
 
         For example, to grant all permissions to the contributor, try:
 
-        .. code:: python
+        .. code-block:: python
 
            thread = reddit.live('ukaeu1ik4sw5')
            thread.contributor.update('spez')
@@ -199,13 +199,13 @@ class LiveContributorRelationship:
         To grant 'access' and 'edit' permissions (and to remove other
         permissions), try:
 
-        .. code:: python
+        .. code-block:: python
 
            thread.contributor.update('spez', ['access', 'edit'])
 
         To remove all permissions from the contributor, try:
 
-        .. code:: python
+        .. code-block:: python
 
            subreddit.moderator.update('spez', [])
 
@@ -235,7 +235,7 @@ class LiveContributorRelationship:
 
         For example, to set all permissions to the invitation, try:
 
-        .. code:: python
+        .. code-block:: python
 
            thread = reddit.live('ukaeu1ik4sw5')
            thread.contributor.update_invite('spez')
@@ -243,13 +243,13 @@ class LiveContributorRelationship:
         To set 'access' and 'edit' permissions (and to remove other
         permissions) to the invitation, try:
 
-        .. code:: python
+        .. code-block:: python
 
            thread.contributor.update_invite('spez', ['access', 'edit'])
 
         To remove all permissions from the invitation, try:
 
-        .. code:: python
+        .. code-block:: python
 
            thread.contributor.update_invite('spez', [])
 

--- a/praw/models/reddit/mixins/__init__.py
+++ b/praw/models/reddit/mixins/__init__.py
@@ -54,7 +54,7 @@ class ThingModerationMixin:
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            # approve a comment:
            comment = reddit.comment('dkk4qjd')
@@ -80,7 +80,7 @@ class ThingModerationMixin:
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            # distinguish and sticky a comment:
            comment = reddit.comment('dkk4qjd')
@@ -107,7 +107,7 @@ class ThingModerationMixin:
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            # ignore future reports on a comment:
            comment = reddit.comment('dkk4qjd')
@@ -128,7 +128,7 @@ class ThingModerationMixin:
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            # lock a comment:
            comment = reddit.comment('dkk4qjd')
@@ -157,7 +157,7 @@ class ThingModerationMixin:
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            # remove a comment and mark as spam:
            comment = reddit.comment('dkk4qjd')
@@ -219,7 +219,7 @@ class ThingModerationMixin:
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            # undistinguish a comment:
            comment = reddit.comment('dkk4qjd')
@@ -242,7 +242,7 @@ class ThingModerationMixin:
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            # accept future reports on a comment:
            comment = reddit.comment('dkk4qjd')

--- a/praw/models/reddit/mixins/editable.py
+++ b/praw/models/reddit/mixins/editable.py
@@ -10,7 +10,7 @@ class EditableMixin:
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            comment = reddit.comment('dkk4qjd')
            comment.delete()
@@ -29,7 +29,7 @@ class EditableMixin:
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            comment = reddit.comment('dkk4qjd')
 

--- a/praw/models/reddit/mixins/gildable.py
+++ b/praw/models/reddit/mixins/gildable.py
@@ -13,7 +13,7 @@ class GildableMixin:
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            comment = reddit.comment('dkk4qjd')
            comment.gild()

--- a/praw/models/reddit/mixins/inboxable.py
+++ b/praw/models/reddit/mixins/inboxable.py
@@ -14,7 +14,7 @@ class InboxableMixin:
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            comment = reddit.comment('dkk4qjd')
            comment.block()
@@ -34,7 +34,7 @@ class InboxableMixin:
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            inbox = reddit.inbox()
 
@@ -55,7 +55,7 @@ class InboxableMixin:
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            inbox = reddit.inbox.unread()
 
@@ -78,7 +78,7 @@ class InboxableMixin:
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            inbox = reddit.inbox(limit=10)
 
@@ -98,7 +98,7 @@ class InboxableMixin:
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            inbox = reddit.inbox()
 

--- a/praw/models/reddit/mixins/inboxtoggleable.py
+++ b/praw/models/reddit/mixins/inboxtoggleable.py
@@ -10,7 +10,7 @@ class InboxToggleableMixin:
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            comment = reddit.comment('dkk4qjd')
            comment.disable_inbox_replies()
@@ -30,7 +30,7 @@ class InboxToggleableMixin:
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            comment = reddit.comment('dkk4qjd')
            comment.enable_inbox_replies()

--- a/praw/models/reddit/mixins/messageable.py
+++ b/praw/models/reddit/mixins/messageable.py
@@ -19,20 +19,20 @@ class MessageableMixin:
 
         For example, to send a private message to ``u/spez``, try:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.redditor('spez').message('TEST', 'test message from PRAW')
 
         To send a message to ``u/spez`` from the moderators of ``r/test`` try:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.redditor('spez').message('TEST', 'test message from r/test',
                                            from_subreddit='test')
 
         To send a message to the moderators of ``r/test``, try:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('test').message('TEST', 'test PM from PRAW')
 

--- a/praw/models/reddit/mixins/replyable.py
+++ b/praw/models/reddit/mixins/replyable.py
@@ -20,7 +20,7 @@ class ReplyableMixin:
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            submission = reddit.submission(id='5or86n')
            submission.reply('reply')

--- a/praw/models/reddit/mixins/reportable.py
+++ b/praw/models/reddit/mixins/reportable.py
@@ -15,7 +15,7 @@ class ReportableMixin:
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            submission = reddit.submission(id='5or86n')
            submission.report('report reason')

--- a/praw/models/reddit/mixins/savable.py
+++ b/praw/models/reddit/mixins/savable.py
@@ -14,7 +14,7 @@ class SavableMixin:
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            submission = reddit.submission(id='5or86n')
            submission.save(category="view later")
@@ -34,7 +34,7 @@ class SavableMixin:
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            submission = reddit.submission(id='5or86n')
            submission.unsave()

--- a/praw/models/reddit/mixins/votable.py
+++ b/praw/models/reddit/mixins/votable.py
@@ -21,7 +21,7 @@ class VotableMixin:
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            submission = reddit.submission(id='5or86n')
            submission.clear_vote()
@@ -43,7 +43,7 @@ class VotableMixin:
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            submission = reddit.submission(id='5or86n')
            submission.downvote()
@@ -67,7 +67,7 @@ class VotableMixin:
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            submission = reddit.submission(id='5or86n')
            submission.upvote()

--- a/praw/models/reddit/modmail.py
+++ b/praw/models/reddit/modmail.py
@@ -174,7 +174,7 @@ class ModmailConversation(RedditBase):
 
         For example:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('redditdev').modmail('2gmz').archive()
 
@@ -186,7 +186,7 @@ class ModmailConversation(RedditBase):
 
         For example:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('redditdev').modmail('2gmz').highlight()
 
@@ -198,7 +198,7 @@ class ModmailConversation(RedditBase):
 
         For example:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('redditdev').modmail('2gmz').mute()
 
@@ -218,7 +218,7 @@ class ModmailConversation(RedditBase):
         For example, to mark the conversation as read along with other recent
         conversations from the same user:
 
-        .. code:: python
+        .. code-block:: python
 
            subreddit = reddit.subreddit('redditdev')
            conversation = subreddit.modmail.conversation('2gmz')
@@ -248,14 +248,14 @@ class ModmailConversation(RedditBase):
 
         For example, to reply to the non-mod user while hiding your username:
 
-        .. code:: python
+        .. code-block:: python
 
            conversation = reddit.subreddit('redditdev').modmail('2gmz')
            conversation.reply('Message body', author_hidden=True)
 
         To create a private moderator note on the conversation:
 
-        .. code:: python
+        .. code-block:: python
 
            conversation.reply('Message body', internal=True)
 
@@ -277,7 +277,7 @@ class ModmailConversation(RedditBase):
 
         For example:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('redditdev').modmail('2gmz').unarchive()
 
@@ -289,7 +289,7 @@ class ModmailConversation(RedditBase):
 
         For example:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('redditdev').modmail('2gmz').unhighlight()
 
@@ -303,7 +303,7 @@ class ModmailConversation(RedditBase):
 
         For example:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('redditdev').modmail('2gmz').unmute()
 
@@ -323,7 +323,7 @@ class ModmailConversation(RedditBase):
         For example, to mark the conversation as unread along with other recent
         conversations from the same user:
 
-        .. code:: python
+        .. code-block:: python
 
            subreddit = reddit.subreddit('redditdev')
            conversation = subreddit.modmail.conversation('2gmz')

--- a/praw/models/reddit/multi.py
+++ b/praw/models/reddit/multi.py
@@ -77,7 +77,7 @@ class Multireddit(SubredditListingMixin, RedditBase):
         Streams can be used to indefinitely retrieve new comments made to a
         multireddit, like:
 
-        .. code:: python
+        .. code-block:: python
 
            for comment in reddit.multireddit('spez', 'fun').stream.comments():
                print(comment)
@@ -85,7 +85,7 @@ class Multireddit(SubredditListingMixin, RedditBase):
         Additionally, new submissions can be retrieved via the stream. In the
         following example all new submissions to the multireddit are fetched:
 
-        .. code:: python
+        .. code-block:: python
 
            for submission in reddit.multireddit('bboe',
                                                 'games').stream.submissions():

--- a/praw/models/reddit/redditor.py
+++ b/praw/models/reddit/redditor.py
@@ -90,7 +90,7 @@ class Redditor(
         Streams can be used to indefinitely retrieve new comments made by a
         redditor, like:
 
-        .. code:: python
+        .. code-block:: python
 
            for comment in reddit.redditor('spez').stream.comments():
                print(comment)
@@ -99,7 +99,7 @@ class Redditor(
         following example all submissions are fetched via the redditor
         ``spez``:
 
-        .. code:: python
+        .. code-block:: python
 
            for submission in reddit.redditor('spez').stream.submissions():
                print(submission)
@@ -226,7 +226,7 @@ class Redditor(
 
         Usage:
 
-        .. code:: python
+        .. code-block:: python
 
             for subreddit in reddit.redditor('spez').moderated():
                 print(subreddit.display_name)
@@ -256,7 +256,7 @@ class Redditor(
 
         Usage:
 
-        .. code:: python
+        .. code-block:: python
 
             for trophy in reddit.redditor('spez').trophies():
                 print(trophy.name)
@@ -304,7 +304,7 @@ class RedditorStream:
         For example, to retrieve all new comments made by redditor ``spez``,
         try:
 
-        .. code:: python
+        .. code-block:: python
 
            for comment in reddit.redditor('spez').stream.comments():
                print(comment)
@@ -325,7 +325,7 @@ class RedditorStream:
         For example to retrieve all new submissions made by redditor
         ``spez``, try:
 
-        .. code:: python
+        .. code-block:: python
 
            for submission in reddit.redditor('spez').stream.submissions():
                print(submission)

--- a/praw/models/reddit/removal_reasons.py
+++ b/praw/models/reddit/removal_reasons.py
@@ -71,7 +71,7 @@ class RemovalReason(RedditBase):
 
         To delete ``'141vv5c16py7d'`` from the subreddit ``'NAME'`` try:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('NAME').removal_reasons['141vv5c16py7d'].mod.delete()
 
@@ -89,7 +89,7 @@ class RemovalReason(RedditBase):
 
         To update ``'141vv5c16py7d'`` from the subreddit ``'NAME'`` try:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('NAME').removal_reasons['141vv5c16py7d'].mod.update(
                message='New message',
@@ -113,7 +113,7 @@ class SubredditRemovalReasons:
 
         This method is to be used to fetch a specific removal reason, like so:
 
-        .. code:: python
+        .. code-block:: python
 
            reason_id = '141vv5c16py7d'
            reason = reddit.subreddit('NAME').mod.removal_reasons[reason_id]
@@ -162,7 +162,7 @@ class SubredditRemovalReasons:
 
         To add ``'Test'`` to the subreddit ``'NAME'`` try:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('NAME').removal_reasons.mod.add(
                message='Foobar',

--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -35,7 +35,7 @@ class SubmissionFlair:
 
         For example:
 
-        .. code:: python
+        .. code-block:: python
 
            choices = submission.flair.choices()
 
@@ -59,7 +59,7 @@ class SubmissionFlair:
         For example, to select an arbitrary editable flair text (assuming there
         is one) and set a custom value try:
 
-        .. code:: python
+        .. code-block:: python
 
            choices = submission.flair.choices()
            template_id = next(x for x in choices
@@ -83,7 +83,7 @@ class SubmissionModeration(ThingModerationMixin):
 
     Example usage:
 
-    .. code:: python
+    .. code-block:: python
 
        submission = reddit.submission(id="8dmv8z")
        submission.mod.approve()
@@ -116,7 +116,7 @@ class SubmissionModeration(ThingModerationMixin):
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            submission = reddit.submission(id='5or86n')
            submission.mod.contest_mode(state=True)
@@ -140,7 +140,7 @@ class SubmissionModeration(ThingModerationMixin):
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            submission = reddit.submission(id='5or86n')
            submission.mod.flair(text='PRAW', css_class='bot')
@@ -162,7 +162,7 @@ class SubmissionModeration(ThingModerationMixin):
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            submission = reddit.subreddit('test').submit('nsfw test',
                                                         selftext='nsfw')
@@ -185,7 +185,7 @@ class SubmissionModeration(ThingModerationMixin):
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            submission = reddit.subreddit('test').submit('oc test',
                                                         selftext='original')
@@ -211,7 +211,7 @@ class SubmissionModeration(ThingModerationMixin):
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            submission = reddit.submission(id='5or86n')
            submission.mod.sfw()
@@ -231,7 +231,7 @@ class SubmissionModeration(ThingModerationMixin):
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            submission = reddit.submission(id='5or86n')
            submission.mod.spoiler()
@@ -257,7 +257,7 @@ class SubmissionModeration(ThingModerationMixin):
 
         For example:
 
-        .. code:: python
+        .. code-block:: python
 
            submission = reddit.submission(id='5or86n')
            submission.mod.sticky()
@@ -292,7 +292,7 @@ class SubmissionModeration(ThingModerationMixin):
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            submission = reddit.subreddit('test').submit('oc test',
                                                         selftext='original')
@@ -318,7 +318,7 @@ class SubmissionModeration(ThingModerationMixin):
 
         For example:
 
-        .. code:: python
+        .. code-block:: python
 
            submission = reddit.subreddit('test').submit('not spoiler',
                                                         selftext='spoiler')
@@ -432,7 +432,7 @@ class Submission(
         This attribute can use used, for example, to obtain a flat list of
         comments, with any :class:`.MoreComments` removed:
 
-        .. code:: python
+        .. code-block:: python
 
            submission.comments.replace_more(limit=0)
            comments = submission.comments.list()
@@ -441,7 +441,7 @@ class Submission(
         ``comment_limit`` attributes before comments are fetched, including
         any call to :meth:`.replace_more`:
 
-        .. code:: python
+        .. code-block:: python
 
            submission.comment_sort = 'new'
            comments = submission.comments.list()
@@ -464,7 +464,7 @@ class Submission(
         For example, to select an arbitrary editable flair text (assuming there
         is one) and set a custom value try:
 
-        .. code:: python
+        .. code-block:: python
 
            choices = submission.flair.choices()
            template_id = next(x for x in choices
@@ -574,7 +574,7 @@ class Submission(
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            submission = reddit.submission(id='5or86n')
            submission.mark_visited()
@@ -592,7 +592,7 @@ class Submission(
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            submission = reddit.submission(id='5or86n')
            submission.hide()
@@ -612,7 +612,7 @@ class Submission(
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            submission = reddit.submission(id='5or86n')
            submission.unhide()
@@ -657,7 +657,7 @@ class Submission(
 
         Example usage:
 
-        .. code:: python
+        .. code-block:: python
 
            submission = reddit.submission(id='5or86n')
            cross_post = submission.crosspost(subreddit="learnprogramming",

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -30,7 +30,7 @@ class Subreddit(
 
     To obtain an instance of this class for subreddit ``r/redditdev`` execute:
 
-    .. code:: python
+    .. code-block:: python
 
        subreddit = reddit.subreddit('redditdev')
 
@@ -38,14 +38,14 @@ class Subreddit(
     one. The following outputs the titles of the 25 hottest submissions in
     ``r/all``:
 
-    .. code:: python
+    .. code-block:: python
 
        for submission in reddit.subreddit('all').hot(limit=25):
            print(submission.title)
 
     Multiple subreddits can be combined with a ``+`` like so:
 
-    .. code:: python
+    .. code-block:: python
 
        for submission in reddit.subreddit('redditdev+learnpython').top('all'):
            print(submission)
@@ -56,7 +56,7 @@ class Subreddit(
     :meth:`~praw.models.Subreddit.gilded`, and
     :meth:`.SubredditStream.comments`.
 
-    .. code:: python
+    .. code-block:: python
 
        for submission in reddit.subreddit('all-redditdev').new():
            print(submission)
@@ -259,14 +259,14 @@ class Subreddit(
 
         This attribute can be used to discover all emoji for a subreddit:
 
-        .. code:: python
+        .. code-block:: python
 
            for emoji in reddit.subreddit('iama').emoji:
                print(emoji)
 
         A single emoji can be lazily retrieved via:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('blah').emoji['emoji_name']
 
@@ -357,7 +357,7 @@ class Subreddit(
         Streams can be used to indefinitely retrieve new comments made to a
         subreddit, like:
 
-        .. code:: python
+        .. code-block:: python
 
            for comment in reddit.subreddit('iama').stream.comments():
                print(comment)
@@ -366,7 +366,7 @@ class Subreddit(
         following example all submissions are fetched via the special subreddit
         ``r/all``:
 
-        .. code:: python
+        .. code-block:: python
 
            for submission in reddit.subreddit('all').stream.submissions():
                print(submission)
@@ -407,14 +407,14 @@ class Subreddit(
 
         This attribute can be used to discover all wikipages for a subreddit:
 
-        .. code:: python
+        .. code-block:: python
 
            for wikipage in reddit.subreddit('iama').wiki:
                print(wikipage)
 
         To fetch the content for a given wikipage try:
 
-        .. code:: python
+        .. code-block:: python
 
            wikipage = reddit.subreddit('iama').wiki['proof']
            print(wikipage.content_md)
@@ -566,7 +566,7 @@ class Subreddit(
 
         For example to show the rules of ``r/redditdev`` try:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('redditdev').rules()
 
@@ -596,7 +596,7 @@ class Subreddit(
 
         For example to search all subreddits for ``praw`` try:
 
-        .. code:: python
+        .. code-block:: python
 
            for submission in reddit.subreddit('all').search('praw'):
                print(submission.title)
@@ -674,7 +674,7 @@ class Subreddit(
 
         For example to submit a URL to ``r/reddit_api_test`` do:
 
-        .. code:: python
+        .. code-block:: python
 
            title = 'PRAW documentation'
            url = 'https://praw.readthedocs.io'
@@ -768,7 +768,7 @@ class Subreddit(
 
         For example to submit an image to ``r/reddit_api_test`` do:
 
-        .. code:: python
+        .. code-block:: python
 
            title = 'My favorite picture'
            image = '/path/to/image.png'
@@ -861,7 +861,7 @@ class Subreddit(
 
         For example to submit a video to ``r/reddit_api_test`` do:
 
-        .. code:: python
+        .. code-block:: python
 
            title = 'My favorite movie'
            video = '/path/to/video.mp4'
@@ -942,7 +942,7 @@ class SubredditFilters:
     Members of this class should be utilized via ``Subreddit.filters``. For
     example to add a filter run:
 
-    .. code:: python
+    .. code-block:: python
 
        reddit.subreddit('all').filters.add('subreddit_name')
 
@@ -964,7 +964,7 @@ class SubredditFilters:
 
         This method should be invoked as:
 
-        .. code:: python
+        .. code-block:: python
 
            for subreddit in reddit.subreddit('NAME').filters:
                ...
@@ -989,7 +989,7 @@ class SubredditFilters:
         Alternatively, you can filter a subreddit temporarily from a special
         listing in a manner like so:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('all-redditdev-learnpython')
 
@@ -1163,7 +1163,7 @@ class SubredditFlair:
 
         For example:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('redditdev').flair.set('bboe', 'PRAW author',
                                                    css_class='mods')
@@ -1208,7 +1208,7 @@ class SubredditFlair:
         For example to clear the flair text, and set the ``praw`` flair css
         class on a few users try:
 
-        .. code:: python
+        .. code-block:: python
 
            subreddit.flair.update(['bboe', 'spez', 'spladug'],
                                   css_class='praw')
@@ -1569,7 +1569,7 @@ class SubredditModeration:
 
         To print all items in the edited queue try:
 
-        .. code:: python
+        .. code-block:: python
 
            for item in reddit.subreddit('mod').mod.edited(limit=None):
                print(item)
@@ -1592,7 +1592,7 @@ class SubredditModeration:
 
         To print the last 5 moderator mail messages and their replies, try:
 
-        .. code:: python
+        .. code-block:: python
 
            for message in reddit.subreddit('mod').mod.inbox(limit=5):
                print("From: {}, Body: {}".format(message.author, message.body))
@@ -1619,7 +1619,7 @@ class SubredditModeration:
 
         To print the moderator and subreddit of the last 5 modlog entries try:
 
-        .. code:: python
+        .. code-block:: python
 
            for log in reddit.subreddit('mod').mod.log(limit=5):
                print("Mod: {}, Subreddit: {}".format(log.mod, log.subreddit))
@@ -1644,7 +1644,7 @@ class SubredditModeration:
 
         To print all modqueue items try:
 
-        .. code:: python
+        .. code-block:: python
 
            for item in reddit.subreddit('mod').mod.modqueue(limit=None):
                print(item)
@@ -1672,7 +1672,7 @@ class SubredditModeration:
 
         A single removal reason can be lazily retrieved via:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('NAME').mod.removal_reasons['reason_id']
 
@@ -1693,7 +1693,7 @@ class SubredditModeration:
 
         To print the user and mod report reasons in the report queue try:
 
-        .. code:: python
+        .. code-block:: python
 
            for reported_item in reddit.subreddit('mod').mod.reports():
                print("User Reports: {}".format(reported_item.user_reports))
@@ -1723,7 +1723,7 @@ class SubredditModeration:
 
         To print the items in the spam queue try:
 
-        .. code:: python
+        .. code-block:: python
 
            for item in reddit.subreddit('mod').mod.spam():
                print(item)
@@ -1744,7 +1744,7 @@ class SubredditModeration:
 
         To print the items in the unmoderated queue try:
 
-        .. code:: python
+        .. code-block:: python
 
            for item in reddit.subreddit('mod').mod.unmoderated():
                print(item)
@@ -1766,7 +1766,7 @@ class SubredditModeration:
 
         To print the mail in the unread modmail queue try:
 
-        .. code:: python
+        .. code-block:: python
 
            for message in reddit.subreddit('mod').mod.unread():
                print("From: {}, To: {}".format(message.author, message.dest))
@@ -1895,7 +1895,7 @@ class SubredditQuarantine:
 
         Usage:
 
-        .. code:: python
+        .. code-block:: python
 
            subreddit = reddit.subreddit('QUESTIONABLE')
            next(subreddit.hot())  # Raises prawcore.Forbidden
@@ -1917,7 +1917,7 @@ class SubredditQuarantine:
 
         Usage:
 
-        .. code:: python
+        .. code-block:: python
 
            subreddit = reddit.subreddit('QUESTIONABLE')
            next(subreddit.hot())  # Returns Submission
@@ -2063,13 +2063,13 @@ class ModeratorRelationship(SubredditRelationship):
 
         To be used like:
 
-        .. code:: python
+        .. code-block:: python
 
            moderators = reddit.subreddit('nameofsub').moderator()
 
         For example, to list the moderators along with their permissions try:
 
-        .. code:: python
+        .. code-block:: python
 
            for moderator in reddit.subreddit('SUBREDDIT').moderator():
                print('{}: {}'.format(moderator, moderator.mod_permissions))
@@ -2099,7 +2099,7 @@ class ModeratorRelationship(SubredditRelationship):
         For example, to invite ``'spez'`` with ``'posts'`` and ``'mail'``
             permissions to ``r/test``, try:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('test').moderator.add('spez', ['posts', 'mail'])
 
@@ -2122,7 +2122,7 @@ class ModeratorRelationship(SubredditRelationship):
         For example, to invite ``'spez'`` with ``posts`` and ``mail``
             permissions to ``r/test``, try:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('test').moderator.invite('spez', ['posts', 'mail'])
 
@@ -2137,7 +2137,7 @@ class ModeratorRelationship(SubredditRelationship):
 
         For example:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('subredditname').moderator.leave()
 
@@ -2152,7 +2152,7 @@ class ModeratorRelationship(SubredditRelationship):
 
         For example:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('subredditname').moderator.remove_invite('spez')
 
@@ -2173,13 +2173,13 @@ class ModeratorRelationship(SubredditRelationship):
 
         For example, to add all permissions to the moderator, try:
 
-        .. code:: python
+        .. code-block:: python
 
            subreddit.moderator.update('spez')
 
         To remove all permissions from the moderator, try:
 
-        .. code:: python
+        .. code-block:: python
 
            subreddit.moderator.update('spez', [])
 
@@ -2203,7 +2203,7 @@ class ModeratorRelationship(SubredditRelationship):
         For example, to grant the ``flair``` and ``mail``` permissions to
         the moderator invite, try:
 
-        .. code:: python
+        .. code-block:: python
 
            subreddit.moderator.update_invite('spez', ['flair', 'mail'])
 
@@ -2227,13 +2227,13 @@ class Modmail:
 
         For example:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('redditdev').modmail('2gmz', mark_read=True)
 
         To print all messages from a conversation as Markdown source:
 
-        .. code:: python
+        .. code-block:: python
 
            conversation = reddit.subreddit('redditdev').modmail('2gmz', \
 mark_read=True)
@@ -2248,7 +2248,7 @@ mark_read=True)
 
         For example, to print the user's ban status:
 
-        .. code:: python
+        .. code-block:: python
 
            conversation = reddit.subreddit('redditdev').modmail('2gmz', \
 mark_read=True)
@@ -2256,7 +2256,7 @@ mark_read=True)
 
         To print a list of recent submissions by the user:
 
-        .. code:: python
+        .. code-block:: python
 
            conversation = reddit.subreddit('redditdev').modmail('2gmz', \
 mark_read=True)
@@ -2294,7 +2294,7 @@ mark_read=True)
 
         For example, to mark all notifications for a subreddit as read:
 
-        .. code:: python
+        .. code-block:: python
 
            subreddit = reddit.subreddit('redditdev')
            subreddit.modmail.bulk_read(state='notifications')
@@ -2337,7 +2337,7 @@ mark_read=True)
 
         For example:
 
-        .. code:: python
+        .. code-block:: python
 
             conversations = reddit.subreddit('all').modmail.conversations(\
 state='mod')
@@ -2380,7 +2380,7 @@ state='mod')
         :returns: A :class:`.ModmailConversation` object for the newly created
             conversation.
 
-        .. code:: python
+        .. code-block:: python
 
            subreddit = reddit.subreddit('redditdev')
            redditor = reddit.redditor('bboe')
@@ -2403,7 +2403,7 @@ state='mod')
 
         For example:
 
-        .. code:: python
+        .. code-block:: python
 
            subreddits = reddit.subreddit('all').modmail.subreddits()
 
@@ -2424,7 +2424,7 @@ state='mod')
 
         For example, to print the count of unread moderator discussions:
 
-        .. code:: python
+        .. code-block:: python
 
            subreddit = reddit.subreddit('redditdev')
            unread_counts = subreddit.modmail.unread_count()
@@ -2456,7 +2456,7 @@ class SubredditStream:
         For example, to retrieve all new comments made to the ``iama``
         subreddit, try:
 
-        .. code:: python
+        .. code-block:: python
 
            for comment in reddit.subreddit('iama').stream.comments():
                print(comment)
@@ -2464,7 +2464,7 @@ class SubredditStream:
         To only retreive new submissions starting when the stream is
         created, pass `skip_existing=True`:
 
-        .. code:: python
+        .. code-block:: python
 
            subreddit = reddit.subreddit('iama')
            for comment in subreddit.stream.comments(skip_existing=True):
@@ -2483,7 +2483,7 @@ class SubredditStream:
 
         For example to retrieve all new submissions made to all of Reddit, try:
 
-        .. code:: python
+        .. code-block:: python
 
            for submission in reddit.subreddit('all').stream.submissions():
                print(submission)
@@ -2500,7 +2500,7 @@ class SubredditStylesheet:
 
         To be used as:
 
-        .. code:: python
+        .. code-block:: python
 
            stylesheet = reddit.subreddit('SUBREDDIT').stylesheet()
 
@@ -2515,7 +2515,7 @@ class SubredditStylesheet:
 
         An instance of this class is provided as:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('SUBREDDIT').stylesheet
 
@@ -2575,7 +2575,7 @@ class SubredditStylesheet:
 
         For example:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('SUBREDDIT').stylesheet.delete_banner()
 
@@ -2591,7 +2591,7 @@ class SubredditStylesheet:
 
         For example:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('SUBREDDIT').stylesheet.delete_banner_additional_image()
 
@@ -2609,7 +2609,7 @@ class SubredditStylesheet:
 
         For example:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('SUBREDDIT').stylesheet.delete_banner_hover_image()
 
@@ -2624,7 +2624,7 @@ class SubredditStylesheet:
 
         For example:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('SUBREDDIT').stylesheet.delete_header()
 
@@ -2639,7 +2639,7 @@ class SubredditStylesheet:
 
         For example:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('SUBREDDIT').stylesheet.delete_image('smile')
 
@@ -2654,7 +2654,7 @@ class SubredditStylesheet:
 
         For example:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('SUBREDDIT').stylesheet.delete_mobile_header()
 
@@ -2669,7 +2669,7 @@ class SubredditStylesheet:
 
         For example:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('SUBREDDIT').stylesheet.delete_mobile_icon()
 
@@ -2684,7 +2684,7 @@ class SubredditStylesheet:
 
         For example:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('SUBREDDIT').stylesheet.update(
                'p { color: green; }', 'color text green')
@@ -2716,7 +2716,7 @@ class SubredditStylesheet:
 
         For example:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('SUBREDDIT').stylesheet.upload('smile', 'img.png')
 
@@ -2739,7 +2739,7 @@ class SubredditStylesheet:
 
         For example:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('SUBREDDIT').stylesheet.upload_banner('banner.png')
 
@@ -2764,7 +2764,7 @@ class SubredditStylesheet:
 
         For example:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('SUBREDDIT').stylesheet.upload_banner_additional_image('banner.png')
 
@@ -2801,7 +2801,7 @@ class SubredditStylesheet:
 
         For example:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('SUBREDDIT').stylesheet.upload_banner_hover_image('banner.png')
 
@@ -2826,7 +2826,7 @@ class SubredditStylesheet:
 
         For example:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('SUBREDDIT').stylesheet.upload_header('header.png')
 
@@ -2849,7 +2849,7 @@ class SubredditStylesheet:
 
         For example:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('SUBREDDIT').stylesheet.upload_mobile_header(
                'header.png')
@@ -2873,7 +2873,7 @@ class SubredditStylesheet:
 
         For example:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('SUBREDDIT').stylesheet.upload_mobile_icon(
                'icon.png')
@@ -2890,7 +2890,7 @@ class SubredditWiki:
 
         This method is to be used to fetch a specific wikipage, like so:
 
-        .. code:: python
+        .. code-block:: python
 
            wikipage = reddit.subreddit('iama').wiki['proof']
            print(wikipage.content_md)
@@ -2915,7 +2915,7 @@ class SubredditWiki:
 
         This method is to be used to discover all wikipages for a subreddit:
 
-        .. code:: python
+        .. code-block:: python
 
            for wikipage in reddit.subreddit('iama').wiki:
                print(wikipage)
@@ -2939,7 +2939,7 @@ class SubredditWiki:
 
         To create the wiki page ``praw_test`` in ``r/test`` try:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('test').wiki.create(
                'praw_test', 'wiki body text', reason='PRAW Test Creation')
@@ -2958,7 +2958,7 @@ class SubredditWiki:
 
         To view the wiki revisions for ``'praw_test'`` in ``r/test`` try:
 
-        .. code:: python
+        .. code-block:: python
 
            for item in reddit.subreddit('test').wiki['praw_test'].revisions():
                print(item)

--- a/praw/models/reddit/wikipage.py
+++ b/praw/models/reddit/wikipage.py
@@ -127,7 +127,7 @@ class WikiPage(RedditBase):
 
         To view revision ``[ID]`` of ``'praw_test'`` in ``'/r/test'``:
 
-        .. code:: python
+        .. code-block:: python
 
            page = reddit.subreddit('test').wiki['praw_test'].revision('[ID]')
 
@@ -144,14 +144,14 @@ class WikiPage(RedditBase):
 
         To view the wiki revisions for ``'praw_test'`` in ``'/r/test'`` try:
 
-        .. code:: python
+        .. code-block:: python
 
            for item in reddit.subreddit('test').wiki['praw_test'].revisions():
                print(item)
 
         To get :class:`.WikiPage` objects for each revision:
 
-        .. code:: python
+        .. code-block:: python
 
            for item in reddit.subreddit('test').wiki['praw_test'].revisions():
                print(item['page'])
@@ -182,7 +182,7 @@ class WikiPageModeration:
 
         To add ``'spez'`` as an editor on the wikipage ``'praw_test'`` try:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('test').wiki['praw_test'].mod.add('spez')
 
@@ -201,7 +201,7 @@ class WikiPageModeration:
 
         To remove ``'spez'`` as an editor on the wikipage ``'praw_test'`` try:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('test').wiki['praw_test'].mod.remove('spez')
 
@@ -233,7 +233,7 @@ class WikiPageModeration:
         To set the wikipage ``'praw_test'`` in ``'/r/test'`` to mod only and
           disable it from showing in the page list, try:
 
-        .. code:: python
+        .. code-block:: python
 
            reddit.subreddit('test').wiki['praw_test'].mod.update(listed=False,
                                                                  permlevel=2)

--- a/praw/models/util.py
+++ b/praw/models/util.py
@@ -115,7 +115,7 @@ def stream_generator(
 
     For example, to create a stream of comment replies, try:
 
-    .. code:: python
+    .. code-block:: python
 
        reply_function = reddit.inbox.comment_replies
        for reply in praw.models.util.stream_generator(reply_function):
@@ -124,7 +124,7 @@ def stream_generator(
     To pause a comment stream after six responses with no new
     comments, try:
 
-    .. code:: python
+    .. code-block:: python
 
        subreddit = reddit.subreddit('redditdev')
        for comment in subreddit.stream.comments(pause_after=6):
@@ -134,7 +134,7 @@ def stream_generator(
 
     To resume fetching comments after a pause, try:
 
-    .. code:: python
+    .. code-block:: python
 
        subreddit = reddit.subreddit('help')
        comment_stream = subreddit.stream.comments(pause_after=5)
@@ -155,7 +155,7 @@ def stream_generator(
     stream as soon as possible, rather than up to a delay of just over sixteen
     seconds.
 
-    .. code:: python
+    .. code-block:: python
 
        subreddit = reddit.subreddit('help')
        for comment in subreddit.stream.comments(pause_after=0):


### PR DESCRIPTION
According to [this stackoverflow answer](https://stackoverflow.com/a/35174436/) the `code::` and `code-block::` directives function similarly when using Sphinx, but `code-block::` should be used over `code::` if using Sphinx. The advantage of `code::` is that it works in a standalone reStructuredText file (not parsed by Sphinx) but since it's being used in doc strings which are only obtained through Sphinx, it would make sense to replace all of the `code::` directives with `code-block::` directives.