### PR TITLE
Change [...].count() to (...).count() to decrease run time by 1/3

### DIFF
--- a/praw/models/reddit/comment.py
+++ b/praw/models/reddit/comment.py
@@ -150,7 +150,7 @@ class Comment(InboxableMixin, UserContentMixin, FullnameMixin, RedditBase):
         _data: Optional[Dict[str, Any]] = None,
     ):
         """Construct an instance of the Comment object."""
-        if [id, url, _data].count(None) != 2:
+        if (id, url, _data).count(None) != 2:
             raise TypeError(
                 "Exactly one of `id`, `url`, or `_data` must be provided."
             )

--- a/praw/models/reddit/redditor.py
+++ b/praw/models/reddit/redditor.py
@@ -132,7 +132,7 @@ class Redditor(
         Exactly one of ``name``, ``fullname`` or ``_data`` must be provided.
 
         """
-        if [name, fullname, _data].count(None) != 2:
+        if (name, fullname, _data).count(None) != 2:
             raise TypeError(
                 "Exactly one of `name`, `fullname`, or `_data` must be "
                 "provided."

--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -508,7 +508,7 @@ class Submission(
         Either ``id`` or ``url`` can be provided, but not both.
 
         """
-        if [id, url, _data].count(None) != 2:
+        if (id, url, _data).count(None) != 2:
             raise TypeError(
                 "Exactly one of `id`, `url`, or `_data` must be provided."
             )

--- a/praw/reddit.py
+++ b/praw/reddit.py
@@ -485,7 +485,7 @@ class Reddit:
                   different set of submissions.
 
         """
-        none_count = [fullnames, url].count(None)
+        none_count = (fullnames, url).count(None)
         if none_count > 1:
             raise TypeError("Either `fullnames` or `url` must be provided.")
         if none_count < 1:


### PR DESCRIPTION
This saves 34% of time when running a calculation.

Test:

```python
In [2]: from timeit import timeit   

In [4]: timeit("(1, 2, 3).count(1)")                                                                                                                                               
Out[4]: 0.08089671100000118

In [5]: timeit("[1, 2, 3].count(1)")                                                                                                                                               
Out[5]: 0.12496681500000051

In [8]: ((timeit("(1, 2, 3).count(1)") - timeit("[1, 2, 3].count(1)")) / timeit("[1, 2, 3].count(1)")) * 100                                                                       
Out[8]: -34.34746208108047
```
