### PR TITLE
Add note with appropriate values for comment/reply sort

### DIFF
--- a/praw/models/reddit/comment.py
+++ b/praw/models/reddit/comment.py
@@ -116,6 +116,9 @@ class Comment(InboxableMixin, UserContentMixin, FullnameMixin, RedditBase):
            comment.refresh()
            replies = comment.replies
 
+        .. note:: The appropriate values for ``reply_sort`` include ``best``,
+            ``top``, ``new``, ``controversial``, ``old`` and ``q&a``.
+
         """
         if isinstance(self._replies, list):
             self._replies = CommentForest(self.submission, self._replies)

--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -445,6 +445,9 @@ class Submission(
            submission.comment_sort = 'new'
            comments = submission.comments.list()
 
+        .. note:: The appropriate values for ``comment_sort`` include ``best``,
+            ``top``, ``new``, ``controversial``, ``old`` and ``q&a``.
+
         See :ref:`extracting_comments` for more on working with a
         :class:`.CommentForest`.
 


### PR DESCRIPTION
Fixes # (provide issue number if applicable)
Fix #1291 
## Feature Summary and Justification

This feature provides a note stating the values that can be used with comment_sort.

## References

* Comment sort options on a reddit post
