### PR TITLE
Checks to see if the attribute already exists

### DIFF
--- a/praw/models/reddit/base.py
+++ b/praw/models/reddit/base.py
@@ -29,7 +29,11 @@ class RedditBase(PRAWBase):
 
     def __getattr__(self, attribute: str) -> Any:
         """Return the value of `attribute`."""
-        if not attribute.startswith("_") and not self._fetched:
+        if (
+            not attribute.startswith("_")
+            and attribute not in self.__dict__
+            and not self._fetched
+        ):
             self._fetch()
             return getattr(self, attribute)
         raise AttributeError(


### PR DESCRIPTION
There is no point in fetching an id or fullname if it already exists (loaded from dict).

Helps #1112 so there is no need to create a new class