### PR TITLE
Add method to retrieve friend data from users.friends

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,10 @@ Unreleased
 * Add :meth:`.Redditors.partial_redditors` that returns lightweight redditor
   objects that contain only a few fields. This is useful for resolving
   Redditor IDs to their usernames in bulk.
+* :meth:`.User.friends` has a new parameter ``user`` that takes either an
+  instance of :class:`.Redditor` or a string containing a redditor name and
+  returns an instance of :class:`.Redditor` if the authenticated user is
+  friends with the user, otherwise throws an exception.
 
 **Removed**
 

--- a/praw/models/user.py
+++ b/praw/models/user.py
@@ -73,9 +73,24 @@ class User(PRAWBase):
             self._reddit, API_PATH["my_contributor"], **generator_kwargs
         )
 
-    def friends(self) -> List[Redditor]:
-        """Return a RedditorList of friends."""
-        return self._reddit.get(API_PATH["friends"])
+    def friends(
+        self, user: Optional[Union[str, Redditor]] = None
+    ) -> Union[List[Redditor], Redditor]:
+        """Return a RedditorList of friends or a Redditor in the friends list.
+
+        :param user: Checks to see if you are friends with the Redditor. Either
+            an instance of :class:`.Redditor` or a string can be given.
+        :returns: A list of Redditors, or a Redditor if you are friends with
+            the given Redditor. The Redditor also has friend attributes.
+        :raises: An instance of ``prawcore.exceptions.BadRequest`` if you are
+            not friends with the specified Redditor.
+        """
+        endpoint = (
+            API_PATH["friends"]
+            if user is None
+            else API_PATH["friend_v1"].format(user=str(user))
+        )
+        return self._reddit.get(endpoint)
 
     def karma(self) -> Dict[Subreddit, int]:
         """Return a dictionary mapping subreddits to their karma."""

--- a/tests/integration/cassettes/TestUser.test_friend_exist.json
+++ b/tests/integration/cassettes/TestUser.test_friend_exist.json
@@ -1,0 +1,330 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2020-01-26T03:51:57",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "61"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.6.0.dev0 prawcore/1.0.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "118"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 26 Jan 2020 03:51:57 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "edgebucket=8XrVL4mbQVaVDmMEvy; Domain=reddit.com; Max-Age=63071999; Path=/;  secure"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-lga21957-LGA"
+          ],
+          "X-Timer": [
+            "S1580010717.915209,VS0,VE288"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2020-01-26T03:51:57",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "edgebucket=8XrVL4mbQVaVDmMEvy"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.6.0.dev0 prawcore/1.0.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/api/v1/me?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"is_employee\": false, \"seen_layout_switch\": true, \"has_visited_new_profile\": false, \"pref_no_profanity\": true, \"has_external_account\": false, \"pref_geopopular\": \"\", \"seen_redesign_modal\": true, \"pref_show_trending\": true, \"subreddit\": {\"default_set\": true, \"user_is_contributor\": false, \"banner_img\": \"\", \"restrict_posting\": true, \"user_is_banned\": false, \"free_form_reports\": true, \"community_icon\": \"\", \"show_media\": true, \"icon_color\": \"#4856A3\", \"user_is_muted\": false, \"display_name\": \"u_<USERNAME>\", \"header_img\": null, \"title\": \"\", \"coins\": 0, \"over_18\": false, \"icon_size\": [256, 256], \"primary_color\": \"\", \"icon_img\": \"https://www.redditstatic.com/avatars/avatar_default_03_4856A3.png\", \"description\": \"\", \"submit_link_label\": \"\", \"header_size\": null, \"restrict_commenting\": false, \"subscribers\": 0, \"submit_text_label\": \"\", \"is_default_icon\": true, \"link_flair_position\": \"\", \"display_name_prefixed\": \"u/<USERNAME>\", \"key_color\": \"\", \"name\": \"t5_2bhrub\", \"is_default_banner\": true, \"url\": \"/user/<USERNAME>/\", \"banner_size\": null, \"user_is_moderator\": true, \"public_description\": \"\", \"link_flair_enabled\": false, \"disable_contributor_requests\": false, \"subreddit_type\": \"user\", \"user_is_subscriber\": false}, \"is_sponsor\": false, \"gold_expiration\": null, \"has_gold_subscription\": false, \"num_friends\": 1, \"features\": {\"promoted_trend_blanks\": true, \"show_amp_link\": true, \"chat\": true, \"twitter_embed\": true, \"is_email_permission_required\": false, \"mod_awards\": true, \"expensive_coins_package\": true, \"mweb_xpromo_revamp_v2\": {\"owner\": \"growth\", \"variant\": \"treatment_6\", \"experiment_id\": 457}, \"awards_on_streams\": true, \"mweb_xpromo_modal_listing_click_daily_dismissible_ios\": true, \"community_awards\": true, \"modlog_copyright_removal\": true, \"do_not_track\": true, \"chat_user_settings\": true, \"mweb_xpromo_interstitial_comments_ios\": true, \"chat_subreddit\": true, \"mweb_xpromo_modal_listing_click_daily_dismissible_android\": true, \"premium_subscriptions_table\": true, \"mweb_xpromo_interstitial_comments_android\": true, \"mweb_nsfw_xpromo\": {\"owner\": \"growth\", \"variant\": \"control_2\", \"experiment_id\": 361}, \"delete_vod_when_post_is_deleted\": true, \"awarder_names\": true, \"chat_group_rollout\": true, \"custom_feeds\": true, \"spez_modal\": true, \"mweb_sharing_clipboard\": {\"owner\": \"growth\", \"variant\": \"treatment_2\", \"experiment_id\": 315}, \"feed_ad_load_3\": {\"owner\": \"ads\", \"variant\": \"control_1\", \"experiment_id\": 436}}, \"has_android_subscription\": false, \"verified\": true, \"new_modmail_exists\": false, \"pref_autoplay\": true, \"coins\": 0, \"has_paypal_subscription\": false, \"has_subscribed_to_premium\": false, \"id\": \"5bn5wlvy\", \"has_stripe_subscription\": false, \"seen_premium_adblock_modal\": false, \"can_create_subreddit\": false, \"over_18\": true, \"is_gold\": false, \"is_mod\": true, \"suspension_expiration_utc\": null, \"has_verified_email\": true, \"is_suspended\": false, \"pref_video_autoplay\": true, \"in_chat\": true, \"in_redesign_beta\": true, \"icon_img\": \"https://www.redditstatic.com/avatars/avatar_default_03_4856A3.png\", \"has_mod_mail\": false, \"pref_nightmode\": true, \"oauth_client_id\": \"<CLIENT_ID>\", \"hide_from_robots\": false, \"link_karma\": 1, \"force_password_reset\": false, \"seen_give_award_tooltip\": false, \"inbox_count\": 1, \"pref_top_karma_subreddits\": true, \"has_mail\": true, \"pref_show_snoovatar\": false, \"name\": \"<USERNAME>\", \"pref_clickgadget\": 5, \"created\": 1577613361.0, \"gold_creddits\": 0, \"created_utc\": 1577584561.0, \"has_ios_subscription\": false, \"pref_show_twitter\": false, \"in_beta\": false, \"comment_karma\": 0, \"has_subscribed\": true, \"seen_subreddit_chat_ftux\": false}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "3607"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 26 Jan 2020 03:51:57 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Vary": [
+            "accept-encoding"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-lga21922-LGA"
+          ],
+          "X-Timer": [
+            "S1580010717.365465,VS0,VE84"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, no-store, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "set-cookie": [
+            "loid=00000000005bn5wlvy.2.1577584524387.Z0FBQUFBQmVMUXpkZHpwalBUcjF4Rmt6aEdtTGt4NEl1ZWFXcHhsSXRrU292NVdMQ1dIWU5VZ1NiNGhqVXVPaUgwY0lCVUh6cUtTNlR6ZFVQQVo0OFhNa2xJMWN5c1c3bGhIakpoWm9OZG9EUjBsYjVvRE1QVl8tUU5TbHVaWXRkMGFyUU5kajZWc3k; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Tue, 25-Jan-2022 03:51:57 GMT; secure",
+            "session_tracker=XST5Mpqr98BXFwiFLh.0.1580010717390.Z0FBQUFBQmVMUXpka1BFMEU4U09XUUNla19IV2FnTmFUNUxDV2cyTmJlT0hBb1lJNmxVRmRxazBqY0kxRm5hQXlkcHhRMFdkcS1GNEhtQlpZN3lodzZmdlEyX0RxeHpGN2oxSXlWTS1wOXZ3SGlyYmZPc1JIVnNCVTFSa1AtLWFmTlZsUHE5cFVuQXM; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 26-Jan-2020 05:51:57 GMT; secure"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "599.0"
+          ],
+          "x-ratelimit-reset": [
+            "483"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-01-26T03:51:57",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "edgebucket=8XrVL4mbQVaVDmMEvy; loid=00000000005bn5wlvy.2.1577584524387.Z0FBQUFBQmVMUXpkZHpwalBUcjF4Rmt6aEdtTGt4NEl1ZWFXcHhsSXRrU292NVdMQ1dIWU5VZ1NiNGhqVXVPaUgwY0lCVUh6cUtTNlR6ZFVQQVo0OFhNa2xJMWN5c1c3bGhIakpoWm9OZG9EUjBsYjVvRE1QVl8tUU5TbHVaWXRkMGFyUU5kajZWc3k; session_tracker=XST5Mpqr98BXFwiFLh.0.1580010717390.Z0FBQUFBQmVMUXpka1BFMEU4U09XUUNla19IV2FnTmFUNUxDV2cyTmJlT0hBb1lJNmxVRmRxazBqY0kxRm5hQXlkcHhRMFdkcS1GNEhtQlpZN3lodzZmdlEyX0RxeHpGN2oxSXlWTS1wOXZ3SGlyYmZPc1JIVnNCVTFSa1AtLWFmTlZsUHE5cFVuQXM"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.6.0.dev0 prawcore/1.0.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/api/v1/me/friends/<USERNAME>?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"date\": 1580010106.0, \"rel_id\": \"r9_1gn7e1\", \"name\": \"<USERNAME>\", \"id\": \"t2_5bn5wlvy\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "91"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 26 Jan 2020 03:51:57 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-lga21922-LGA"
+          ],
+          "X-Timer": [
+            "S1580010717.475243,VS0,VE56"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, no-store, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "set-cookie": [
+            "session_tracker=XST5Mpqr98BXFwiFLh.0.1580010717513.Z0FBQUFBQmVMUXpkWFNVb0dFNG1oTHVvMzB0UElWUWtqSXQyR1F1OUV2WWNha1MtOHBlZHBUVWFleDJsMTVGQmpfUDJrOTZHMC1DU0RHdTR6b3Z5aVpoUFdTLVg0SXc4cDlnUnhhQVItWFY5VXp4LV9pdUFqWERfN0s3TllNQndDY3NtazR1b3FfbXU; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 26-Jan-2020 05:51:57 GMT; secure"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "598.0"
+          ],
+          "x-ratelimit-reset": [
+            "483"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/friends/<USERNAME>?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/integration/cassettes/TestUser.test_friend_not_exist.json
+++ b/tests/integration/cassettes/TestUser.test_friend_not_exist.json
@@ -1,0 +1,228 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2020-01-26T03:51:57",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "61"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.6.0.dev0 prawcore/1.0.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "118"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 26 Jan 2020 03:51:57 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "edgebucket=Wz234ADdJ109JjrwmB; Domain=reddit.com; Max-Age=63071999; Path=/;  secure"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-lga21940-LGA"
+          ],
+          "X-Timer": [
+            "S1580010718.651845,VS0,VE280"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2020-01-26T03:51:58",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "edgebucket=Wz234ADdJ109JjrwmB"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/6.6.0.dev0 prawcore/1.0.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/api/v1/me/friends/fake__user_user_user?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"fields\": [\"id\"], \"explanation\": \"that user doesn't exist\", \"message\": \"Bad Request\", \"reason\": \"USER_DOESNT_EXIST\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "117"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sun, 26 Jan 2020 03:51:58 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-lga21975-LGA"
+          ],
+          "X-Timer": [
+            "S1580010718.060904,VS0,VE77"
+          ],
+          "access-control-allow-origin": [
+            "*"
+          ],
+          "access-control-expose-headers": [
+            "X-Moose"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, no-store, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "set-cookie": [
+            "loid=00000000005bn5wlvy.2.1577584524387.Z0FBQUFBQmVMUXpleFhyWUtlRTdJUi1sbm9aTjdsb09VZWJIRXdIdlh4cFFBQkVURUUtMnJrSEt5c0JaNTI0NXZwdlhLQjNXdXJlc2l1TTdDajZUcnNHLXhkLWM2Qi1FRmRTMFgyaHVsN1hoZWQwWktTZ0RtVGE0VkNKSUViWHFPYWlZN0xUM2pnV0Y; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Tue, 25-Jan-2022 03:51:58 GMT; secure",
+            "session_tracker=Wu8qKMIISwbq62YFEb.0.1580010718093.Z0FBQUFBQmVMUXplRm1HMmc1UE5zRjFVZXVLYXBWdzZMTE1WUVhFS3p4c24zN0xwdm9fcmVZVlFabFUycUtiQ0dHYmRvQVJxSGtBSU9taU5Ka0tuY3VxZnZzNnBKLU4tMGIzNHRUcmhlZnd6RjROb2Y0eXpuT0VzeDlhNWlfQWQtbEZ3b2ZQeXhvSlk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 26-Jan-2020 05:51:58 GMT; secure",
+            "loid=00000000005j26udtq.2.1580010718131.Z0FBQUFBQmVMUXplV3ZaRjFKNlJaLXB2bElDWFUxOHRpZElMU0tmYlZDY0poQjR3MUJKU1pEYWczR1ZQUm9wdXRLaTBMZVVqNWdXMnYwcEdkaXYzb2p1bHJUeEdZcG9Fa0d1WkpzOHlYaThJQXNVT0x0dlhvbjgwUEVTUkx2UkRoWFFWajlaZ0VHaUk; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Tue, 25-Jan-2022 03:51:58 GMT; secure",
+            "session_tracker=hM3sXEMwy9ydcQc79J.0.1580010718131.Z0FBQUFBQmVMUXplV2xXcm9RMnZ6bVM3ZHpRUmFHOGd4U3JnWjFPNk9nUU9rME84bjJHcXVSUGNFNWhPS0lGRXVaVW0wdzVEeHRnT2hFS21UbWNFbWlQTWQ2MDNvRFc2ZmdEbTZTSF9MamY4M2E4Y1IzaFV2Wmh0TU9iX19SekRJcTdCODNWbkh0ay0; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 26-Jan-2020 05:51:58 GMT; secure"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "597.0"
+          ],
+          "x-ratelimit-reset": [
+            "482"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 400,
+          "message": "Bad Request"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me/friends/fake__user_user_user?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/integration/models/test_user.py
+++ b/tests/integration/models/test_user.py
@@ -1,6 +1,8 @@
 """Test praw.models.user."""
 from praw.models import Multireddit, Redditor, Subreddit
+from prawcore.exceptions import BadRequest
 import mock
+import pytest
 
 from .. import IntegrationTest
 
@@ -30,6 +32,20 @@ class TestUser(IntegrationTest):
             friends = self.reddit.user.friends()
         assert len(friends) > 0
         assert all(isinstance(friend, Redditor) for friend in friends)
+
+    @mock.patch("time.sleep", return_value=None)
+    def test_friend_exist(self, _):
+        self.reddit.read_only = False
+        with self.recorder.use_cassette("TestUser.test_friend_exist"):
+            friend = self.reddit.user.friends(user=self.reddit.user.me())
+            assert isinstance(friend, Redditor)
+
+    @mock.patch("time.sleep", return_value=None)
+    def test_friend_not_exist(self, _):
+        self.reddit.read_only = False
+        with self.recorder.use_cassette("TestUser.test_friend_not_exist"):
+            with pytest.raises(BadRequest):
+                self.reddit.user.friends(user="fake__user_user_user")
 
     def test_karma(self):
         self.reddit.read_only = False


### PR DESCRIPTION
I am aware that you can get friend data from `Redditor.friend_info`, but it requires creation of a Redditor object and this PR makes it clear that the function is to check if you are friends with i.e., a suspended or shadowbanned user. 

Fix 1 for #1241 