### PR TITLE
Fix documentation that contained invalid code

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -82,7 +82,7 @@ With the ``reddit`` instance you can then interact with Reddit:
       print(submission.score)
 
   # Obtain the moderator listing for r/redditdev
-  for moderator in reddit.subreddit('redditdev').moderator:
+  for moderator in reddit.subreddit('redditdev').moderator():
       print(moderator)
 
 Please see PRAW's `documentation <https://praw.readthedocs.io/>`_ for


### PR DESCRIPTION
`subreddit.moderator` results in an instance of `ModeratorRelationship`, which is not iterable. Instead, it is callable, so it needs to be called. 

```
>>> for moderator in reddit.subreddit('redditdev').moderator:
...     print(moderator)
... 
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
TypeError: 'ModeratorRelationship' object is not iterable
```