### PR TITLE
Documentation: wrong prefix

### DIFF
--- a/praw/models/reddit/comment.py
+++ b/praw/models/reddit/comment.py
@@ -45,9 +45,9 @@ class Comment(InboxableMixin, UserContentMixin, FullnameMixin, RedditBase):
     ``is_submitter``        Whether or not the comment author is also the
                             author of the submission.
     ``link_id``             The submission ID that the comment belongs to.
-    ``parent_id``           The ID of the parent comment (prefixed with ``t3_``).
+    ``parent_id``           The ID of the parent comment (prefixed with ``t1_``).
                             If it is a top-level comment, this returns the
-                            submission ID instead (prefixed with ``t1_``).
+                            submission ID instead (prefixed with ``t3_``).
     ``permalink``           A permalink for the comment. Comment objects from
                             the inbox have a ``context`` attribute instead.
     ``replies``             Provides an instance of :class:`.CommentForest`.


### PR DESCRIPTION
t1_ are comments, t3_ are links (submissions)

Fixes a mistake that snuck in with #1392 
