### PR TITLE
Fix for exceptions

### DIFF
--- a/praw/exceptions.py
+++ b/praw/exceptions.py
@@ -15,12 +15,7 @@ class PRAWException(Exception):
 class APIException(PRAWException):
     """Indicate exception that involve responses from Reddit's API."""
 
-    def __init__(
-        self,
-        error_type: Optional[str],
-        message: Optional[str],
-        field: Optional[str],
-    ):
+    def __init__(self, error_type: str, message: str, field: Optional[str]):
         """Initialize an instance of APIException.
 
         :param error_type: The error type set on Reddit's end.

--- a/praw/exceptions.py
+++ b/praw/exceptions.py
@@ -5,6 +5,7 @@ wrong on the server side, and :class:`.ClientException` when something goes
 wrong on the client side. Both of these classes extend :class:`.PRAWException`.
 
 """
+from typing import Optional
 
 
 class PRAWException(Exception):
@@ -14,7 +15,12 @@ class PRAWException(Exception):
 class APIException(PRAWException):
     """Indicate exception that involve responses from Reddit's API."""
 
-    def __init__(self, error_type: str, message: str, field: str):
+    def __init__(
+        self,
+        error_type: Optional[str],
+        message: Optional[str],
+        field: Optional[str],
+    ):
         """Initialize an instance of APIException.
 
         :param error_type: The error type set on Reddit's end.


### PR DESCRIPTION
An instance of APIException can have the third parameter be None, but that was not indicated, so I indicated it with an `Optional[str]` argument.