### PR TITLE
Remove useless coding tag

### DIFF
--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -1,4 +1,3 @@
-# coding: utf-8
 from praw.exceptions import APIException, ClientException, PRAWException
 
 


### PR DESCRIPTION
This does nothing and is not needed in Python3.