### PR TITLE
Add parent comment attribute to comment_forest

### DIFF
--- a/praw/models/comment_forest.py
+++ b/praw/models/comment_forest.py
@@ -54,7 +54,10 @@ class CommentForest:
         return self._comments[index]
 
     def __init__(
-        self, submission: Submission, comments: Optional[List[Comment]] = None
+        self,
+        submission: Submission,
+        comments: Optional[List[Comment]] = None,
+        parent_comment: Optional[Comment] = None,
     ):
         """Initialize a CommentForest instance.
 
@@ -62,9 +65,12 @@ class CommentForest:
             parent of the comments.
         :param comments: Initialize the Forest with a list of comments
             (default: None).
+        :param parent_comment: Initialize the Forest with a parent comment
+            (default: None).
 
         """
         self._comments = comments
+        self._parent_comment = parent_comment
         self._submission = submission
 
     def __len__(self) -> int:
@@ -154,6 +160,9 @@ class CommentForest:
                              sleep(1)
 
         """
+        if self._parent_comment is not None:
+            if self._parent_comment._refreshed:
+                return []
         remaining = limit
         more_comments = self._gather_more_comments(self._comments)
         skipped = []

--- a/praw/models/reddit/comment.py
+++ b/praw/models/reddit/comment.py
@@ -118,7 +118,7 @@ class Comment(InboxableMixin, UserContentMixin, FullnameMixin, RedditBase):
 
         """
         if isinstance(self._replies, list):
-            self._replies = CommentForest(self.submission, self._replies)
+            self._replies = CommentForest(self.submission, self._replies, self)
         return self._replies
 
     @property
@@ -153,6 +153,7 @@ class Comment(InboxableMixin, UserContentMixin, FullnameMixin, RedditBase):
             )
         self._replies = []
         self._submission = None
+        self._refreshed = False
         super().__init__(reddit, _data=_data)
         if id:
             self.id = id
@@ -321,6 +322,7 @@ class Comment(InboxableMixin, UserContentMixin, FullnameMixin, RedditBase):
 
         for reply in comment_list:
             reply.submission = self.submission
+        self._refreshed = True
         return self
 
 


### PR DESCRIPTION
Fix #1268 .

The issue was that if a comment is refreshed, then it will throw an `AssertionError`. The solution is to include an optional argument called `parent_comment`, and when replace_more is called, a logic check will be preformed:

If parent_comment is not None -> If parent_comment is refreshed -> return None
else: continue function 