### PR TITLE
Limit coverallsapp/github-action version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,7 @@ jobs:
     needs: test-multi-python
     runs-on: ubuntu-latest
     steps:
-    - uses: coverallsapp/github-action@master
+    - uses: coverallsapp/github-action@57daa114
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         parallel-finished: true


### PR DESCRIPTION
## Feature Summary and Justification

The coverallsapp/github-action runner made changes to how parallel jobs are run. We should update our `ci.yml` to support these changes, but for now this PR pins an old version of the CI runner.

## References

* https://github.com/coverallsapp/github-action/commit/198c7931d32bc4bfa3768f698af3332214dae75f
* #1400
