### PR TITLE
Revert "Get rid of redundant ``'<content>'``"

### DIFF
--- a/praw/models/helpers.py
+++ b/praw/models/helpers.py
@@ -119,7 +119,7 @@ class MultiredditHelper(PRAWBase):
     ) -> Multireddit:
         """Return a lazy instance of :class:`~.Multireddit`.
 
-        :param redditor: A redditor name (e.g., ``'spez'``) or
+        :param redditor: A redditor name (e.g., ``"spez"``) or
             :class:`~.Redditor` instance who owns the multireddit.
         :param name: The name of the multireddit.
 
@@ -152,7 +152,7 @@ class MultiredditHelper(PRAWBase):
             ``sports``, ``style``, ``tech``, ``travel``, ``unusual stories``,
             ``video``, or ``None``.
         :param key_color: (Optional) RGB hex color code of the form
-            ``'#FFFFFF'``.
+            ``"#FFFFFF"``.
         :param visibility: (Optional) Can be one of: ``hidden``, ``private``,
             ``public`` (default: private).
         :param weighting_scheme: (Optional) Can be one of: ``classic``,
@@ -204,7 +204,7 @@ class SubredditHelper(PRAWBase):
 
         :param name: The name for the new subreddit.
 
-        :param title: The title of the subreddit. When ``None`` or ``''`` use
+        :param title: The title of the subreddit. When ``None`` or ``""`` use
             the value of ``name``.
 
         :param link_type: The types of submissions users can make.

--- a/praw/models/helpers.py
+++ b/praw/models/helpers.py
@@ -119,7 +119,7 @@ class MultiredditHelper(PRAWBase):
     ) -> Multireddit:
         """Return a lazy instance of :class:`~.Multireddit`.
 
-        :param redditor: A redditor name (e.g., ``spez``) or
+        :param redditor: A redditor name (e.g., ``'spez'``) or
             :class:`~.Redditor` instance who owns the multireddit.
         :param name: The name of the multireddit.
 
@@ -152,7 +152,7 @@ class MultiredditHelper(PRAWBase):
             ``sports``, ``style``, ``tech``, ``travel``, ``unusual stories``,
             ``video``, or ``None``.
         :param key_color: (Optional) RGB hex color code of the form
-            ``#FFFFFF``.
+            ``'#FFFFFF'``.
         :param visibility: (Optional) Can be one of: ``hidden``, ``private``,
             ``public`` (default: private).
         :param weighting_scheme: (Optional) Can be one of: ``classic``,

--- a/praw/models/preferences.py
+++ b/praw/models/preferences.py
@@ -59,8 +59,8 @@ class Preferences:
         :param creddit_autorenew: Use a creddit to automatically renew my
             gold if it expires (boolean).
         :param default_comment_sort: Default comment sort (one of
-            ``'confidence'``, ``'top'``, ``'new'``, ``'controversial'``,
-            ``'old'``, ``'random'``, ``'qa'``, ``'live'``).
+            ``"confidence"``, ``"top"``, ``"new"``, ``"controversial"``,
+            ``"old"``, ``"random"``, ``"qa"``, ``"live"``).
         :param domain_details: Show additional details in the domain text
             when available, such as the source subreddit or the content
             author's url/name (boolean).
@@ -68,22 +68,22 @@ class Preferences:
         :param email_messages: Send messages as emails (boolean).
         :param email_unsubscribe_all: Unsubscribe from all emails (boolean).
         :param enable_default_themes: Use reddit theme (boolean).
-        :param g: Location (one of ``'GLOBAL'``, ``'AR'``, ``'AU'``, ``'BG'``,
-            ``'CA'``, ``'CL'``, ``'CO'``, ``'CZ'``, ``'FI'``, ``'GB'``,
-            ``'GR'``, ``'HR'``, ``'HU'``, ``'IE'``, ``'IN'``, ``'IS'``,
-            ``'JP'``, ``'MX'``, ``'MY'``, ``'NZ'``, ``'PH'``, ``'PL'``,
-            ``'PR'``, ``'PT'``, ``'RO'``, ``'RS'``, ``'SE'``, ``'SG'``,
-            ``'TH'``, ``'TR'``, ``'TW'``, ``'US'``, ``'US_AK'``, ``'US_AL'``,
-            ``'US_AR'``, ``'US_AZ'``, ``'US_CA'``, ``'US_CO'``, ``'US_CT'``,
-            ``'US_DC'``, ``'US_DE'``, ``'US_FL'``, ``'US_GA'``, ``'US_HI'``,
-            ``'US_IA'``, ``'US_ID'``, ``'US_IL'``, ``'US_IN'``, ``'US_KS'``,
-            ``'US_KY'``, ``'US_LA'``, ``'US_MA'``, ``'US_MD'``, ``'US_ME'``,
-            ``'US_MI'``, ``'US_MN'``, ``'US_MO'``, ``'US_MS'``, ``'US_MT'``,
-            ``'US_NC'``, ``'US_ND'``, ``'US_NE'``, ``'US_NH'``, ``'US_NJ'``,
-            ``'US_NM'``, ``'US_NV'``, ``'US_NY'``, ``'US_OH'``, ``'US_OK'``,
-            ``'US_OR'``, ``'US_PA'``, ``'US_RI'``, ``'US_SC'``, ``'US_SD'``,
-            ``'US_TN'``, ``'US_TX'``, ``'US_UT'``, ``'US_VA'``, ``'US_VT'``,
-            ``'US_WA'``, ``'US_WI'``, ``'US_WV'``, ``'US_WY'``).
+        :param g: Location (one of ``"GLOBAL"``, ``"AR"``, ``"AU"``, ``"BG"``,
+            ``"CA"``, ``"CL"``, ``"CO"``, ``"CZ"``, ``"FI"``, ``"GB"``,
+            ``"GR"``, ``"HR"``, ``"HU"``, ``"IE"``, ``"IN"``, ``"IS"``,
+            ``"JP"``, ``"MX"``, ``"MY"``, ``"NZ"``, ``"PH"``, ``"PL"``,
+            ``"PR"``, ``"PT"``, ``"RO"``, ``"RS"``, ``"SE"``, ``"SG"``,
+            ``"TH"``, ``"TR"``, ``"TW"``, ``"US"``, ``"US_AK"``, ``"US_AL"``,
+            ``"US_AR"``, ``"US_AZ"``, ``"US_CA"``, ``"US_CO"``, ``"US_CT"``,
+            ``"US_DC"``, ``"US_DE"``, ``"US_FL"``, ``"US_GA"``, ``"US_HI"``,
+            ``"US_IA"``, ``"US_ID"``, ``"US_IL"``, ``"US_IN"``, ``"US_KS"``,
+            ``"US_KY"``, ``"US_LA"``, ``"US_MA"``, ``"US_MD"``, ``"US_ME"``,
+            ``"US_MI"``, ``"US_MN"``, ``"US_MO"``, ``"US_MS"``, ``"US_MT"``,
+            ``"US_NC"``, ``"US_ND"``, ``"US_NE"``, ``"US_NH"``, ``"US_NJ"``,
+            ``"US_NM"``, ``"US_NV"``, ``"US_NY"``, ``"US_OH"``, ``"US_OK"``,
+            ``"US_OR"``, ``"US_PA"``, ``"US_RI"``, ``"US_SC"``, ``"US_SD"``,
+            ``"US_TN"``, ``"US_TX"``, ``"US_UT"``, ``"US_VA"``, ``"US_VT"``,
+            ``"US_WA"``, ``"US_WI"``, ``"US_WV"``, ``"US_WY"``).
         :param hide_ads: Hide ads (boolean).
         :param hide_downs: Don't show me submissions after I've downvoted them,
             except my own (boolean).
@@ -105,10 +105,10 @@ class Preferences:
             (boolean).
         :param mark_messages_read: Mark messages as read when I open my inbox
             (boolean).
-        :param media: Thumbnail preference (one of ``'on'``, ``'off'``,
-            ``'subreddit'``).
-        :param media_preview: Media preview preference (one of ``'on'``,
-            ``'off'``, ``'subreddit'``).
+        :param media: Thumbnail preference (one of ``"on"``, ``"off"``,
+            ``"subreddit"``).
+        :param media_preview: Media preview preference (one of ``"on"``,
+            ``"off"``, ``"subreddit"``).
         :param min_comment_score: Don't show me comments with a score less than
             this number (int between ``-100`` and ``100``).
         :param min_link_score: Don't show me submissions with a score less than

--- a/praw/models/preferences.py
+++ b/praw/models/preferences.py
@@ -59,8 +59,8 @@ class Preferences:
         :param creddit_autorenew: Use a creddit to automatically renew my
             gold if it expires (boolean).
         :param default_comment_sort: Default comment sort (one of
-            ``confidence``, ``top``, ``new``, ``controversial``,
-            ``old``, ``random``, ``qa``, ``live``).
+            ``'confidence'``, ``'top'``, ``'new'``, ``'controversial'``,
+            ``'old'``, ``'random'``, ``'qa'``, ``'live'``).
         :param domain_details: Show additional details in the domain text
             when available, such as the source subreddit or the content
             author's url/name (boolean).
@@ -68,22 +68,22 @@ class Preferences:
         :param email_messages: Send messages as emails (boolean).
         :param email_unsubscribe_all: Unsubscribe from all emails (boolean).
         :param enable_default_themes: Use reddit theme (boolean).
-        :param g: Location (one of ``GLOBAL``, ``AR``, ``AU``, ``BG``,
-            ``CA``, ``CL``, ``CO``, ``CZ``, ``FI``, ``GB``,
-            ``GR``, ``HR``, ``HU``, ``IE``, ``IN``, ``IS``,
-            ``JP``, ``MX``, ``MY``, ``NZ``, ``PH``, ``PL``,
-            ``PR``, ``PT``, ``RO``, ``RS``, ``SE``, ``SG``,
-            ``TH``, ``TR``, ``TW``, ``US``, ``US_AK``, ``US_AL``,
-            ``US_AR``, ``US_AZ``, ``US_CA``, ``US_CO``, ``US_CT``,
-            ``US_DC``, ``US_DE``, ``US_FL``, ``US_GA``, ``US_HI``,
-            ``US_IA``, ``US_ID``, ``US_IL``, ``US_IN``, ``US_KS``,
-            ``US_KY``, ``US_LA``, ``US_MA``, ``US_MD``, ``US_ME``,
-            ``US_MI``, ``US_MN``, ``US_MO``, ``US_MS``, ``US_MT``,
-            ``US_NC``, ``US_ND``, ``US_NE``, ``US_NH``, ``US_NJ``,
-            ``US_NM``, ``US_NV``, ``US_NY``, ``US_OH``, ``US_OK``,
-            ``US_OR``, ``US_PA``, ``US_RI``, ``US_SC``, ``US_SD``,
-            ``US_TN``, ``US_TX``, ``US_UT``, ``US_VA``, ``US_VT``,
-            ``US_WA``, ``US_WI``, ``US_WV``, ``US_WY``).
+        :param g: Location (one of ``'GLOBAL'``, ``'AR'``, ``'AU'``, ``'BG'``,
+            ``'CA'``, ``'CL'``, ``'CO'``, ``'CZ'``, ``'FI'``, ``'GB'``,
+            ``'GR'``, ``'HR'``, ``'HU'``, ``'IE'``, ``'IN'``, ``'IS'``,
+            ``'JP'``, ``'MX'``, ``'MY'``, ``'NZ'``, ``'PH'``, ``'PL'``,
+            ``'PR'``, ``'PT'``, ``'RO'``, ``'RS'``, ``'SE'``, ``'SG'``,
+            ``'TH'``, ``'TR'``, ``'TW'``, ``'US'``, ``'US_AK'``, ``'US_AL'``,
+            ``'US_AR'``, ``'US_AZ'``, ``'US_CA'``, ``'US_CO'``, ``'US_CT'``,
+            ``'US_DC'``, ``'US_DE'``, ``'US_FL'``, ``'US_GA'``, ``'US_HI'``,
+            ``'US_IA'``, ``'US_ID'``, ``'US_IL'``, ``'US_IN'``, ``'US_KS'``,
+            ``'US_KY'``, ``'US_LA'``, ``'US_MA'``, ``'US_MD'``, ``'US_ME'``,
+            ``'US_MI'``, ``'US_MN'``, ``'US_MO'``, ``'US_MS'``, ``'US_MT'``,
+            ``'US_NC'``, ``'US_ND'``, ``'US_NE'``, ``'US_NH'``, ``'US_NJ'``,
+            ``'US_NM'``, ``'US_NV'``, ``'US_NY'``, ``'US_OH'``, ``'US_OK'``,
+            ``'US_OR'``, ``'US_PA'``, ``'US_RI'``, ``'US_SC'``, ``'US_SD'``,
+            ``'US_TN'``, ``'US_TX'``, ``'US_UT'``, ``'US_VA'``, ``'US_VT'``,
+            ``'US_WA'``, ``'US_WI'``, ``'US_WV'``, ``'US_WY'``).
         :param hide_ads: Hide ads (boolean).
         :param hide_downs: Don't show me submissions after I've downvoted them,
             except my own (boolean).
@@ -105,10 +105,10 @@ class Preferences:
             (boolean).
         :param mark_messages_read: Mark messages as read when I open my inbox
             (boolean).
-        :param media: Thumbnail preference (one of ``on``, ``off``,
-            ``subreddit``).
-        :param media_preview: Media preview preference (one of ``on``,
-            ``off``, ``subreddit``).
+        :param media: Thumbnail preference (one of ``'on'``, ``'off'``,
+            ``'subreddit'``).
+        :param media_preview: Media preview preference (one of ``'on'``,
+            ``'off'``, ``'subreddit'``).
         :param min_comment_score: Don't show me comments with a score less than
             this number (int between ``-100`` and ``100``).
         :param min_link_score: Don't show me submissions with a score less than

--- a/praw/models/reddit/emoji.py
+++ b/praw/models/reddit/emoji.py
@@ -81,7 +81,7 @@ class Emoji(RedditBase):
     def delete(self):
         """Delete an emoji from this subreddit by Emoji.
 
-        To delete ``test`` as an emoji on the subreddit ``praw_test`` try:
+        To delete ``'test'`` as an emoji on the subreddit ``'praw_test'`` try:
 
         .. code-block:: python
 

--- a/praw/models/reddit/emoji.py
+++ b/praw/models/reddit/emoji.py
@@ -81,7 +81,7 @@ class Emoji(RedditBase):
     def delete(self):
         """Delete an emoji from this subreddit by Emoji.
 
-        To delete ``'test'`` as an emoji on the subreddit ``'praw_test'`` try:
+        To delete ``"test"`` as an emoji on the subreddit ``"praw_test"`` try:
 
         .. code-block:: python
 

--- a/praw/models/reddit/live.py
+++ b/praw/models/reddit/live.py
@@ -77,14 +77,13 @@ class LiveContributorRelationship:
     ):
         """Invite a redditor to be a contributor of the live thread.
 
-        :param redditor: A redditor name (e.g., ``spez``) or
+        :param redditor: A redditor name (e.g., ``'spez'``) or
             :class:`~.Redditor` instance.
         :param permissions: When provided (not ``None``), permissions should
             be a list of strings specifying which subset of permissions to
             grant. An empty list ``[]`` indicates no permissions, and when
             not provided (``None``), indicates full permissions.
-        :raises: :class:`praw.exceptions.RedditAPIException` if the invitation
-            already exists.
+        :raises: :class:`.RedditAPIException` if the invitation already exists.
 
         Usage:
 
@@ -125,7 +124,7 @@ class LiveContributorRelationship:
     def remove(self, redditor: Union[str, Redditor]):
         """Remove the redditor from the live thread contributors.
 
-        :param redditor: A redditor fullname (e.g., ``t2_1w72``) or
+        :param redditor: A redditor fullname (e.g., ``'t2_1w72'``) or
             :class:`~.Redditor` instance.
 
         Usage:
@@ -149,7 +148,7 @@ class LiveContributorRelationship:
     def remove_invite(self, redditor: Union[str, Redditor]):
         """Remove the invite for redditor.
 
-        :param redditor: A redditor fullname (e.g., ``t2_1w72``) or
+        :param redditor: A redditor fullname (e.g., ``'t2_1w72'``) or
             :class:`~.Redditor` instance.
 
         Usage:
@@ -180,7 +179,7 @@ class LiveContributorRelationship:
     ):
         """Update the contributor permissions for ``redditor``.
 
-        :param redditor: A redditor name (e.g., ``spez``) or
+        :param redditor: A redditor name (e.g., ``'spez'``) or
             :class:`~.Redditor` instance.
         :param permissions: When provided (not ``None``), permissions should
             be a list of strings specifying which subset of permissions to
@@ -224,7 +223,7 @@ class LiveContributorRelationship:
     ):
         """Update the contributor invite permissions for ``redditor``.
 
-        :param redditor: A redditor name (e.g., ``spez``) or
+        :param redditor: A redditor name (e.g., ``'spez'``) or
             :class:`~.Redditor` instance.
         :param permissions: When provided (not ``None``), permissions should
             be a list of strings specifying which subset of permissions to
@@ -336,7 +335,7 @@ class LiveThread(RedditBase):
         """Return a lazy :class:`.LiveUpdate` instance.
 
         :param update_id: A live update ID, e.g.,
-            ``7827987a-c998-11e4-a0b9-22000b6a88d2``.
+            ``'7827987a-c998-11e4-a0b9-22000b6a88d2'``.
 
         Usage:
 
@@ -365,7 +364,7 @@ class LiveThread(RedditBase):
         """Initialize a lazy :class:`.LiveThread` instance.
 
         :param reddit: An instance of :class:`.Reddit`.
-        :param id: A live thread ID, e.g., ``ukaeu1ik4sw5``
+        :param id: A live thread ID, e.g., ``'ukaeu1ik4sw5'``
         """
         if bool(id) == bool(_data):
             raise TypeError("Either `id` or `_data` must be provided.")
@@ -416,9 +415,9 @@ class LiveThread(RedditBase):
     def report(self, type: str):  # pylint: disable=redefined-builtin
         """Report the thread violating the Reddit rules.
 
-        :param type: One of ``spam``, ``vote-manipulation``,
-            ``personal-information``, ``sexualizing-minors``,
-            ``site-breaking``.
+        :param type: One of ``'spam'``, ``'vote-manipulation'``,
+            ``'personal-information'``, ``'sexualizing-minors'``,
+            ``'site-breaking'``.
 
         Usage:
 
@@ -635,9 +634,9 @@ class LiveUpdate(FullnameMixin, RedditBase):
         provided.
 
         :param reddit: An instance of :class:`.Reddit`.
-        :param thread_id: A live thread ID, e.g., ``ukaeu1ik4sw5``.
+        :param thread_id: A live thread ID, e.g., ``'ukaeu1ik4sw5'``.
         :param update_id: A live update ID, e.g.,
-            ``7827987a-c998-11e4-a0b9-22000b6a88d2``.
+            ``'7827987a-c998-11e4-a0b9-22000b6a88d2'``.
 
         Usage:
 

--- a/praw/models/reddit/live.py
+++ b/praw/models/reddit/live.py
@@ -77,7 +77,7 @@ class LiveContributorRelationship:
     ):
         """Invite a redditor to be a contributor of the live thread.
 
-        :param redditor: A redditor name (e.g., ``'spez'``) or
+        :param redditor: A redditor name (e.g., ``"spez"``) or
             :class:`~.Redditor` instance.
         :param permissions: When provided (not ``None``), permissions should
             be a list of strings specifying which subset of permissions to
@@ -124,7 +124,7 @@ class LiveContributorRelationship:
     def remove(self, redditor: Union[str, Redditor]):
         """Remove the redditor from the live thread contributors.
 
-        :param redditor: A redditor fullname (e.g., ``'t2_1w72'``) or
+        :param redditor: A redditor fullname (e.g., ``"t2_1w72"``) or
             :class:`~.Redditor` instance.
 
         Usage:
@@ -148,7 +148,7 @@ class LiveContributorRelationship:
     def remove_invite(self, redditor: Union[str, Redditor]):
         """Remove the invite for redditor.
 
-        :param redditor: A redditor fullname (e.g., ``'t2_1w72'``) or
+        :param redditor: A redditor fullname (e.g., ``"t2_1w72"``) or
             :class:`~.Redditor` instance.
 
         Usage:
@@ -179,7 +179,7 @@ class LiveContributorRelationship:
     ):
         """Update the contributor permissions for ``redditor``.
 
-        :param redditor: A redditor name (e.g., ``'spez'``) or
+        :param redditor: A redditor name (e.g., ``"spez"``) or
             :class:`~.Redditor` instance.
         :param permissions: When provided (not ``None``), permissions should
             be a list of strings specifying which subset of permissions to
@@ -223,7 +223,7 @@ class LiveContributorRelationship:
     ):
         """Update the contributor invite permissions for ``redditor``.
 
-        :param redditor: A redditor name (e.g., ``'spez'``) or
+        :param redditor: A redditor name (e.g., ``"spez"``) or
             :class:`~.Redditor` instance.
         :param permissions: When provided (not ``None``), permissions should
             be a list of strings specifying which subset of permissions to
@@ -335,7 +335,7 @@ class LiveThread(RedditBase):
         """Return a lazy :class:`.LiveUpdate` instance.
 
         :param update_id: A live update ID, e.g.,
-            ``'7827987a-c998-11e4-a0b9-22000b6a88d2'``.
+            ``"7827987a-c998-11e4-a0b9-22000b6a88d2"``.
 
         Usage:
 
@@ -364,7 +364,7 @@ class LiveThread(RedditBase):
         """Initialize a lazy :class:`.LiveThread` instance.
 
         :param reddit: An instance of :class:`.Reddit`.
-        :param id: A live thread ID, e.g., ``'ukaeu1ik4sw5'``
+        :param id: A live thread ID, e.g., ``"ukaeu1ik4sw5"``
         """
         if bool(id) == bool(_data):
             raise TypeError("Either `id` or `_data` must be provided.")
@@ -415,9 +415,9 @@ class LiveThread(RedditBase):
     def report(self, type: str):  # pylint: disable=redefined-builtin
         """Report the thread violating the Reddit rules.
 
-        :param type: One of ``'spam'``, ``'vote-manipulation'``,
-            ``'personal-information'``, ``'sexualizing-minors'``,
-            ``'site-breaking'``.
+        :param type: One of ``"spam"``, ``"vote-manipulation"``,
+            ``"personal-information"``, ``"sexualizing-minors"``,
+            ``"site-breaking"``.
 
         Usage:
 
@@ -634,9 +634,9 @@ class LiveUpdate(FullnameMixin, RedditBase):
         provided.
 
         :param reddit: An instance of :class:`.Reddit`.
-        :param thread_id: A live thread ID, e.g., ``'ukaeu1ik4sw5'``.
+        :param thread_id: A live thread ID, e.g., ``"ukaeu1ik4sw5"``.
         :param update_id: A live update ID, e.g.,
-            ``'7827987a-c998-11e4-a0b9-22000b6a88d2'``.
+            ``"7827987a-c998-11e4-a0b9-22000b6a88d2"``.
 
         Usage:
 

--- a/praw/models/reddit/multi.py
+++ b/praw/models/reddit/multi.py
@@ -235,7 +235,7 @@ class Multireddit(SubredditListingMixin, RedditBase):
             ``models pinup``, ``music``, ``news``, ``philosophy``, ``pictures
             and gifs``, ``science``, ``shopping``, ``sports``, ``style``,
             ``tech``, ``travel``, ``unusual stories``, ``video``, or ``None``.
-        :param key_color: RGB hex color code of the form ``'#FFFFFF'``.
+        :param key_color: RGB hex color code of the form ``"#FFFFFF"``.
         :param visibility: Can be one of: ``hidden``, ``private``, ``public``.
         :param weighting_scheme: Can be one of: ``classic``, ``fresh``.
 

--- a/praw/models/reddit/multi.py
+++ b/praw/models/reddit/multi.py
@@ -235,7 +235,7 @@ class Multireddit(SubredditListingMixin, RedditBase):
             ``models pinup``, ``music``, ``news``, ``philosophy``, ``pictures
             and gifs``, ``science``, ``shopping``, ``sports``, ``style``,
             ``tech``, ``travel``, ``unusual stories``, ``video``, or ``None``.
-        :param key_color: RGB hex color code of the form ``#FFFFFF``.
+        :param key_color: RGB hex color code of the form ``'#FFFFFF'``.
         :param visibility: Can be one of: ``hidden``, ``private``, ``public``.
         :param weighting_scheme: Can be one of: ``classic``, ``fresh``.
 

--- a/praw/models/reddit/removal_reasons.py
+++ b/praw/models/reddit/removal_reasons.py
@@ -69,7 +69,7 @@ class RemovalReason(RedditBase):
     def delete(self):
         """Delete a removal reason from this subreddit.
 
-        To delete ``141vv5c16py7d`` from the subreddit ``NAME`` try:
+        To delete ``'141vv5c16py7d'`` from the subreddit ``'NAME'`` try:
 
         .. code-block:: python
 
@@ -87,7 +87,7 @@ class RemovalReason(RedditBase):
         :param message: The removal reason's new message (required).
         :param title: The removal reason's new title (required).
 
-        To update ``141vv5c16py7d`` from the subreddit ``NAME`` try:
+        To update ``'141vv5c16py7d'`` from the subreddit ``'NAME'`` try:
 
         .. code-block:: python
 
@@ -160,7 +160,7 @@ class SubredditRemovalReasons:
 
         The message will be prepended with `Hi u/username,` automatically.
 
-        To add ``Test`` to the subreddit ``NAME`` try:
+        To add ``'Test'`` to the subreddit ``'NAME'`` try:
 
         .. code-block:: python
 

--- a/praw/models/reddit/removal_reasons.py
+++ b/praw/models/reddit/removal_reasons.py
@@ -69,7 +69,7 @@ class RemovalReason(RedditBase):
     def delete(self):
         """Delete a removal reason from this subreddit.
 
-        To delete ``'141vv5c16py7d'`` from the subreddit ``'NAME'`` try:
+        To delete ``"141vv5c16py7d"`` from the subreddit ``"NAME"`` try:
 
         .. code-block:: python
 
@@ -87,7 +87,7 @@ class RemovalReason(RedditBase):
         :param message: The removal reason's new message (required).
         :param title: The removal reason's new title (required).
 
-        To update ``'141vv5c16py7d'`` from the subreddit ``'NAME'`` try:
+        To update ``"141vv5c16py7d"`` from the subreddit ``"NAME"`` try:
 
         .. code-block:: python
 
@@ -160,7 +160,7 @@ class SubredditRemovalReasons:
 
         The message will be prepended with `Hi u/username,` automatically.
 
-        To add ``'Test'`` to the subreddit ``'NAME'`` try:
+        To add ``"Test"`` to the subreddit ``"NAME"`` try:
 
         .. code-block:: python
 

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -1335,7 +1335,7 @@ class SubredditFlair:
     def delete(self, redditor):
         """Delete flair for a Redditor.
 
-        :param redditor: A redditor name (e.g., ``spez``) or
+        :param redditor: A redditor name (e.g., ``'spez'``) or
             :class:`~.Redditor` instance.
 
         .. seealso::
@@ -1359,7 +1359,7 @@ class SubredditFlair:
     def set(self, redditor, text="", css_class="", flair_template_id=None):
         """Set flair for a Redditor.
 
-        :param redditor: (Required) A redditor name (e.g., ``spez``) or
+        :param redditor: (Required) A redditor name (e.g., ``'spez'``) or
             :class:`~.Redditor` instance.
         :param text: The flair text to associate with the Redditor or
             Submission (default: '').
@@ -1545,13 +1545,13 @@ class SubredditFlairTemplates:
         :param background_color: The flair template's new background color,
             as a hex color.
         :param text_color: The flair template's new text color, either
-            ``light`` or ``dark``.
+            ``'light'`` or ``'dark'``.
         :param mod_only: (boolean) Indicate if the flair can only be used by
             moderators.
-        :param allowable_content: If specified, most be one of ``all``,
-            ``emoji``, or ``text`` to restrict content to that type.
-            If set to ``emoji`` then the ``text`` param must be a
-            valid emoji string, for example ``:snoo:``.
+        :param allowable_content: If specified, most be one of ``'all'``,
+            ``'emoji'``, or ``'text'`` to restrict content to that type.
+            If set to ``'emoji'`` then the ``'text'`` param must be a
+            valid emoji string, for example ``':snoo:'``.
         :param max_emojis: (int) Maximum emojis in the flair
             (Reddit defaults this value to 10).
         :param fetch: Whether or not PRAW will fetch existing information on
@@ -1640,13 +1640,13 @@ class SubredditRedditorFlairTemplates(SubredditFlairTemplates):
         :param background_color: The flair template's new background color,
             as a hex color.
         :param text_color: The flair template's new text color, either
-            ``light`` or ``dark``.
+            ``'light'`` or ``'dark'``.
         :param mod_only: (boolean) Indicate if the flair can only be used by
             moderators.
-        :param allowable_content: If specified, most be one of ``all``,
-            ``emoji``, or ``text`` to restrict content to that type.
-            If set to ``emoji`` then the ``text`` param must be a
-            valid emoji string, for example ``:snoo:``.
+        :param allowable_content: If specified, most be one of ``'all'``,
+            ``'emoji'``, or ``'text'`` to restrict content to that type.
+            If set to ``'emoji'`` then the ``'text'`` param must be a
+            valid emoji string, for example ``':snoo:'``.
         :param max_emojis: (int) Maximum emojis in the flair
             (Reddit defaults this value to 10).
 
@@ -1721,13 +1721,13 @@ class SubredditLinkFlairTemplates(SubredditFlairTemplates):
         :param background_color: The flair template's new background color,
             as a hex color.
         :param text_color: The flair template's new text color, either
-            ``light`` or ``dark``.
+            ``'light'`` or ``'dark'``.
         :param mod_only: (boolean) Indicate if the flair can only be used by
             moderators.
-        :param allowable_content: If specified, most be one of ``all``,
-            ``emoji``, or ``text`` to restrict content to that type.
-            If set to ``emoji`` then the ``text`` param must be a
-            valid emoji string, for example ``:snoo:``.
+        :param allowable_content: If specified, most be one of ``'all'``,
+            ``'emoji'``, or ``'text'`` to restrict content to that type.
+            If set to ``'emoji'`` then the ``'text'`` param must be a
+            valid emoji string, for example ``':snoo:'``.
         :param max_emojis: (int) Maximum emojis in the flair
             (Reddit defaults this value to 10).
 
@@ -1801,7 +1801,7 @@ class SubredditModeration:
     def edited(self, only=None, **generator_kwargs):
         """Return a :class:`.ListingGenerator` for edited comments and submissions.
 
-        :param only: If specified, one of ``comments``, or ``submissions``
+        :param only: If specified, one of ``'comments'``, or ``'submissions'``
             to yield only results of that type.
 
         Additional keyword arguments are passed in the initialization of
@@ -1876,7 +1876,7 @@ class SubredditModeration:
     def modqueue(self, only=None, **generator_kwargs):
         """Return a :class:`.ListingGenerator` for modqueue items.
 
-        :param only: If specified, one of ``comments``, or ``submissions``
+        :param only: If specified, one of ``'comments'``, or ``'submissions'``
             to yield only results of that type.
 
         Additional keyword arguments are passed in the initialization of
@@ -1942,7 +1942,7 @@ class SubredditModeration:
     def reports(self, only=None, **generator_kwargs):
         """Return a :class:`.ListingGenerator` for reported comments and submissions.
 
-        :param only: If specified, one of ``comments``, or ``submissions``
+        :param only: If specified, one of ``'comments'``, or ``'submissions'``
             to yield only results of that type.
 
         Additional keyword arguments are passed in the initialization of
@@ -1972,7 +1972,7 @@ class SubredditModeration:
     def spam(self, only=None, **generator_kwargs):
         """Return a :class:`.ListingGenerator` for spam comments and submissions.
 
-        :param only: If specified, one of ``comments``, or ``submissions``
+        :param only: If specified, one of ``'comments'``, or ``'submissions'``
             to yield only results of that type.
 
         Additional keyword arguments are passed in the initialization of
@@ -2070,7 +2070,7 @@ class SubredditModeration:
         :param header_hover_text: The text seen when hovering over the snoo.
         :param hide_ads: Don't show ads within this subreddit. Only applies to
             Premium-user only subreddits.
-        :param key_color: A 6-digit rgb hex color (e.g. ``#AABBCC``), used as
+        :param key_color: A 6-digit rgb hex color (e.g. ``'#AABBCC'``), used as
             a thematic color for your subreddit on mobile.
         :param lang: A valid IETF language tag (underscore separated).
         :param link_type: The types of submissions users can make.
@@ -2162,7 +2162,7 @@ class SubredditModerationStream:
     def edited(self, only=None, **stream_options):
         """Yield edited comments and submissions as they become available.
 
-        :param only: If specified, one of ``comments``, or ``submissions``
+        :param only: If specified, one of ``'comments'``, or ``'submissions'``
             to yield only results of that type.
 
         Keyword arguments are passed to :func:`.stream_generator`.
@@ -2244,7 +2244,7 @@ class SubredditModerationStream:
     def modqueue(self, only=None, **stream_options):
         """Yield comments/submissions in the modqueue as they become available.
 
-        :param only: If specified, one of ``comments``, or ``submissions``
+        :param only: If specified, one of ``'comments'``, or ``'submissions'``
             to yield only results of that type.
 
         Keyword arguments are passed to :func:`.stream_generator`.
@@ -2264,7 +2264,7 @@ class SubredditModerationStream:
     def reports(self, only=None, **stream_options):
         """Yield reported comments and submissions as they become available.
 
-        :param only: If specified, one of ``comments``, or ``submissions``
+        :param only: If specified, one of ``'comments'``, or ``'submissions'``
             to yield only results of that type.
 
         Keyword arguments are passed to :func:`.stream_generator`.
@@ -2284,7 +2284,7 @@ class SubredditModerationStream:
     def spam(self, only=None, **stream_options):
         """Yield spam comments and submissions as they become available.
 
-        :param only: If specified, one of ``comments``, or ``submissions``
+        :param only: If specified, one of ``'comments'``, or ``'submissions'``
             to yield only results of that type.
 
         Keyword arguments are passed to :func:`.stream_generator`.
@@ -2450,7 +2450,7 @@ class SubredditRelationship:
     def add(self, redditor, **other_settings):
         """Add ``redditor`` to this relationship.
 
-        :param redditor: A redditor name (e.g., ``spez``) or
+        :param redditor: A redditor name (e.g., ``'spez'``) or
             :class:`~.Redditor` instance.
 
         """
@@ -2462,7 +2462,7 @@ class SubredditRelationship:
     def remove(self, redditor):
         """Remove ``redditor`` from this relationship.
 
-        :param redditor: A redditor name (e.g., ``spez``) or
+        :param redditor: A redditor name (e.g., ``'spez'``) or
             :class:`~.Redditor` instance.
 
         """
@@ -2551,7 +2551,7 @@ class ModeratorRelationship(SubredditRelationship):
     def add(self, redditor, permissions=None, **other_settings):
         """Add or invite ``redditor`` to be a moderator of the subreddit.
 
-        :param redditor: A redditor name (e.g., ``spez``) or
+        :param redditor: A redditor name (e.g., ``'spez'``) or
             :class:`~.Redditor` instance.
         :param permissions: When provided (not ``None``), permissions should be
             a list of strings specifying which subset of permissions to
@@ -2561,7 +2561,7 @@ class ModeratorRelationship(SubredditRelationship):
         An invite will be sent unless the user making this call is an admin
         user.
 
-        For example, to invite ``spez`` with ``posts`` and ``mail``
+        For example, to invite ``'spez'`` with ``'posts'`` and ``'mail'``
         permissions to ``r/test``, try:
 
         .. code-block:: python
@@ -2577,14 +2577,14 @@ class ModeratorRelationship(SubredditRelationship):
     def invite(self, redditor, permissions=None, **other_settings):
         """Invite ``redditor`` to be a moderator of the subreddit.
 
-        :param redditor: A redditor name (e.g., ``spez``) or
+        :param redditor: A redditor name (e.g., ``'spez'``) or
             :class:`~.Redditor` instance.
         :param permissions: When provided (not ``None``), permissions should be
             a list of strings specifying which subset of permissions to
             grant. An empty list ``[]`` indicates no permissions, and when not
             provided ``None``, indicates full permissions.
 
-        For example, to invite ``spez`` with ``posts`` and ``mail``
+        For example, to invite ``'spez'`` with ``posts`` and ``mail``
             permissions to ``r/test``, try:
 
         .. code-block:: python
@@ -2612,7 +2612,7 @@ class ModeratorRelationship(SubredditRelationship):
     def remove_invite(self, redditor):
         """Remove the moderator invite for ``redditor``.
 
-        :param redditor: A redditor name (e.g., ``spez``) or
+        :param redditor: A redditor name (e.g., ``'spez'``) or
             :class:`~.Redditor` instance.
 
         For example:
@@ -2629,7 +2629,7 @@ class ModeratorRelationship(SubredditRelationship):
     def update(self, redditor, permissions=None):
         """Update the moderator permissions for ``redditor``.
 
-        :param redditor: A redditor name (e.g., ``spez``) or
+        :param redditor: A redditor name (e.g., ``'spez'``) or
             :class:`~.Redditor` instance.
         :param permissions: When provided (not ``None``), permissions should be
             a list of strings specifying which subset of permissions to
@@ -2658,7 +2658,7 @@ class ModeratorRelationship(SubredditRelationship):
     def update_invite(self, redditor, permissions=None):
         """Update the moderator invite permissions for ``redditor``.
 
-        :param redditor: A redditor name (e.g., ``spez``) or
+        :param redditor: A redditor name (e.g., ``'spez'``) or
             :class:`~.Redditor` instance.
         :param permissions: When provided (not ``None``), permissions should be
             a list of strings specifying which subset of permissions to
@@ -3452,7 +3452,7 @@ class SubredditWiki:
         Additional keyword arguments are passed in the initialization of
         :class:`.ListingGenerator`.
 
-        To view the wiki revisions for ``praw_test`` in ``r/test`` try:
+        To view the wiki revisions for ``'praw_test'`` in ``r/test`` try:
 
         .. code-block:: python
 

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -799,7 +799,7 @@ class Subreddit(
 
         :param title: The title of the submission.
         :param selftext: The Markdown formatted content for a ``text``
-            submission. Use an empty string, ``''``, to make a title-only
+            submission. Use an empty string, ``""``, to make a title-only
             submission.
         :param url: The URL for a ``link`` submission.
         :param collection_id: The UUID of a :class:`.Collection` to add the
@@ -1335,7 +1335,7 @@ class SubredditFlair:
     def delete(self, redditor):
         """Delete flair for a Redditor.
 
-        :param redditor: A redditor name (e.g., ``'spez'``) or
+        :param redditor: A redditor name (e.g., ``"spez"``) or
             :class:`~.Redditor` instance.
 
         .. seealso::
@@ -1359,7 +1359,7 @@ class SubredditFlair:
     def set(self, redditor, text="", css_class="", flair_template_id=None):
         """Set flair for a Redditor.
 
-        :param redditor: (Required) A redditor name (e.g., ``'spez'``) or
+        :param redditor: (Required) A redditor name (e.g., ``"spez"``) or
             :class:`~.Redditor` instance.
         :param text: The flair text to associate with the Redditor or
             Submission (default: '').
@@ -1545,13 +1545,13 @@ class SubredditFlairTemplates:
         :param background_color: The flair template's new background color,
             as a hex color.
         :param text_color: The flair template's new text color, either
-            ``'light'`` or ``'dark'``.
+            ``"light"`` or ``"dark"``.
         :param mod_only: (boolean) Indicate if the flair can only be used by
             moderators.
-        :param allowable_content: If specified, most be one of ``'all'``,
-            ``'emoji'``, or ``'text'`` to restrict content to that type.
-            If set to ``'emoji'`` then the ``'text'`` param must be a
-            valid emoji string, for example ``':snoo:'``.
+        :param allowable_content: If specified, most be one of ``"all"``,
+            ``"emoji"``, or ``"text"`` to restrict content to that type.
+            If set to ``"emoji"`` then the ``"text"`` param must be a
+            valid emoji string, for example ``":snoo:"``.
         :param max_emojis: (int) Maximum emojis in the flair
             (Reddit defaults this value to 10).
         :param fetch: Whether or not PRAW will fetch existing information on
@@ -1640,13 +1640,13 @@ class SubredditRedditorFlairTemplates(SubredditFlairTemplates):
         :param background_color: The flair template's new background color,
             as a hex color.
         :param text_color: The flair template's new text color, either
-            ``'light'`` or ``'dark'``.
+            ``"light"`` or ``"dark"``.
         :param mod_only: (boolean) Indicate if the flair can only be used by
             moderators.
-        :param allowable_content: If specified, most be one of ``'all'``,
-            ``'emoji'``, or ``'text'`` to restrict content to that type.
-            If set to ``'emoji'`` then the ``'text'`` param must be a
-            valid emoji string, for example ``':snoo:'``.
+        :param allowable_content: If specified, most be one of ``"all"``,
+            ``"emoji"``, or ``"text"`` to restrict content to that type.
+            If set to ``"emoji"`` then the ``"text"`` param must be a
+            valid emoji string, for example ``":snoo:"``.
         :param max_emojis: (int) Maximum emojis in the flair
             (Reddit defaults this value to 10).
 
@@ -1721,13 +1721,13 @@ class SubredditLinkFlairTemplates(SubredditFlairTemplates):
         :param background_color: The flair template's new background color,
             as a hex color.
         :param text_color: The flair template's new text color, either
-            ``'light'`` or ``'dark'``.
+            ``"light"`` or ``"dark"``.
         :param mod_only: (boolean) Indicate if the flair can only be used by
             moderators.
-        :param allowable_content: If specified, most be one of ``'all'``,
-            ``'emoji'``, or ``'text'`` to restrict content to that type.
-            If set to ``'emoji'`` then the ``'text'`` param must be a
-            valid emoji string, for example ``':snoo:'``.
+        :param allowable_content: If specified, most be one of ``"all"``,
+            ``"emoji"``, or ``"text"`` to restrict content to that type.
+            If set to ``"emoji"`` then the ``"text"`` param must be a
+            valid emoji string, for example ``":snoo:"``.
         :param max_emojis: (int) Maximum emojis in the flair
             (Reddit defaults this value to 10).
 
@@ -1801,7 +1801,7 @@ class SubredditModeration:
     def edited(self, only=None, **generator_kwargs):
         """Return a :class:`.ListingGenerator` for edited comments and submissions.
 
-        :param only: If specified, one of ``'comments'``, or ``'submissions'``
+        :param only: If specified, one of ``"comments"``, or ``"submissions"``
             to yield only results of that type.
 
         Additional keyword arguments are passed in the initialization of
@@ -1876,7 +1876,7 @@ class SubredditModeration:
     def modqueue(self, only=None, **generator_kwargs):
         """Return a :class:`.ListingGenerator` for modqueue items.
 
-        :param only: If specified, one of ``'comments'``, or ``'submissions'``
+        :param only: If specified, one of ``"comments"``, or ``"submissions"``
             to yield only results of that type.
 
         Additional keyword arguments are passed in the initialization of
@@ -1942,7 +1942,7 @@ class SubredditModeration:
     def reports(self, only=None, **generator_kwargs):
         """Return a :class:`.ListingGenerator` for reported comments and submissions.
 
-        :param only: If specified, one of ``'comments'``, or ``'submissions'``
+        :param only: If specified, one of ``"comments"``, or ``"submissions"``
             to yield only results of that type.
 
         Additional keyword arguments are passed in the initialization of
@@ -1972,7 +1972,7 @@ class SubredditModeration:
     def spam(self, only=None, **generator_kwargs):
         """Return a :class:`.ListingGenerator` for spam comments and submissions.
 
-        :param only: If specified, one of ``'comments'``, or ``'submissions'``
+        :param only: If specified, one of ``"comments"``, or ``"submissions"``
             to yield only results of that type.
 
         Additional keyword arguments are passed in the initialization of
@@ -2070,7 +2070,7 @@ class SubredditModeration:
         :param header_hover_text: The text seen when hovering over the snoo.
         :param hide_ads: Don't show ads within this subreddit. Only applies to
             Premium-user only subreddits.
-        :param key_color: A 6-digit rgb hex color (e.g. ``'#AABBCC'``), used as
+        :param key_color: A 6-digit rgb hex color (e.g. ``"#AABBCC"``), used as
             a thematic color for your subreddit on mobile.
         :param lang: A valid IETF language tag (underscore separated).
         :param link_type: The types of submissions users can make.
@@ -2162,7 +2162,7 @@ class SubredditModerationStream:
     def edited(self, only=None, **stream_options):
         """Yield edited comments and submissions as they become available.
 
-        :param only: If specified, one of ``'comments'``, or ``'submissions'``
+        :param only: If specified, one of ``"comments"``, or ``"submissions"``
             to yield only results of that type.
 
         Keyword arguments are passed to :func:`.stream_generator`.
@@ -2244,7 +2244,7 @@ class SubredditModerationStream:
     def modqueue(self, only=None, **stream_options):
         """Yield comments/submissions in the modqueue as they become available.
 
-        :param only: If specified, one of ``'comments'``, or ``'submissions'``
+        :param only: If specified, one of ``"comments"``, or ``"submissions"``
             to yield only results of that type.
 
         Keyword arguments are passed to :func:`.stream_generator`.
@@ -2264,7 +2264,7 @@ class SubredditModerationStream:
     def reports(self, only=None, **stream_options):
         """Yield reported comments and submissions as they become available.
 
-        :param only: If specified, one of ``'comments'``, or ``'submissions'``
+        :param only: If specified, one of ``"comments"``, or ``"submissions"``
             to yield only results of that type.
 
         Keyword arguments are passed to :func:`.stream_generator`.
@@ -2284,7 +2284,7 @@ class SubredditModerationStream:
     def spam(self, only=None, **stream_options):
         """Yield spam comments and submissions as they become available.
 
-        :param only: If specified, one of ``'comments'``, or ``'submissions'``
+        :param only: If specified, one of ``"comments"``, or ``"submissions"``
             to yield only results of that type.
 
         Keyword arguments are passed to :func:`.stream_generator`.
@@ -2450,7 +2450,7 @@ class SubredditRelationship:
     def add(self, redditor, **other_settings):
         """Add ``redditor`` to this relationship.
 
-        :param redditor: A redditor name (e.g., ``'spez'``) or
+        :param redditor: A redditor name (e.g., ``"spez"``) or
             :class:`~.Redditor` instance.
 
         """
@@ -2462,7 +2462,7 @@ class SubredditRelationship:
     def remove(self, redditor):
         """Remove ``redditor`` from this relationship.
 
-        :param redditor: A redditor name (e.g., ``'spez'``) or
+        :param redditor: A redditor name (e.g., ``"spez"``) or
             :class:`~.Redditor` instance.
 
         """
@@ -2551,7 +2551,7 @@ class ModeratorRelationship(SubredditRelationship):
     def add(self, redditor, permissions=None, **other_settings):
         """Add or invite ``redditor`` to be a moderator of the subreddit.
 
-        :param redditor: A redditor name (e.g., ``'spez'``) or
+        :param redditor: A redditor name (e.g., ``"spez"``) or
             :class:`~.Redditor` instance.
         :param permissions: When provided (not ``None``), permissions should be
             a list of strings specifying which subset of permissions to
@@ -2561,7 +2561,7 @@ class ModeratorRelationship(SubredditRelationship):
         An invite will be sent unless the user making this call is an admin
         user.
 
-        For example, to invite ``'spez'`` with ``'posts'`` and ``'mail'``
+        For example, to invite ``"spez"`` with ``"posts"`` and ``"mail"``
         permissions to ``r/test``, try:
 
         .. code-block:: python
@@ -2577,14 +2577,14 @@ class ModeratorRelationship(SubredditRelationship):
     def invite(self, redditor, permissions=None, **other_settings):
         """Invite ``redditor`` to be a moderator of the subreddit.
 
-        :param redditor: A redditor name (e.g., ``'spez'``) or
+        :param redditor: A redditor name (e.g., ``"spez"``) or
             :class:`~.Redditor` instance.
         :param permissions: When provided (not ``None``), permissions should be
             a list of strings specifying which subset of permissions to
             grant. An empty list ``[]`` indicates no permissions, and when not
             provided ``None``, indicates full permissions.
 
-        For example, to invite ``'spez'`` with ``posts`` and ``mail``
+        For example, to invite ``"spez"`` with ``posts`` and ``mail``
             permissions to ``r/test``, try:
 
         .. code-block:: python
@@ -2612,7 +2612,7 @@ class ModeratorRelationship(SubredditRelationship):
     def remove_invite(self, redditor):
         """Remove the moderator invite for ``redditor``.
 
-        :param redditor: A redditor name (e.g., ``'spez'``) or
+        :param redditor: A redditor name (e.g., ``"spez"``) or
             :class:`~.Redditor` instance.
 
         For example:
@@ -2629,7 +2629,7 @@ class ModeratorRelationship(SubredditRelationship):
     def update(self, redditor, permissions=None):
         """Update the moderator permissions for ``redditor``.
 
-        :param redditor: A redditor name (e.g., ``'spez'``) or
+        :param redditor: A redditor name (e.g., ``"spez"``) or
             :class:`~.Redditor` instance.
         :param permissions: When provided (not ``None``), permissions should be
             a list of strings specifying which subset of permissions to
@@ -2658,7 +2658,7 @@ class ModeratorRelationship(SubredditRelationship):
     def update_invite(self, redditor, permissions=None):
         """Update the moderator invite permissions for ``redditor``.
 
-        :param redditor: A redditor name (e.g., ``'spez'``) or
+        :param redditor: A redditor name (e.g., ``"spez"``) or
             :class:`~.Redditor` instance.
         :param permissions: When provided (not ``None``), permissions should be
             a list of strings specifying which subset of permissions to
@@ -3452,7 +3452,7 @@ class SubredditWiki:
         Additional keyword arguments are passed in the initialization of
         :class:`.ListingGenerator`.
 
-        To view the wiki revisions for ``'praw_test'`` in ``r/test`` try:
+        To view the wiki revisions for ``"praw_test"`` in ``r/test`` try:
 
         .. code-block:: python
 

--- a/praw/models/reddit/widgets.py
+++ b/praw/models/reddit/widgets.py
@@ -27,7 +27,7 @@ class Button(PRAWBase):
     ``height``              Image height. Only present on image buttons.
     ``hoverState``          A ``dict`` describing the state of the button when
                             hovered over. Optional.
-    ``kind``                Either ``text`` or ``image``.
+    ``kind``                Either ``'text'`` or ``'image'``.
     ``linkUrl``             A link that can be visited by clicking the button.
                             Only present on image buttons.
     ``text``                The text displayed on the button.
@@ -563,7 +563,7 @@ class SubredditWidgetsModeration:
 
         :param short_name: A name for the widget, no longer than 30 characters.
         :param data: A ``list`` of subreddits. Subreddits can be represented as
-                     ``str`` (e.g. the string ``redditdev``) or as
+                     ``str`` (e.g. the string ``'redditdev'``) or as
                      :class:`.Subreddit` (e.g.
                      ``reddit.subreddit('redditdev')``). These types may be
                      mixed within the list.
@@ -615,12 +615,12 @@ class SubredditWidgetsModeration:
             .. note::
                 As of this writing, Reddit will not accept empty CSS. If you
                 wish to create a custom widget without CSS, consider using
-                ``/**/`` (an empty comment) as your CSS.
+                ``'/**/'`` (an empty comment) as your CSS.
 
         :param height: The height of the widget, between 50 and 500.
         :param image_data: A ``list`` of ``dict``\ s as specified in
             `Reddit docs`_. Each ``dict`` represents an image and has the
-            key ``url`` which maps to the URL of an image hosted on
+            key ``'url'`` which maps to the URL of an image hosted on
             Reddit's servers. Images should be uploaded using
             :meth:`.upload_image`.
 
@@ -677,7 +677,7 @@ class SubredditWidgetsModeration:
 
         :param short_name: A name for the widget, no longer than 30 characters.
         :param data: A ``list`` of ``dict``\ s as specified in `Reddit docs`_.
-            Each ``dict`` has the key ``url`` which maps to the URL
+            Each ``dict`` has the key ``'url'`` which maps to the URL
             of an image hosted on Reddit's servers. Images should
             be uploaded using :meth:`.upload_image`.
 
@@ -779,7 +779,7 @@ class SubredditWidgetsModeration:
         """Add and return a :class:`.PostFlairWidget`.
 
         :param short_name: A name for the widget, no longer than 30 characters.
-        :param display: Display style. Either ``cloud`` or ``list``.
+        :param display: Display style. Either ``'cloud'`` or ``'list'``.
         :param order: A ``list`` of flair template IDs. You can get all flair
             template IDs in a subreddit with:
 
@@ -851,7 +851,7 @@ class SubredditWidgetsModeration:
         :param new_order: A list of widgets. Represented as a ``list`` that
             contains ``Widget`` objects, or widget IDs as strings. These types
             may be mixed.
-        :param section: The section to reorder. (default: ``sidebar``)
+        :param section: The section to reorder. (default: ``'sidebar'``)
 
         Example usage:
 
@@ -1038,10 +1038,10 @@ class ButtonWidget(Widget, BaseList):
     ``description``         The description, in Markdown.
     ``description_html``    The description, in HTML.
     ``id``                  The widget ID.
-    ``kind``                The widget kind (always ``button``).
+    ``kind``                The widget kind (always ``'button'``).
     ``shortName``           The short name of the widget.
-    ``styles``              A ``dict`` with the keys ``backgroundColor`` and
-                            ``headerColor``.
+    ``styles``              A ``dict`` with the keys ``'backgroundColor'`` and
+                            ``'headerColor'``.
     ``subreddit``           The :class:`.Subreddit` the button widget belongs
                             to.
     ======================= ===================================================
@@ -1112,11 +1112,11 @@ class Calendar(Widget):
     ``configuration``       A ``dict`` describing the calendar configuration.
     ``data``                A ``list`` of ``dict``\ s that represent events.
     ``id``                  The widget ID.
-    ``kind``                The widget kind (always ``calendar``).
+    ``kind``                The widget kind (always ``'calendar'``).
     ``requiresSync``        A ``bool``.
     ``shortName``           The short name of the widget.
-    ``styles``              A ``dict`` with the keys ``backgroundColor`` and
-                            ``headerColor``.
+    ``styles``              A ``dict`` with the keys ``'backgroundColor'`` and
+                            ``'headerColor'``.
     ``subreddit``           The :class:`.Subreddit` the button widget belongs
                             to.
     ======================= ===================================================
@@ -1182,10 +1182,10 @@ class CommunityList(Widget, BaseList):
                             :class:`.CommunityList` (e.g. ``for sub in
                             community_list``).
     ``id``                  The widget ID.
-    ``kind``                The widget kind (always ``community-list``).
+    ``kind``                The widget kind (always ``'community-list'``).
     ``shortName``           The short name of the widget.
-    ``styles``              A ``dict`` with the keys ``backgroundColor`` and
-                            ``headerColor``.
+    ``styles``              A ``dict`` with the keys ``'backgroundColor'`` and
+                            ``'headerColor'``.
     ``subreddit``           The :class:`.Subreddit` the button widget belongs
                             to.
     ======================= ===================================================
@@ -1252,10 +1252,10 @@ class CustomWidget(Widget):
     ``id``                  The widget ID.
     ``imageData``           A ``list`` of :class:`.ImageData` that belong to
                             the widget.
-    ``kind``                The widget kind (always ``custom``).
+    ``kind``                The widget kind (always ``'custom'``).
     ``shortName``           The short name of the widget.
-    ``styles``              A ``dict`` with the keys ``backgroundColor`` and
-                            ``headerColor``.
+    ``styles``              A ``dict`` with the keys ``'backgroundColor'`` and
+                            ``'headerColor'``.
     ``stylesheetUrl``       A link to the widget's stylesheet.
     ``subreddit``           The :class:`.Subreddit` the button widget belongs
                             to.
@@ -1303,10 +1303,10 @@ class IDCard(Widget):
                                 example, "users online".
     ``description``             The subreddit description.
     ``id``                      The widget ID.
-    ``kind``                    The widget kind (always ``id-card``).
+    ``kind``                    The widget kind (always ``'id-card'``).
     ``shortName``               The short name of the widget.
-    ``styles``                  A ``dict`` with the keys ``backgroundColor``
-                                and ``headerColor``.
+    ``styles``                  A ``dict`` with the keys ``'backgroundColor'``
+                                and ``'headerColor'``.
     ``subreddit``               The :class:`.Subreddit` the button widget
                                 belongs to.
     ``subscribersCount``        The number of subscribers to the subreddit.
@@ -1378,10 +1378,10 @@ class ImageWidget(Widget, BaseList):
                             :class:`.ImageWidget` (e.g. ``for img in
                             image_widget``).
     ``id``                  The widget ID.
-    ``kind``                The widget kind (always ``image``).
+    ``kind``                The widget kind (always ``'image'``).
     ``shortName``           The short name of the widget.
-    ``styles``              A ``dict`` with the keys ``backgroundColor`` and
-                            ``headerColor``.
+    ``styles``              A ``dict`` with the keys ``'backgroundColor'`` and
+                            ``'headerColor'``.
     ``subreddit``           The :class:`.Subreddit` the button widget belongs
                             to.
     ======================= ===================================================
@@ -1457,7 +1457,7 @@ class Menu(Widget, BaseList):
                             Can be iterated over by iterating over the
                             :class:`.Menu` (e.g. ``for item in menu``).
     ``id``                  The widget ID.
-    ``kind``                The widget kind (always ``menu``).
+    ``kind``                The widget kind (always ``'menu'``).
     ``subreddit``           The :class:`.Subreddit` the button widget belongs
                             to.
     ======================= ===================================================
@@ -1494,13 +1494,13 @@ class ModeratorsWidget(Widget, BaseList):
     Attribute               Description
     ======================= ===================================================
     ``id``                  The widget ID.
-    ``kind``                The widget kind (always ``moderators``).
+    ``kind``                The widget kind (always ``'moderators'``).
     ``mods``                A list of the :class:`.Redditor`\ s that moderate
                             the subreddit. Can be iterated over by iterating
                             over the :class:`.ModeratorsWidget` (e.g. ``for
                             mod in widgets.moderators_widget``).
-    ``styles``              A ``dict`` with the keys ``backgroundColor``
-                            and ``headerColor``.
+    ``styles``              A ``dict`` with the keys ``'backgroundColor'``
+                            and ``'headerColor'``.
     ``subreddit``           The :class:`.Subreddit` the button widget
                             belongs to.
     ``totalMods``           The total number of moderators in the subreddit.
@@ -1573,17 +1573,17 @@ class PostFlairWidget(Widget, BaseList):
     ======================= ===================================================
     Attribute               Description
     ======================= ===================================================
-    ``display``             The display style of the widget, either ``cloud``
-                            or ``list``.
+    ``display``             The display style of the widget, either ``'cloud'``
+                            or ``'list'``.
     ``id``                  The widget ID.
-    ``kind``                The widget kind (always ``post-flair``).
+    ``kind``                The widget kind (always ``'post-flair'``).
     ``order``               A list of the flair IDs in this widget.
                             Can be iterated over by iterating over the
                             :class:`.PostFlairWidget` (e.g. ``for flair_id in
                             post_flair``).
     ``shortName``           The short name of the widget.
-    ``styles``              A ``dict`` with the keys ``backgroundColor`` and
-                            ``headerColor``.
+    ``styles``              A ``dict`` with the keys ``'backgroundColor'`` and
+                            ``'headerColor'``.
     ``subreddit``           The :class:`.Subreddit` the button widget belongs
                             to.
     ``templates``           A ``dict`` that maps flair IDs to ``dict``\ s that
@@ -1630,13 +1630,13 @@ class RulesWidget(Widget, BaseList):
                             Can be iterated over by iterating over the
                             :class:`.RulesWidget` (e.g. ``for rule in
                             rules_widget``).
-    ``display``             The display style of the widget, either ``full``
-                            or ``compact``.
+    ``display``             The display style of the widget, either ``'full'``
+                            or ``'compact'``.
     ``id``                  The widget ID.
-    ``kind``                The widget kind (always ``subreddit-rules``).
+    ``kind``                The widget kind (always ``'subreddit-rules'``).
     ``shortName``           The short name of the widget.
-    ``styles``              A ``dict`` with the keys ``backgroundColor``
-                            and ``headerColor``.
+    ``styles``              A ``dict`` with the keys ``'backgroundColor'``
+                            and ``'headerColor'``.
     ``subreddit``           The :class:`.Subreddit` the button widget
                             belongs to.
     ======================= ===================================================
@@ -1705,10 +1705,10 @@ class TextArea(Widget):
     Attribute               Description
     ======================= ===================================================
     ``id``                  The widget ID.
-    ``kind``                The widget kind (always ``textarea``).
+    ``kind``                The widget kind (always ``'textarea'``).
     ``shortName``           The short name of the widget.
-    ``styles``              A ``dict`` with the keys ``backgroundColor`` and
-                            ``headerColor``.
+    ``styles``              A ``dict`` with the keys ``'backgroundColor'`` and
+                            ``'headerColor'``.
     ``subreddit``           The :class:`.Subreddit` the button widget belongs
                             to.
     ``text``                The widget's text, as Markdown.

--- a/praw/models/reddit/widgets.py
+++ b/praw/models/reddit/widgets.py
@@ -27,7 +27,7 @@ class Button(PRAWBase):
     ``height``              Image height. Only present on image buttons.
     ``hoverState``          A ``dict`` describing the state of the button when
                             hovered over. Optional.
-    ``kind``                Either ``'text'`` or ``'image'``.
+    ``kind``                Either ``"text"`` or ``"image"``.
     ``linkUrl``             A link that can be visited by clicking the button.
                             Only present on image buttons.
     ``text``                The text displayed on the button.
@@ -563,7 +563,7 @@ class SubredditWidgetsModeration:
 
         :param short_name: A name for the widget, no longer than 30 characters.
         :param data: A ``list`` of subreddits. Subreddits can be represented as
-                     ``str`` (e.g. the string ``'redditdev'``) or as
+                     ``str`` (e.g. the string ``"redditdev"``) or as
                      :class:`.Subreddit` (e.g.
                      ``reddit.subreddit('redditdev')``). These types may be
                      mixed within the list.
@@ -571,7 +571,7 @@ class SubredditWidgetsModeration:
                        ``headerColor``, and values of hex colors. For example,
                        ``{'backgroundColor': '#FFFF66', 'headerColor':
                        '#3333EE'}``.
-        :param description: A ``str`` containing Markdown (default: ``''``).
+        :param description: A ``str`` containing Markdown (default: ``""``).
 
         Example usage:
 
@@ -615,12 +615,12 @@ class SubredditWidgetsModeration:
             .. note::
                 As of this writing, Reddit will not accept empty CSS. If you
                 wish to create a custom widget without CSS, consider using
-                ``'/**/'`` (an empty comment) as your CSS.
+                ``"/**/"`` (an empty comment) as your CSS.
 
         :param height: The height of the widget, between 50 and 500.
         :param image_data: A ``list`` of ``dict``\ s as specified in
             `Reddit docs`_. Each ``dict`` represents an image and has the
-            key ``'url'`` which maps to the URL of an image hosted on
+            key ``"url"`` which maps to the URL of an image hosted on
             Reddit's servers. Images should be uploaded using
             :meth:`.upload_image`.
 
@@ -677,7 +677,7 @@ class SubredditWidgetsModeration:
 
         :param short_name: A name for the widget, no longer than 30 characters.
         :param data: A ``list`` of ``dict``\ s as specified in `Reddit docs`_.
-            Each ``dict`` has the key ``'url'`` which maps to the URL
+            Each ``dict`` has the key ``"url"`` which maps to the URL
             of an image hosted on Reddit's servers. Images should
             be uploaded using :meth:`.upload_image`.
 
@@ -779,7 +779,7 @@ class SubredditWidgetsModeration:
         """Add and return a :class:`.PostFlairWidget`.
 
         :param short_name: A name for the widget, no longer than 30 characters.
-        :param display: Display style. Either ``'cloud'`` or ``'list'``.
+        :param display: Display style. Either ``"cloud"`` or ``"list"``.
         :param order: A ``list`` of flair template IDs. You can get all flair
             template IDs in a subreddit with:
 
@@ -851,7 +851,7 @@ class SubredditWidgetsModeration:
         :param new_order: A list of widgets. Represented as a ``list`` that
             contains ``Widget`` objects, or widget IDs as strings. These types
             may be mixed.
-        :param section: The section to reorder. (default: ``'sidebar'``)
+        :param section: The section to reorder. (default: ``"sidebar"``)
 
         Example usage:
 
@@ -1038,10 +1038,10 @@ class ButtonWidget(Widget, BaseList):
     ``description``         The description, in Markdown.
     ``description_html``    The description, in HTML.
     ``id``                  The widget ID.
-    ``kind``                The widget kind (always ``'button'``).
+    ``kind``                The widget kind (always ``"button"``).
     ``shortName``           The short name of the widget.
-    ``styles``              A ``dict`` with the keys ``'backgroundColor'`` and
-                            ``'headerColor'``.
+    ``styles``              A ``dict`` with the keys ``"backgroundColor"`` and
+                            ``"headerColor"``.
     ``subreddit``           The :class:`.Subreddit` the button widget belongs
                             to.
     ======================= ===================================================
@@ -1112,11 +1112,11 @@ class Calendar(Widget):
     ``configuration``       A ``dict`` describing the calendar configuration.
     ``data``                A ``list`` of ``dict``\ s that represent events.
     ``id``                  The widget ID.
-    ``kind``                The widget kind (always ``'calendar'``).
+    ``kind``                The widget kind (always ``"calendar"``).
     ``requiresSync``        A ``bool``.
     ``shortName``           The short name of the widget.
-    ``styles``              A ``dict`` with the keys ``'backgroundColor'`` and
-                            ``'headerColor'``.
+    ``styles``              A ``dict`` with the keys ``"backgroundColor"`` and
+                            ``"headerColor"``.
     ``subreddit``           The :class:`.Subreddit` the button widget belongs
                             to.
     ======================= ===================================================
@@ -1182,10 +1182,10 @@ class CommunityList(Widget, BaseList):
                             :class:`.CommunityList` (e.g. ``for sub in
                             community_list``).
     ``id``                  The widget ID.
-    ``kind``                The widget kind (always ``'community-list'``).
+    ``kind``                The widget kind (always ``"community-list"``).
     ``shortName``           The short name of the widget.
-    ``styles``              A ``dict`` with the keys ``'backgroundColor'`` and
-                            ``'headerColor'``.
+    ``styles``              A ``dict`` with the keys ``"backgroundColor"`` and
+                            ``"headerColor"``.
     ``subreddit``           The :class:`.Subreddit` the button widget belongs
                             to.
     ======================= ===================================================
@@ -1252,10 +1252,10 @@ class CustomWidget(Widget):
     ``id``                  The widget ID.
     ``imageData``           A ``list`` of :class:`.ImageData` that belong to
                             the widget.
-    ``kind``                The widget kind (always ``'custom'``).
+    ``kind``                The widget kind (always ``"custom"``).
     ``shortName``           The short name of the widget.
-    ``styles``              A ``dict`` with the keys ``'backgroundColor'`` and
-                            ``'headerColor'``.
+    ``styles``              A ``dict`` with the keys ``"backgroundColor"`` and
+                            ``"headerColor"``.
     ``stylesheetUrl``       A link to the widget's stylesheet.
     ``subreddit``           The :class:`.Subreddit` the button widget belongs
                             to.
@@ -1303,10 +1303,10 @@ class IDCard(Widget):
                                 example, "users online".
     ``description``             The subreddit description.
     ``id``                      The widget ID.
-    ``kind``                    The widget kind (always ``'id-card'``).
+    ``kind``                    The widget kind (always ``"id-card"``).
     ``shortName``               The short name of the widget.
-    ``styles``                  A ``dict`` with the keys ``'backgroundColor'``
-                                and ``'headerColor'``.
+    ``styles``                  A ``dict`` with the keys ``"backgroundColor"``
+                                and ``"headerColor"``.
     ``subreddit``               The :class:`.Subreddit` the button widget
                                 belongs to.
     ``subscribersCount``        The number of subscribers to the subreddit.
@@ -1378,10 +1378,10 @@ class ImageWidget(Widget, BaseList):
                             :class:`.ImageWidget` (e.g. ``for img in
                             image_widget``).
     ``id``                  The widget ID.
-    ``kind``                The widget kind (always ``'image'``).
+    ``kind``                The widget kind (always ``"image"``).
     ``shortName``           The short name of the widget.
-    ``styles``              A ``dict`` with the keys ``'backgroundColor'`` and
-                            ``'headerColor'``.
+    ``styles``              A ``dict`` with the keys ``"backgroundColor"`` and
+                            ``"headerColor"``.
     ``subreddit``           The :class:`.Subreddit` the button widget belongs
                             to.
     ======================= ===================================================
@@ -1457,7 +1457,7 @@ class Menu(Widget, BaseList):
                             Can be iterated over by iterating over the
                             :class:`.Menu` (e.g. ``for item in menu``).
     ``id``                  The widget ID.
-    ``kind``                The widget kind (always ``'menu'``).
+    ``kind``                The widget kind (always ``"menu"``).
     ``subreddit``           The :class:`.Subreddit` the button widget belongs
                             to.
     ======================= ===================================================
@@ -1494,13 +1494,13 @@ class ModeratorsWidget(Widget, BaseList):
     Attribute               Description
     ======================= ===================================================
     ``id``                  The widget ID.
-    ``kind``                The widget kind (always ``'moderators'``).
+    ``kind``                The widget kind (always ``"moderators"``).
     ``mods``                A list of the :class:`.Redditor`\ s that moderate
                             the subreddit. Can be iterated over by iterating
                             over the :class:`.ModeratorsWidget` (e.g. ``for
                             mod in widgets.moderators_widget``).
-    ``styles``              A ``dict`` with the keys ``'backgroundColor'``
-                            and ``'headerColor'``.
+    ``styles``              A ``dict`` with the keys ``"backgroundColor"``
+                            and ``"headerColor"``.
     ``subreddit``           The :class:`.Subreddit` the button widget
                             belongs to.
     ``totalMods``           The total number of moderators in the subreddit.
@@ -1573,17 +1573,17 @@ class PostFlairWidget(Widget, BaseList):
     ======================= ===================================================
     Attribute               Description
     ======================= ===================================================
-    ``display``             The display style of the widget, either ``'cloud'``
-                            or ``'list'``.
+    ``display``             The display style of the widget, either ``"cloud"``
+                            or ``"list"``.
     ``id``                  The widget ID.
-    ``kind``                The widget kind (always ``'post-flair'``).
+    ``kind``                The widget kind (always ``"post-flair"``).
     ``order``               A list of the flair IDs in this widget.
                             Can be iterated over by iterating over the
                             :class:`.PostFlairWidget` (e.g. ``for flair_id in
                             post_flair``).
     ``shortName``           The short name of the widget.
-    ``styles``              A ``dict`` with the keys ``'backgroundColor'`` and
-                            ``'headerColor'``.
+    ``styles``              A ``dict`` with the keys ``"backgroundColor"`` and
+                            ``"headerColor"``.
     ``subreddit``           The :class:`.Subreddit` the button widget belongs
                             to.
     ``templates``           A ``dict`` that maps flair IDs to ``dict``\ s that
@@ -1630,13 +1630,13 @@ class RulesWidget(Widget, BaseList):
                             Can be iterated over by iterating over the
                             :class:`.RulesWidget` (e.g. ``for rule in
                             rules_widget``).
-    ``display``             The display style of the widget, either ``'full'``
-                            or ``'compact'``.
+    ``display``             The display style of the widget, either ``"full"``
+                            or ``"compact"``.
     ``id``                  The widget ID.
-    ``kind``                The widget kind (always ``'subreddit-rules'``).
+    ``kind``                The widget kind (always ``"subreddit-rules"``).
     ``shortName``           The short name of the widget.
-    ``styles``              A ``dict`` with the keys ``'backgroundColor'``
-                            and ``'headerColor'``.
+    ``styles``              A ``dict`` with the keys ``"backgroundColor"``
+                            and ``"headerColor"``.
     ``subreddit``           The :class:`.Subreddit` the button widget
                             belongs to.
     ======================= ===================================================
@@ -1705,10 +1705,10 @@ class TextArea(Widget):
     Attribute               Description
     ======================= ===================================================
     ``id``                  The widget ID.
-    ``kind``                The widget kind (always ``'textarea'``).
+    ``kind``                The widget kind (always ``"textarea"``).
     ``shortName``           The short name of the widget.
-    ``styles``              A ``dict`` with the keys ``'backgroundColor'`` and
-                            ``'headerColor'``.
+    ``styles``              A ``dict`` with the keys ``"backgroundColor"`` and
+                            ``"headerColor"``.
     ``subreddit``           The :class:`.Subreddit` the button widget belongs
                             to.
     ``text``                The widget's text, as Markdown.

--- a/praw/models/reddit/wikipage.py
+++ b/praw/models/reddit/wikipage.py
@@ -34,10 +34,10 @@ class WikiPageModeration:
     def add(self, redditor: Redditor):
         """Add an editor to this WikiPage.
 
-        :param redditor: A redditor name (e.g., ``spez``) or
+        :param redditor: A redditor name (e.g., ``'spez'``) or
             :class:`~.Redditor` instance.
 
-        To add ``spez`` as an editor on the wikipage ``praw_test`` try:
+        To add ``'spez'`` as an editor on the wikipage ``'praw_test'`` try:
 
         .. code-block:: python
 
@@ -53,10 +53,10 @@ class WikiPageModeration:
     def remove(self, redditor: Redditor):
         """Remove an editor from this WikiPage.
 
-        :param redditor: A redditor name (e.g., ``spez``) or
+        :param redditor: A redditor name (e.g., ``'spez'``) or
             :class:`~.Redditor` instance.
 
-        To remove ``spez`` as an editor on the wikipage ``praw_test`` try:
+        To remove ``'spez'`` as an editor on the wikipage ``'praw_test'`` try:
 
         .. code-block:: python
 
@@ -243,7 +243,7 @@ class WikiPage(RedditBase):
     def revision(self, revision: str):
         """Return a specific version of this page by revision ID.
 
-        To view revision ``[ID]`` of ``praw_test`` in ``/r/test``:
+        To view revision ``[ID]`` of ``'praw_test'`` in ``'/r/test'``:
 
         .. code-block:: python
 
@@ -262,7 +262,7 @@ class WikiPage(RedditBase):
         Additional keyword arguments are passed in the initialization of
         :class:`.ListingGenerator`.
 
-        To view the wiki revisions for ``praw_test`` in ``/r/test`` try:
+        To view the wiki revisions for ``'praw_test'`` in ``'/r/test'`` try:
 
         .. code-block:: python
 

--- a/praw/models/reddit/wikipage.py
+++ b/praw/models/reddit/wikipage.py
@@ -34,10 +34,10 @@ class WikiPageModeration:
     def add(self, redditor: Redditor):
         """Add an editor to this WikiPage.
 
-        :param redditor: A redditor name (e.g., ``'spez'``) or
+        :param redditor: A redditor name (e.g., ``"spez"``) or
             :class:`~.Redditor` instance.
 
-        To add ``'spez'`` as an editor on the wikipage ``'praw_test'`` try:
+        To add ``"spez"`` as an editor on the wikipage ``"praw_test"`` try:
 
         .. code-block:: python
 
@@ -53,10 +53,10 @@ class WikiPageModeration:
     def remove(self, redditor: Redditor):
         """Remove an editor from this WikiPage.
 
-        :param redditor: A redditor name (e.g., ``'spez'``) or
+        :param redditor: A redditor name (e.g., ``"spez"``) or
             :class:`~.Redditor` instance.
 
-        To remove ``'spez'`` as an editor on the wikipage ``'praw_test'`` try:
+        To remove ``"spez"`` as an editor on the wikipage ``"praw_test"`` try:
 
         .. code-block:: python
 
@@ -243,7 +243,7 @@ class WikiPage(RedditBase):
     def revision(self, revision: str):
         """Return a specific version of this page by revision ID.
 
-        To view revision ``[ID]`` of ``'praw_test'`` in ``/r/test``:
+        To view revision ``[ID]`` of ``"praw_test"`` in ``/r/test``:
 
         .. code-block:: python
 
@@ -262,7 +262,7 @@ class WikiPage(RedditBase):
         Additional keyword arguments are passed in the initialization of
         :class:`.ListingGenerator`.
 
-        To view the wiki revisions for ``'praw_test'`` in ``/r/test`` try:
+        To view the wiki revisions for ``"praw_test"`` in ``/r/test`` try:
 
         .. code-block:: python
 

--- a/praw/models/reddit/wikipage.py
+++ b/praw/models/reddit/wikipage.py
@@ -243,7 +243,7 @@ class WikiPage(RedditBase):
     def revision(self, revision: str):
         """Return a specific version of this page by revision ID.
 
-        To view revision ``[ID]`` of ``'praw_test'`` in ``'/r/test'``:
+        To view revision ``[ID]`` of ``'praw_test'`` in ``/r/test``:
 
         .. code-block:: python
 
@@ -262,7 +262,7 @@ class WikiPage(RedditBase):
         Additional keyword arguments are passed in the initialization of
         :class:`.ListingGenerator`.
 
-        To view the wiki revisions for ``'praw_test'`` in ``'/r/test'`` try:
+        To view the wiki revisions for ``'praw_test'`` in ``/r/test`` try:
 
         .. code-block:: python
 

--- a/praw/models/trophy.py
+++ b/praw/models/trophy.py
@@ -40,7 +40,7 @@ class Trophy(PRAWBase):
 
         :param reddit: An instance of :class:`.Reddit`.
         :param _data: The structured data, assumed to be a dict
-            and key ``name`` must be provided.
+            and key ``'name'`` must be provided.
 
         """
         assert isinstance(_data, dict) and "name" in _data

--- a/praw/models/trophy.py
+++ b/praw/models/trophy.py
@@ -40,7 +40,7 @@ class Trophy(PRAWBase):
 
         :param reddit: An instance of :class:`.Reddit`.
         :param _data: The structured data, assumed to be a dict
-            and key ``'name'`` must be provided.
+            and key ``"name"`` must be provided.
 
         """
         assert isinstance(_data, dict) and "name" in _data


### PR DESCRIPTION
This reverts commit 698b103514932424a222edfadd6ea735db76e954.

Fixes # (provide issue number if applicable)

Fix #1447