### PR TITLE
Add code-block check to multi-python linters

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,8 @@ jobs:
       run: black --check --verbose .
     - name: Run flake8
       run: flake8 --exclude docs --statistics
+    - name: Check usage of code-block
+      run: python ./tools/replace_code_block.py --check
     - name: Run pydocstyle
       run: pydocstyle praw
     - name: Run sphinx


### PR DESCRIPTION
The multi-python linters did not run the code-block check:

```yaml
    - name: Check usage of code-block
      run: python ./tools/replace_code_block.py --check
```

I added it in to the multi-python lints.