### PR TITLE
Add missing py3.8 and missing refresh_token attr to tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -19,7 +19,7 @@ passenv =
     prawtest_client_id
     prawtest_client_secret
     prawtest_password
+    prawtest_refresh_token
     prawtest_test_subreddit
     prawtest_username
     prawtest_user_agent
-    prawtest_refresh_token

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py35,py36,py37
+envlist = py35,py36,py37,py38
 skip_missing_interpreters = true
 skipsdist = true
 
@@ -22,3 +22,4 @@ passenv =
     prawtest_test_subreddit
     prawtest_username
     prawtest_user_agent
+    prawtest_refresh_token


### PR DESCRIPTION
Python 3.8 is supported and officially tested in,so it should be included.

Refresh tokens can be used, so it should be included.