### PR TITLE
Fix indentation on documentation

### DIFF
--- a/docs/getting_started/authentication.rst
+++ b/docs/getting_started/authentication.rst
@@ -119,9 +119,9 @@ A **code flow** application is useful for two primary purposes:
 * You have an application and want to be able to access Reddit from your users'
   accounts.
 * You have a personal-use script application and you either want to
-  * limit the access one of your PRAW-based programs has to Reddit
-  * avoid the hassle of 2FA (described above)
-  * not pass your username and password to PRAW (and thus not keep it in memory)
+ * limit the access one of your PRAW-based programs has to Reddit
+ * avoid the hassle of 2FA (described above)
+ * not pass your username and password to PRAW (and thus not keep it in memory)
 
 When registering your application you must provide a valid redirect URI. If you
 are running a website you will want to enter the appropriate callback URL and


### PR DESCRIPTION
## Feature Summary and Justification

This fixes the bullet points on the authentication documentation page. The highlighted text (below) should be sub-bullet points, not appearing in-line.

<img width="714" alt="image" src="https://user-images.githubusercontent.com/7957611/74073584-dc89bf80-49d8-11ea-8e8f-094071026962.png">



