### PR TITLE
Fix bug in SubredditFlair update method

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -59,4 +59,5 @@ Source Contributors
 - Michael Cetrulo <contact@michael-cetrulo.com> `@git2samus <https://github.com/git2samus>`_
 - George Schizas `@gschizas <https://github.com/gschizas>`_
 - Todd Roberts `@toddrob99 <https://github.com/toddrob99>`_
+- MaybeNetwork `@MaybeNetwork <https://github.com/MaybeNetwork>`_
 <!-- - Add "Name <email (optional)> and github profile link" above this line. -->

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -72,6 +72,11 @@ Unreleased
 
 * :class:`.APIException` is deprecated and slotted for removal in PRAW 8.0.
 
+**Fixed**
+
+* :meth:`.SubredditFlair.update` will not error out when the flair text 
+  contains quotations.
+  
 **Removed**
 
 * Converting :class:`.APIException` to string will no longer escape unicode

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -75,7 +75,7 @@ Unreleased
 **Fixed**
 
 * :meth:`.SubredditFlair.update` will not error out when the flair text 
-  contains quotations.
+  contains quote marks.
   
 **Removed**
 

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -1412,17 +1412,19 @@ class SubredditFlair:
         templines = StringIO()
         for item in flair_list:
             if isinstance(item, dict):
-                writer(templines).writerow([
-                    str(item["user"]),
-                    item.get("flair_text", text),
-                    item.get("flair_css_class", css_class)
-                ])
+                writer(templines).writerow(
+                    [
+                        str(item["user"]),
+                        item.get("flair_text", text),
+                        item.get("flair_css_class", css_class),
+                    ]
+                )
             else:
                 writer(templines).writerow([str(item), text, css_class])
 
         lines = templines.getvalue().splitlines()
         templines.close()
-        response=[]
+        response = []
         url = API_PATH["flaircsv"].format(subreddit=self.subreddit)
         while lines:
             data = {"flair_csv": "\n".join(lines[:100])}

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -3,6 +3,8 @@
 # pylint: disable=too-many-lines
 import socket
 from copy import deepcopy
+from csv import writer
+from io import StringIO
 from json import dumps, loads
 from os.path import basename, dirname, join
 from urllib.parse import urljoin
@@ -1407,19 +1409,20 @@ class SubredditFlair:
                                   css_class='praw')
 
         """
-        lines = []
+        templines = StringIO()
         for item in flair_list:
             if isinstance(item, dict):
-                fmt_data = (
+                writer(templines).writerow([
                     str(item["user"]),
                     item.get("flair_text", text),
-                    item.get("flair_css_class", css_class),
-                )
+                    item.get("flair_css_class", css_class)
+                ])
             else:
-                fmt_data = (str(item), text, css_class)
-            lines.append('"{}","{}","{}"'.format(*fmt_data))
+                writer(templines).writerow([str(item), text, css_class])
 
-        response = []
+        lines = templines.getvalue().splitlines()
+        templines.close()
+        response=[]
         url = API_PATH["flaircsv"].format(subreddit=self.subreddit)
         while lines:
             data = {"flair_csv": "\n".join(lines[:100])}

--- a/tests/integration/cassettes/TestSubredditFlair.test_update_quotes.json
+++ b/tests/integration/cassettes/TestSubredditFlair.test_update_quotes.json
@@ -1,0 +1,452 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2020-04-07T19:43:08",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "61"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/7.0.0.dev0 prawcore/1.0.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "118"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 07 Apr 2020 19:43:08 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "edgebucket=Q0dLKfSMzHAzw8YRZr; Domain=reddit.com; Max-Age=63071999; Path=/;  secure"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-lga21937-LGA"
+          ],
+          "X-Timer": [
+            "S1586288588.037771,VS0,VE332"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2020-04-07T19:43:08",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "edgebucket=Q0dLKfSMzHAzw8YRZr"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/7.0.0.dev0 prawcore/1.0.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/api/v1/me?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"is_employee\": false, \"seen_layout_switch\": true, \"has_visited_new_profile\": false, \"pref_no_profanity\": true, \"has_external_account\": false, \"pref_geopopular\": \"\", \"seen_redesign_modal\": true, \"pref_show_trending\": true, \"subreddit\": {\"default_set\": true, \"user_is_contributor\": false, \"banner_img\": \"\", \"restrict_posting\": true, \"user_is_banned\": false, \"free_form_reports\": true, \"community_icon\": \"\", \"show_media\": true, \"icon_color\": \"#4856A3\", \"user_is_muted\": false, \"display_name\": \"u_<USERNAME>\", \"header_img\": null, \"title\": \"\", \"coins\": 0, \"previous_names\": [], \"over_18\": false, \"icon_size\": [256, 256], \"primary_color\": \"\", \"icon_img\": \"https://www.redditstatic.com/avatars/avatar_default_03_4856A3.png\", \"description\": \"\", \"submit_link_label\": \"\", \"header_size\": null, \"restrict_commenting\": false, \"subscribers\": 0, \"submit_text_label\": \"\", \"is_default_icon\": true, \"link_flair_position\": \"\", \"display_name_prefixed\": \"u/<USERNAME>\", \"key_color\": \"\", \"name\": \"t5_2bhrub\", \"is_default_banner\": true, \"url\": \"/user/<USERNAME>/\", \"banner_size\": null, \"user_is_moderator\": true, \"public_description\": \"\", \"link_flair_enabled\": false, \"disable_contributor_requests\": false, \"subreddit_type\": \"user\", \"user_is_subscriber\": false}, \"is_sponsor\": false, \"gold_expiration\": null, \"has_gold_subscription\": false, \"num_friends\": 1, \"features\": {\"promoted_trend_blanks\": true, \"show_amp_link\": true, \"chat\": true, \"twitter_embed\": true, \"is_email_permission_required\": false, \"mod_awards\": true, \"expensive_coins_package\": true, \"mweb_xpromo_revamp_v2\": {\"owner\": \"growth\", \"variant\": \"treatment_6\", \"experiment_id\": 457}, \"awards_on_streams\": true, \"mweb_xpromo_modal_listing_click_daily_dismissible_ios\": true, \"community_awards\": true, \"modlog_copyright_removal\": true, \"do_not_track\": true, \"chat_user_settings\": true, \"mweb_xpromo_interstitial_comments_ios\": true, \"chat_subreddit\": true, \"mweb_xpromo_modal_listing_click_daily_dismissible_android\": true, \"premium_subscriptions_table\": true, \"mweb_xpromo_interstitial_comments_android\": true, \"mweb_nsfw_xpromo\": {\"owner\": \"growth\", \"variant\": \"control_2\", \"experiment_id\": 361}, \"stream_as_a_post_type\": true, \"chat_group_rollout\": true, \"custom_feeds\": true, \"spez_modal\": true, \"mweb_sharing_clipboard\": {\"owner\": \"growth\", \"variant\": \"treatment_2\", \"experiment_id\": 315}, \"feed_ad_load_3\": {\"owner\": \"ads\", \"variant\": \"control_1\", \"experiment_id\": 436}}, \"has_android_subscription\": false, \"verified\": true, \"new_modmail_exists\": false, \"pref_autoplay\": true, \"coins\": 0, \"has_paypal_subscription\": false, \"has_subscribed_to_premium\": false, \"id\": \"5bn5wlvy\", \"has_stripe_subscription\": false, \"seen_premium_adblock_modal\": false, \"can_create_subreddit\": false, \"over_18\": true, \"is_gold\": false, \"is_mod\": true, \"suspension_expiration_utc\": null, \"has_verified_email\": true, \"is_suspended\": false, \"pref_video_autoplay\": true, \"in_chat\": true, \"can_edit_name\": false, \"in_redesign_beta\": true, \"icon_img\": \"https://www.redditstatic.com/avatars/avatar_default_03_4856A3.png\", \"has_mod_mail\": false, \"pref_nightmode\": true, \"oauth_client_id\": \"<CLIENT_ID>\", \"hide_from_robots\": false, \"link_karma\": 1, \"force_password_reset\": false, \"seen_give_award_tooltip\": false, \"inbox_count\": 12, \"pref_top_karma_subreddits\": true, \"has_mail\": true, \"pref_show_snoovatar\": false, \"name\": \"<USERNAME>\", \"pref_clickgadget\": 5, \"created\": 1577613361.0, \"gold_creddits\": 0, \"created_utc\": 1577584561.0, \"has_ios_subscription\": false, \"pref_show_twitter\": false, \"in_beta\": false, \"comment_karma\": 0, \"has_subscribed\": true, \"seen_subreddit_chat_ftux\": false}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "3621"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 07 Apr 2020 19:43:08 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "session_tracker=EjA3Ql8hHLv76dkFVx.0.1586288588538.Z0FBQUFBQmVqTmZNR1JHZlViNnBPbVFFMV9uTkZkNVdRX1RwSlNBSlh6VGNOSU1GMGFfdHB0d01SM2ZLZVZvT1BPV0pZdzR3WkJnVm1ZSkhfbDBpT2dRZHg1ZGl4R3FPQzlSODVDNXNvVTZSN2N2bHVZT0pCQmhwZVFxdk9rMlFub2xJR05Va0Z4M1Q; Domain=reddit.com; Max-Age=7199; Path=/; expires=Tue, 07-Apr-2020 21:43:08 GMT; secure; SameSite=None; Secure",
+            "csv=1; Max-Age=63072000; Domain=.reddit.com; Path=/; Secure; SameSite=None"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Vary": [
+            "accept-encoding"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-lga21966-LGA"
+          ],
+          "X-Timer": [
+            "S1586288589.502648,VS0,VE108"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, no-store, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "597.0"
+          ],
+          "x-ratelimit-reset": [
+            "412"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/me?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-04-07T19:43:08",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "api_type=json&flair_csv=<USERNAME>%2C%22%22%22testing%22%22%22%2Ctesting"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "75"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "Cookie": [
+            "csv=1; edgebucket=Q0dLKfSMzHAzw8YRZr; session_tracker=EjA3Ql8hHLv76dkFVx.0.1586288588538.Z0FBQUFBQmVqTmZNR1JHZlViNnBPbVFFMV9uTkZkNVdRX1RwSlNBSlh6VGNOSU1GMGFfdHB0d01SM2ZLZVZvT1BPV0pZdzR3WkJnVm1ZSkhfbDBpT2dRZHg1ZGl4R3FPQzlSODVDNXNvVTZSN2N2bHVZT0pCQmhwZVFxdk9rMlFub2xJR05Va0Z4M1Q"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/7.0.0.dev0 prawcore/1.0.1"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flaircsv/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "[{\"status\": \"added flair for user <USERNAME>\", \"errors\": {}, \"ok\": true, \"warnings\": {}}]"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "92"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 07 Apr 2020 19:43:08 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-lga21966-LGA"
+          ],
+          "X-Timer": [
+            "S1586288589.633456,VS0,VE246"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, no-store, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "set-cookie": [
+            "session_tracker=EjA3Ql8hHLv76dkFVx.0.1586288588677.Z0FBQUFBQmVqTmZNaU5MaDFVaUhPV3VCYUdpWUEyUVpFQ25EZjB0SlUxTlNOY3dFR3QyWHpIcms1ZXBZUW52TkxoUjlGS19ReE9Eb0tjUzgtS3lHYkhNNEJvTnpRUFI2YUFhNGRyVkxKRVBjQ1VMUXNSRHFuNkdaZVBXSWJKYUR1Zmxua1VNSWNoVGE; Domain=reddit.com; Max-Age=7199; Path=/; expires=Tue, 07-Apr-2020 21:43:08 GMT; secure"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "596.0"
+          ],
+          "x-ratelimit-reset": [
+            "412"
+          ],
+          "x-ratelimit-used": [
+            "4"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flaircsv/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-04-07T19:43:09",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "csv=1; edgebucket=Q0dLKfSMzHAzw8YRZr; session_tracker=EjA3Ql8hHLv76dkFVx.0.1586288588677.Z0FBQUFBQmVqTmZNaU5MaDFVaUhPV3VCYUdpWUEyUVpFQ25EZjB0SlUxTlNOY3dFR3QyWHpIcms1ZXBZUW52TkxoUjlGS19ReE9Eb0tjUzgtS3lHYkhNNEJvTnpRUFI2YUFhNGRyVkxKRVBjQ1VMUXNSRHFuNkdaZVBXSWJKYUR1Zmxua1VNSWNoVGE"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/7.0.0.dev0 prawcore/1.0.1"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairlist/?name=<USERNAME>&limit=1024&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"users\": [{\"flair_css_class\": \"testing\", \"user\": \"<USERNAME>\", \"flair_text\": \"\\\"testing\\\"\"}]}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "97"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Tue, 07 Apr 2020 19:43:09 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "session_tracker=EjA3Ql8hHLv76dkFVx.0.1586288588983.Z0FBQUFBQmVqTmZOd2ZzMEJBYi11VXlwRXVrZVFZajRzWHZaME5Vbkp4NTNGbHYwdllqLXhTOENZRlhvcnhBMi14UVloTndyc3g0OHRnUlZBMkhUQ2dRQ2tsWmxnREUtc2dYOFR2QS02S3lQT014clNrYlVhU1NQcEtZcnQ3NUd0ZVVYZzJ4Q096Mk4; Domain=reddit.com; Max-Age=7199; Path=/; expires=Tue, 07-Apr-2020 21:43:09 GMT; secure; SameSite=None; Secure"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-lga21966-LGA"
+          ],
+          "X-Timer": [
+            "S1586288589.926130,VS0,VE89"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, no-store, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "595.0"
+          ],
+          "x-ratelimit-reset": [
+            "412"
+          ],
+          "x-ratelimit-used": [
+            "5"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/api/flairlist/?name=<USERNAME>&limit=1024&raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/integration/models/reddit/test_subreddit.py
+++ b/tests/integration/models/reddit/test_subreddit.py
@@ -1132,7 +1132,21 @@ class TestSubredditFlair(IntegrationTest):
             response = self.subreddit.flair.update(
                 flair_list, css_class="default"
             )
-        assert all(x["ok"] for x in response)
+            assert all(x["ok"] for x in response)
+
+    @mock.patch("time.sleep", return_value=None)
+    def test_update_quotes(self, _):
+        self.reddit.read_only = False
+        with self.recorder.use_cassette(
+            "TestSubredditFlair.test_update_quotes"
+        ):
+            response = self.subreddit.flair.update(
+                [self.reddit.user.me()], text='"testing"', css_class="testing",
+            )
+            assert all(x["ok"] for x in response)
+            flair = next(self.subreddit.flair(self.reddit.user.me()))
+            assert flair["flair_text"] == '"testing"'
+            assert flair["flair_css_class"] == "testing"
 
 
 class TestSubredditFlairTemplates(IntegrationTest):


### PR DESCRIPTION
## Feature Summary and Justification

This  fixes a bug in `SubredditFlair.update`. The Reddit API uses Python's CSV reader, which expects embedded double-quotes to be escaped, and PRAW's current method does not do this. Double-quotes can appear in flair_text values, which means that `SubredditFlair.update` sets flair_texts with double-quotes to incorrect values. For example,  

    reddit.subreddit('TEST_SUBREDDIT').flair.update(['MaybeNetwork'],text='"Quotes"')

will set the flair_text to `Quotes""` instead of `"Quotes"`, and 

    reddit.subreddit('TEST_SUBREDDIT').flair.update(['MaybeNetwork'],text='"quote", unquote, "quote"')

will fail entirely instead of setting the flair_text to `"quote", unquote, "quote"`.

This proposed fix uses `writer` from Python's CSV module to ensure that inputs have the expected escaping.

---

There are a few other things worth noting about the Reddit API's flaircsv method: its validation of flair_text values is bugged, it doesn't handle Unicode the way /api/flair does, and in certain circumstances it can set flair_text values to null.

It [used to be](https://github.com/reddit-archive/reddit/blob/84b9fb1c48c660cbfbfb141faa808671c364e070/r2/r2/controllers/api.py#L2006) that when a row is submitted with a flair_text that is too long, Reddit trimmed the flair down to the max_length parameter (64) and issued a warning in the the response. At present, if the flair_text fails the validation check, the flair_text is silently set to the empty string and no warning is issued. If the corresponding flair_css_class is the empty or null, then the flair is removed entirely. [This change](https://github.com/reddit-archive/reddit/commit/f44a517296b259149453ab17e9a108d5a53190d5#diff-789eb732c0b8724057e638dfa1eac6c5) in 2011 broke this, and it was never fixed. 

If you look at the [relevant code](https://github.com/reddit-archive/reddit/blob/master/r2/r2/controllers/api.py#L4037) for the API, you can see why this happens. The code was changed from

     if text and len(text) > flair_text_limit:
                line_result.warn('text',
                                 'truncating flair text to %d chars'
                                 % flair_text_limit)
                text = text[:flair_text_limit]

to [the current](https://github.com/reddit-archive/reddit/blob/753b17407e9a9dca09558526805922de24133d53/r2/r2/controllers/api.py#L4080)

    orig_text = text
    text = VFlairText('text').run(orig_text)
    if text and orig_text and len(text) < len(orig_text):
        line_result.warn('text',
                         'truncating flair text to %d chars'
                         % len(text))

where `text` is the flair_text value. From the definitions of [VFlairText](https://github.com/reddit-archive/reddit/blob/master/r2/r2/lib/validator/validator.py#L2790) and [VLength](https://github.com/reddit-archive/reddit/blob/753b17407e9a9dca09558526805922de24133d53/r2/r2/lib/validator/validator.py#L530), you can see that a flair is too long, `VFlairText('text').run(orig_text)` sets an error but doesn't specify a return value. This means that `if text and orig_text and len(text) < len(orig_text)` will always be false, because `text` is false if the text is too long, and if it isn't, then `len(text) < len(orig_text)` is false. Even if the condition were satisfied and the server returned a nonempty warning field, note that the line that trimmed the flair was also removed. You can verify that  [VFlairText](https://github.com/reddit-archive/reddit/commit/f44a517296b259149453ab17e9a108d5a53190d5#diff-afa49e60b0f192995d4744c62fc86edb) was created as part of the same commit.

Unfortunately, /api/flaircsv also can't set all of the non-null flair_text values that /api/flair can. [Because](https://old.reddit.com/r/bugs/comments/j5yul/flaircsv_fails_on_unicode_characters/) it was written in Python 2, [whose CSV module didn't support Unicode input](https://docs.python.org/2/library/csv.html), the flair_csv input is first [encoded into UTF-8.](https://github.com/reddit-archive/reddit/commit/84b9fb1c48c660cbfbfb141faa808671c364e070#diff-789eb732c0b8724057e638dfa1eac6c5) This has a side effect of increasing the length of some inputs with Unicode characters. For example, if you check the length of the string `Pͪ̌̃̄͒̀͋ͣͨ̕͝͏̷͚̩͙̜̳͢Ŕ̖͎̳͖̤͈̥̞̥̽̉͆̓ͭ̉ͫ́͞A̼̮̦̽̄ͤ̓͛ͤ̉́W̢̗̤̼͎̑ͧ̾̔͐̚` in Python 2,

`len(u'P\u036a\u030c\u0303\u0304\u0352\u0300\u034b\u0363\u0368\u0315\u035d\u034f\u0337\u0362\u035a\u0329\u0359\u031c\u0333R\u0301\u033d\u0309\u0346\u0343\u036d\u0309\u036b\u0301\u035e\u0316\u034e\u0333\u0356\u0324\u0348\u0325\u031e\u0325A\u033d\u0304\u0364\u0313\u035b\u0364\u0309\u0341\u033c\u032e\u0326W\u0311\u0367\u033e\u031a\u0314\u0350\u0322\u0317\u0324\u033c\u034e') `
 
is 64, but

`len(u'P\u036a\u030c\u0303\u0304\u0352\u0300\u034b\u0363\u0368\u0315\u035d\u034f\u0337\u0362\u035a\u0329\u0359\u031c\u0333R\u0301\u033d\u0309\u0346\u0343\u036d\u0309\u036b\u0301\u035e\u0316\u034e\u0333\u0356\u0324\u0348\u0325\u031e\u0325A\u033d\u0304\u0364\u0313\u035b\u0364\u0309\u0341\u033c\u032e\u0326W\u0311\u0367\u033e\u031a\u0314\u0350\u0322\u0317\u0324\u033c\u034e'.encode('utf-8'))`

is 124. This means that you can set a flair text to `Pͪ̌̃̄͒̀͋ͣͨ̕͝͏̷͚̩͙̜̳͢Ŕ̖͎̳͖̤͈̥̞̥̽̉͆̓ͭ̉ͫ́͞A̼̮̦̽̄ͤ̓͛ͤ̉́W̢̗̤̼͎̑ͧ̾̔͐̚` with either /api/flair or without using the API, but you can't set that value with /api/flaircsv. And, because of the bug noted above, overlong flair texts are the same as an empty string.

If a user does not have flair, or has not recently had a flair with a non-null flair_text value, /api/flaircsv can set flairs with null flair_text values. This will happen if /api/flaircsv is fed rows with blank or "" flair_text values, and the css_class entry has an opening "" but not a closing one. For example, a payload of 

    'MaybeNetwork,,""css class here\nAaronSw,"",""another css class'

will set both flair_text values to null. Neither the current PRAW update method nor this proposed fix can craft rows like this, but someone might find this behavior to be useful.
## References

* https://github.com/reddit-archive/reddit/blob/master/r2/r2/lib/validator/validator.py
* https://github.com/reddit-archive/reddit/blob/master/r2/r2/controllers/api.py