### PR TITLE
Noreturn removal

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -70,11 +70,6 @@ Unreleased
 * The behavior of :class:`.APIException` will no longer unicode-escape strings
   in the next minor release
 
-**Removed**
-
-* Converting :class:`.APIException` to string will no longer escape unicode
-  characters.
-
 6.4.0 (2019/09/21)
 ------------------
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,15 +1,6 @@
 Change Log
 ==========
 
-Unreleased
-----------
-
-**Removed**
-
-* Converting :class:`.APIException` to string will no longer escape unicode
-  characters.
-
-
 6.5.0 (2020/01/05)
 ------------------
 
@@ -70,6 +61,11 @@ Unreleased
 
 * The behavior of :class:`.APIException` will no longer unicode-escape strings
   in the next minor release
+
+**Removed**
+
+* Converting :class:`.APIException` to string will no longer escape unicode
+  characters.
 
 6.4.0 (2019/09/21)
 ------------------

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,14 @@
 Change Log
 ==========
 
+Unreleased
+----------
+
+**Fixed**
+
+* Removed usages of `NoReturn` that caused PRAW to fail due to `ImportError`
+  in Python <3.5.4 and <3.6.2.
+
 6.5.0 (2020/01/05)
 ------------------
 

--- a/praw/exceptions.py
+++ b/praw/exceptions.py
@@ -21,10 +21,18 @@ class APIException(PRAWException):
         :param error_type: The error type set on Reddit's end.
         :param message: The associated message for the error.
         :param field: The input field associated with the error if available.
+
+        .. note:: Calling ``str()`` on the instance returns
+            ``unicode_escape``-d ASCII string because the message may be
+            localized and may contain UNICODE characters. If you want a
+            non-escaped message, access the ``message`` attribute on
+            the instance.
+
         """
-        error_str = "{}: '{}'".format(error_type, message)
+        error_str = u"{}: '{}'".format(error_type, message)
         if field:
-            error_str += " on field '{}'".format(field)
+            error_str += u" on field '{}'".format(field)
+        error_str = error_str.encode("unicode_escape").decode("ascii")
 
         super().__init__(error_str)
         self.error_type = error_type

--- a/praw/models/auth.py
+++ b/praw/models/auth.py
@@ -1,5 +1,5 @@
 """Provide the Auth class."""
-from typing import Dict, List, NoReturn, Optional, Set, Union
+from typing import Dict, List, Optional, Set, Union
 
 from prawcore import (
     Authorizer,
@@ -60,9 +60,7 @@ class Auth(PRAWBase):
         self._reddit._core = self._reddit._authorized_core = authorized_session
         return authorizer.refresh_token
 
-    def implicit(
-        self, access_token: str, expires_in: int, scope: str
-    ) -> NoReturn:
+    def implicit(self, access_token: str, expires_in: int, scope: str) -> None:
         """Set the active authorization to be an implicit authorization.
 
         :param access_token: The access_token obtained from Reddit's callback.

--- a/praw/reddit.py
+++ b/praw/reddit.py
@@ -2,17 +2,7 @@
 import configparser
 import os
 from itertools import islice
-from typing import (
-    IO,
-    Any,
-    Dict,
-    Generator,
-    NoReturn,
-    Optional,
-    Sequence,
-    Type,
-    Union,
-)
+from typing import IO, Any, Dict, Generator, Optional, Sequence, Type, Union
 
 from prawcore import (
     Authorizer,
@@ -76,7 +66,7 @@ class Reddit:
         return self._core == self._read_only_core
 
     @read_only.setter
-    def read_only(self, value: bool) -> NoReturn:
+    def read_only(self, value: bool) -> None:
         """Set or unset the use of the ReadOnlyAuthorizer.
 
         Raise :class:`ClientException` when attempting to unset ``read_only``

--- a/tests/integration/models/reddit/test_widgets.py
+++ b/tests/integration/models/reddit/test_widgets.py
@@ -975,3 +975,4 @@ class TestWidget(IntegrationTest):
             assert len(widgets.sidebar) >= 2
         assert widgets.sidebar[0] != widgets.sidebar[1]
         assert widgets.sidebar[0] != widgets.sidebar[1].id
+        assert u"\xf0\x9f\x98\x80" != widgets.sidebar[0]  # for python 2

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -23,6 +23,14 @@ class TestAPIException:
             "BAD_SOMETHING: 'invalid something' on field 'some_field'"
         )
 
+    def test_str_for_localized_error_string(self):
+        exception = APIException("RATELIMIT", u"実行回数が多すぎます", u"フィールド")
+        assert str(exception) == (
+            "RATELIMIT: '\\u5b9f\\u884c\\u56de\\u6570\\u304c\\u591a"
+            "\\u3059\\u304e\\u307e\\u3059' on field "
+            "'\\u30d5\\u30a3\\u30fc\\u30eb\\u30c9'"
+        )
+
 
 class TestClientException:
     def test_inheritance(self):


### PR DESCRIPTION
NoReturn is not included in some versions of Python 3.5 and 3.6. Further, the annotation was misused. NoReturn indicates that a function _will not_ return, either because it unconditionally throws an exception or because it goes into an infinite loop or because it terminates program execution. The functions annotated with NoReturn here do not have that behavior, though each of them *may* throw an exception. At best, these functions should have been annotated with a union of None and NoReturn, but since the NoReturn name is problematic, it is best to omit it entirely.


--- 


In addition, this PR temporarily reverts changes made to the APIException class, since they are not backwards-compatible, and I intend to release this fix as PRAW 6.5.1. I will un-revert these changes after the release.