### PR TITLE
Use unittest.mock over mock package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,6 @@ extras = {
     "test": [
         "betamax >=0.8, <0.9",
         "betamax-matchers >=0.3.0, <0.5",
-        "mock >=0.8",
         "pytest >=2.7.3",
     ],
 }

--- a/tests/integration/models/reddit/test_collections.py
+++ b/tests/integration/models/reddit/test_collections.py
@@ -1,6 +1,6 @@
 """Test classes from collections.py."""
 
-import mock
+from unittest import mock
 import pytest
 
 from praw.exceptions import ClientException

--- a/tests/integration/models/reddit/test_comment.py
+++ b/tests/integration/models/reddit/test_comment.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from praw.exceptions import ClientException, PRAWException, RedditAPIException

--- a/tests/integration/models/reddit/test_emoji.py
+++ b/tests/integration/models/reddit/test_emoji.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from praw.exceptions import ClientException

--- a/tests/integration/models/reddit/test_live.py
+++ b/tests/integration/models/reddit/test_live.py
@@ -1,5 +1,5 @@
 """Test praw.models.LiveThread"""
-import mock
+from unittest import mock
 import pytest
 
 from praw.const import API_PATH

--- a/tests/integration/models/reddit/test_message.py
+++ b/tests/integration/models/reddit/test_message.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from praw.models import Message, Redditor, Subreddit, SubredditMessage

--- a/tests/integration/models/reddit/test_modmail.py
+++ b/tests/integration/models/reddit/test_modmail.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 from praw.models import ModmailMessage
 

--- a/tests/integration/models/reddit/test_multi.py
+++ b/tests/integration/models/reddit/test_multi.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from praw.models import Comment, Submission, Subreddit

--- a/tests/integration/models/reddit/test_redditor.py
+++ b/tests/integration/models/reddit/test_redditor.py
@@ -1,5 +1,5 @@
 """Test praw.models.redditor."""
-import mock
+from unittest import mock
 import pytest
 from prawcore import Forbidden
 

--- a/tests/integration/models/reddit/test_removal_reasons.py
+++ b/tests/integration/models/reddit/test_removal_reasons.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from praw.exceptions import ClientException

--- a/tests/integration/models/reddit/test_submission.py
+++ b/tests/integration/models/reddit/test_submission.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 
 from praw.exceptions import RedditAPIException

--- a/tests/integration/models/reddit/test_subreddit.py
+++ b/tests/integration/models/reddit/test_subreddit.py
@@ -4,7 +4,7 @@ import sys
 from json import dumps
 from os.path import abspath, dirname, join
 
-import mock
+from unittest import mock
 import pytest
 import requests
 import websocket

--- a/tests/integration/models/reddit/test_widgets.py
+++ b/tests/integration/models/reddit/test_widgets.py
@@ -1,7 +1,7 @@
 import sys
 from os.path import abspath, dirname, join
 
-import mock
+from unittest import mock
 import pytest
 
 from praw.models import (

--- a/tests/integration/models/reddit/test_wikipage.py
+++ b/tests/integration/models/reddit/test_wikipage.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 import pytest
 from prawcore import NotFound
 

--- a/tests/integration/models/test_comment_forest.py
+++ b/tests/integration/models/test_comment_forest.py
@@ -1,5 +1,5 @@
 """Test praw.models.comment_forest."""
-import mock
+from unittest import mock
 import pytest
 
 from praw.exceptions import DuplicateReplaceException

--- a/tests/integration/models/test_inbox.py
+++ b/tests/integration/models/test_inbox.py
@@ -1,5 +1,5 @@
 """Test praw.models.inbox."""
-import mock
+from unittest import mock
 import pytest
 from prawcore import Forbidden
 

--- a/tests/integration/models/test_preferences.py
+++ b/tests/integration/models/test_preferences.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 from praw.models import Preferences
 

--- a/tests/integration/models/test_redditors.py
+++ b/tests/integration/models/test_redditors.py
@@ -1,5 +1,5 @@
 """Test praw.models.redditors."""
-import mock
+from unittest import mock
 
 from praw.models import Redditor, Subreddit
 

--- a/tests/integration/models/test_subreddits.py
+++ b/tests/integration/models/test_subreddits.py
@@ -1,5 +1,5 @@
 """Test praw.models.subreddits."""
-import mock
+from unittest import mock
 
 from praw.models import Subreddit
 

--- a/tests/integration/models/test_trophy.py
+++ b/tests/integration/models/test_trophy.py
@@ -1,5 +1,5 @@
 """Test praw.models.Trophy"""
-import mock
+from unittest import mock
 
 from .. import IntegrationTest
 

--- a/tests/integration/models/test_user.py
+++ b/tests/integration/models/test_user.py
@@ -1,5 +1,5 @@
 """Test praw.models.user."""
-import mock
+from unittest import mock
 import pytest
 
 from praw.exceptions import RedditAPIException

--- a/tests/integration/test_reddit.py
+++ b/tests/integration/test_reddit.py
@@ -1,5 +1,5 @@
 """Test praw.reddit."""
-import mock
+from unittest import mock
 
 from praw.models import LiveThread
 from praw.models.reddit.base import RedditBase

--- a/tests/unit/models/test_redditors.py
+++ b/tests/unit/models/test_redditors.py
@@ -1,6 +1,6 @@
 """Test praw.models.redditors."""
 
-import mock
+from unittest import mock
 
 from .. import UnitTest
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,7 +1,7 @@
 import os
 import sys
 
-import mock
+from unittest import mock
 import pytest
 
 from praw.config import Config

--- a/tests/unit/test_reddit.py
+++ b/tests/unit/test_reddit.py
@@ -1,7 +1,7 @@
 import configparser
 import types
 
-import mock
+from unittest import mock
 import pytest
 from prawcore import Requestor
 from prawcore.exceptions import BadRequest


### PR DESCRIPTION
The mock module is just a backport of the mock module, and as the
minimum version comes with the unittest.mock module, there is no need to
keep on installing another dependency.