### PR TITLE
Add tool for replacing /r/ and /u/

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
       run: flake8 --exclude docs --statistics
     - name: Check usage of code-block
       run: python ./tools/replace_code_block.py --check
+    - name: Check usage of /r/ and /u/
+      run: python ./tools/replace_double_backslash.py --check
     - name: Run pydocstyle
       run: pydocstyle praw
     - name: Run sphinx
@@ -60,6 +62,10 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[lint]
+    - name: Check usage of code-block
+      run: python ./tools/replace_code_block.py --check
+    - name: Check usage of /r/ and /u/
+      run: python ./tools/replace_double_backslash.py --check
     - name: Run black
       run: black --check --verbose .
     - name: Run flake8

--- a/praw/models/inbox.py
+++ b/praw/models/inbox.py
@@ -143,7 +143,7 @@ class Inbox(PRAWBase):
         r"""Return a :class:`.ListingGenerator` for mentions.
 
         A mention is :class:`.Comment` in which the authorized redditor is
-        named in its body like ``/u/redditor_name``.
+        named in its body like ``u/redditor_name``.
 
         Additional keyword arguments are passed in the initialization of
         :class:`.ListingGenerator`.

--- a/praw/models/listing/mixins/redditor.py
+++ b/praw/models/listing/mixins/redditor.py
@@ -35,7 +35,7 @@ class RedditorListingMixin(BaseListingMixin, GildedListingMixin):
         r"""Provide an instance of :class:`.SubListing` for comment access.
 
         For example, to output the first line of all new comments by
-        ``/u/spez`` try:
+        ``u/spez`` try:
 
         .. code-block:: python
 
@@ -50,7 +50,7 @@ class RedditorListingMixin(BaseListingMixin, GildedListingMixin):
         """Provide an instance of :class:`.SubListing` for submission access.
 
         For example, to output the title's of top 100 of all time submissions
-        for ``/u/spez`` try:
+        for ``u/spez`` try:
 
         .. code-block:: python
 

--- a/praw/models/listing/mixins/subreddit.py
+++ b/praw/models/listing/mixins/subreddit.py
@@ -55,7 +55,7 @@ class SubredditListingMixin(
         """Provide an instance of :class:`.CommentHelper`.
 
         For example, to output the author of the 25 most recent comments of
-        ``/r/redditdev`` execute:
+        ``r/redditdev`` execute:
 
         .. code-block:: python
 

--- a/praw/models/reddit/emoji.py
+++ b/praw/models/reddit/emoji.py
@@ -69,9 +69,7 @@ class Emoji(RedditBase):
                 self._fetched = True
                 return
         raise ClientException(
-            "/r/{} does not have the emoji {}".format(
-                self.subreddit, self.name
-            )
+            "r/{} does not have the emoji {}".format(self.subreddit, self.name)
         )
 
     def delete(self):

--- a/praw/models/reddit/wikipage.py
+++ b/praw/models/reddit/wikipage.py
@@ -81,7 +81,7 @@ class WikiPageModeration:
         :param other_settings: Additional keyword arguments to pass.
         :returns: The updated WikiPage settings.
 
-        To set the wikipage ``'praw_test'`` in ``'/r/test'`` to mod only and
+        To set the wikipage ``'praw_test'`` in ``'r/test'`` to mod only and
           disable it from showing in the page list, try:
 
         .. code-block:: python
@@ -225,7 +225,7 @@ class WikiPage(RedditBase):
     def revision(self, revision: str):
         """Return a specific version of this page by revision ID.
 
-        To view revision ``[ID]`` of ``'praw_test'`` in ``'/r/test'``:
+        To view revision ``[ID]`` of ``'praw_test'`` in ``'r/test'``:
 
         .. code-block:: python
 
@@ -244,7 +244,7 @@ class WikiPage(RedditBase):
         Additional keyword arguments are passed in the initialization of
         :class:`.ListingGenerator`.
 
-        To view the wiki revisions for ``'praw_test'`` in ``'/r/test'`` try:
+        To view the wiki revisions for ``'praw_test'`` in ``'r/test'`` try:
 
         .. code-block:: python
 

--- a/praw/reddit.py
+++ b/praw/reddit.py
@@ -284,7 +284,7 @@ class Reddit:
            reddit.subreddit('redditdev')
 
         Note that multiple subreddits can be combined and filtered views of
-        /r/all can also be used just like a subreddit:
+        r/all can also be used just like a subreddit:
 
         .. code-block:: python
 

--- a/pre_push.py
+++ b/pre_push.py
@@ -45,6 +45,12 @@ def run_static():
             path.join(current_directory, "tools/replace_code_block.py"),
         ]
     )
+    success &= do_process(
+        [
+            sys.executable,
+            path.join(current_directory, "tools/replace_double_backslash.py"),
+        ]
+    )
     success &= do_process(["black ."], shell=True)
     success &= do_process(["flake8", "--exclude=.eggs,build,docs"])
     success &= do_process(["pydocstyle", "praw"])

--- a/tests/integration/models/reddit/test_emoji.py
+++ b/tests/integration/models/reddit/test_emoji.py
@@ -32,7 +32,7 @@ class TestEmoji(IntegrationTest):
             with pytest.raises(ClientException) as excinfo2:
                 emoji2.url
             assert str(excinfo2.value) == (
-                "/r/{} does not have the emoji {}".format(
+                "r/{} does not have the emoji {}".format(
                     subreddit, "Test_png"
                 )
             )

--- a/tools/replace_double_backslash.py
+++ b/tools/replace_double_backslash.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+
+import argparse
+import os
+import sys
+from typing import AnyStr
+
+
+def check_for_double_backslash(filename: AnyStr, check: bool):
+    """Check a file and replace ``/u/`` and ``/r/` to ``u/`` and ``r/``.
+
+    :param filename: The file to open
+    :param check: Whether or not the program is operating in ``check`` mode.
+        In check mode, the program will exit with a status 1 if files will be
+        replaced. In non-check mode, the program will replace files.
+    """
+    status = 0
+    with open(filename, "r", encoding="utf-8") as fp:
+        old_content = fp.read()
+    new_content = old_content.replace("/u/", "u/").replace("/r/", "r/")
+    new_content = old_content.replace(
+        "reddit.comr/", "reddit.com/r/"
+    )  # handles reddit.com/r/... urls
+    if old_content == new_content:
+        return 0
+    if check:
+        status = 1
+        print(
+            "File {filename} contains ``/u/`` or ``/r/`` statements!".format(
+                filename=filename
+            )
+        )
+    else:
+        with open(filename, "w", encoding="utf-8") as fp:
+            fp.write(new_content)
+        print(
+            "Replaced ``/u/`` and ``/r/`` statements to ``u/`` and ``r/`` in "
+            "{filename}".format(filename=filename)
+        )
+    return status
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Check and reformat praw's usage of ``/u/`` and ``/r/` to "
+        "``u/`` and ``r/``."
+    )
+    parser.add_argument(
+        "-c",
+        "--check",
+        action="store_true",
+        default=False,
+        help="Check files but do not reformat. Exits if a filename"
+        " can be reformatted.",
+    )
+    parsed = parser.parse_args()
+    check = parsed.check
+    status = 0
+    for current_directory, directories, filenames in os.walk(
+        os.path.abspath(os.path.join(__file__, "..", "..", "praw"))
+    ):
+        for filename in filenames:
+            if not filename.endswith(".py"):
+                continue
+            if filename.endswith("endpoints.py"):
+                # we do not want to mess with reddit endpoints
+                continue
+            filename = os.path.join(current_directory, filename)
+            status |= check_for_double_backslash(filename, check)
+    return status
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Addresses the `Subreddit and User Notation` section on #1152 

> The site officially uses the u/ prefix for usernames and r/ prefix for subreddits, with no trailing /. So:
> 
> r/redditdev, not /r/redditdev or /r/redditdev/
> u/spez, not /u/spez or /u/spez/
> 

