### PR TITLE
Change comment forest to include parent of comment

### DIFF
--- a/praw/models/comment_forest.py
+++ b/praw/models/comment_forest.py
@@ -73,7 +73,7 @@ class CommentForest:
         return len(self._comments)
 
     def _insert_comment(self, comment):
-        if comment.name in self._submission._comments_by_id:
+        if vars(comment).get("name", None) in self._submission._comments_by_id:
             raise DuplicateReplaceException
         comment.submission = self._submission
         if isinstance(comment, MoreComments) or comment.is_root:

--- a/praw/models/comment_forest.py
+++ b/praw/models/comment_forest.py
@@ -79,12 +79,18 @@ class CommentForest:
         if isinstance(comment, MoreComments) or comment.is_root:
             self._comments.append(comment)
         else:
-            assert comment.parent_id in self._submission._comments_by_id, (
-                "PRAW Error occured. Please file a bug report and include "
-                "the code that caused the error."
-            )
-            parent = self._submission._comments_by_id[comment.parent_id]
-            parent.replies._comments.append(comment)
+            if comment.parent_id in self._submission._comments_by_id:
+                parent = self._submission._comments_by_id[comment.parent_id]
+                parent.replies._comments.append(comment)
+            elif comment.parent_id == self._submission.id:
+                self._submission._comments_by_id[comment.id] = comment
+                self._submission.comments._comments.append(comment)
+            else:
+                self._insert_comment(
+                    self._submission._reddit.comment(comment.parent_id)
+                )
+                parent = self._submission._comments_by_id[comment.parent_id]
+                parent.replies._comments.append(comment)
 
     def _update(self, comments):
         self._comments = comments


### PR DESCRIPTION
If a deleted comment is not part of the submission, instead of throwing
an AssertionError, it will obtain the parent comment, add it, and then
continue with normal operations.

Fixes # (provide issue number if applicable)
Fix #1437 

I do not know how to test this new change, guidance would be welcomed. 