### PR TITLE
Remove references to Travis in documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -34,11 +34,12 @@ to you, it likely is not to the person asking the question.
 
 0. Prior to creating a pull request run the `pre_push.py` script. This script
    depends on the tools `black` `flake8`, `pylint`, `pydocstyle`, `sphinx` and `sphinx_rtd_theme`. They can
-   be installed via `pip install black flake8 pydocstyle pylint sphinx sphinx_rtd_theme`.
+   be installed via `pip install black flake8 pydocstyle pylint sphinx sphinx_rtd_theme` or via
+   `pip install praw[lint]`.
 
 0. Add yourself as a contributor to the ``AUTHORS.rst``.
 
-0. Once pushed, ensure that your TravisCI build succeeds. Travis will error
+0. Once pushed, ensure that your Github Actions build succeeds. Actions will error
    before running any tests if there are _any_ `flake8` or `pydocstyle`
    issues. Resolve any issues by updating your pull request.
 
@@ -46,6 +47,7 @@ to you, it likely is not to the person asking the question.
    not require fetching data from Reddit, e.g., method argument validation,
    should be saved as a unit test. Tests that hit Reddit's servers should be an
    integration test and all network activity should be recorded via Betamax.
+   The required packages can be installed with `pip install praw[test]`.
 
 0. Feel free to check on the status of your pull request periodically by adding
    a comment.
@@ -60,8 +62,8 @@ we would like to see you push a number of contributions before we add you on.
 ## Style Recommendations
 
 To keep PRAW's source consistent, all contribution code must pass the
-`pre_push.sh` script. Travis CI will enforce the passing of the automated
-tests, as well as style checking done via the `pre_push.sh` script. While this
+`pre_push.py` script. Github Actions will enforce the passing of the automated
+tests, as well as style checking done via the `pre_push.py` script. While this
 script helps ensure consistency with much of PEP8 and PEP257 there are a few
 things that it does not enforce. Please look over the following list:
 

--- a/README.rst
+++ b/README.rst
@@ -7,9 +7,6 @@ PRAW: The Python Reddit API Wrapper
 .. image:: https://img.shields.io/pypi/dm/praw
    :alt: PyPI - Downloads - Monthly
    :target: https://pypi.python.org/pypi/praw
-.. image:: https://travis-ci.org/praw-dev/praw.svg?branch=master
-   :alt: Travis CI Status
-   :target: https://travis-ci.org/praw-dev/praw
 .. image:: https://coveralls.io/repos/github/praw-dev/praw/badge.svg?branch=master
    :alt: Coveralls Coverage
    :target: https://coveralls.io/github/praw-dev/praw?branch=master

--- a/docs/package_info/contributing.rst
+++ b/docs/package_info/contributing.rst
@@ -37,9 +37,9 @@ anyway so we can work with you to write the necessary tests.
 Running the Test Suite
 ~~~~~~~~~~~~~~~~~~~~~~
 
-`Travis CI <https://travis-ci.org/praw-dev/praw>`_ automatically runs all
-updates to known branches and pull requests. However, it's useful to be able to
-run the tests locally. The simplest way is via:
+`Github Actions <https://github.com/praw-dev/praw/actions>`_ automatically runs
+all updates to known branches and pull requests. However, it's useful to be
+able to run the tests locally. The simplest way is via:
 
 .. code:: bash
 


### PR DESCRIPTION
Travis is being phased out for Github Actions, but Travis is still referenced in documentation.

Coveralls is also being phased out, but as coverage data is still submitted there, I left the coveralls information.