### PR TITLE
Create a new method of accessing the Config

### DIFF
--- a/praw/config.py
+++ b/praw/config.py
@@ -40,7 +40,7 @@ class Config:
             category=DeprecationWarning,
             stacklevel=2,
         )
-        return dict(**self.file_settings, **self.code_settings)
+        return dict(**self._file_settings, **self._code_settings)
 
     @staticmethod
     def _config_boolean(item):
@@ -92,8 +92,8 @@ class Config:
                 self._load_config(config_interpolation)
 
         self._settings = settings
-        self.file_settings = Config.CONFIG.items(site_name)
-        self.code_settings = settings
+        self._file_settings = Config.CONFIG.items(site_name)
+        self._code_settings = settings
 
         self.client_id = self.client_secret = self.oauth_url = None
         self.reddit_url = self.refresh_token = self.redirect_uri = None
@@ -211,14 +211,14 @@ class Config:
         :class:`.Subreddit` with a display_name of ``"redditdev"``.
         """
         return_value = default
-        ini_value = self.file_settings.get(key)
+        ini_value = self._file_settings.get(key)
         if ini_value is not None:
             return_value = ini_value
         if environment_variable:
             env_value = os.getenv("praw_{}".format(key))
             if env_value is not None:
                 return_value = env_value
-        code_value = self.code_settings.get(key)
+        code_value = self._code_settings.get(key)
         if code_value is not None:
             return_value = code_value
         if required and return_value == default:

--- a/praw/config.py
+++ b/praw/config.py
@@ -3,9 +3,12 @@ import configparser
 import os
 import sys
 from threading import Lock
-from typing import Optional
+from typing import Any, Callable, Dict, Optional, Type, TypeVar, Union
+from warnings import warn
 
 from .exceptions import ClientException
+
+_T = TypeVar("_T")
 
 
 class _NotSet:
@@ -28,6 +31,16 @@ class Config:
         "basic": configparser.BasicInterpolation,
         "extended": configparser.ExtendedInterpolation,
     }
+
+    @property
+    def custom(self) -> Dict[str, Any]:
+        warn(
+            "Using the custom attribute is deprecated, and will be removed "
+            "from PRAW 8.0.",
+            category=DeprecationWarning,
+            stacklevel=2,
+        )
+        return dict(**self.file_settings, **self.code_settings)
 
     @staticmethod
     def _config_boolean(item):
@@ -71,7 +84,7 @@ class Config:
         self,
         site_name: str,
         config_interpolation: Optional[str] = None,
-        **settings: str
+        **settings: Any
     ):
         """Initialize a Config instance."""
         with Config.LOCK:
@@ -79,7 +92,8 @@ class Config:
                 self._load_config(config_interpolation)
 
         self._settings = settings
-        self.custom = dict(Config.CONFIG.items(site_name), **settings)
+        self.file_settings = Config.CONFIG.items(site_name)
+        self.code_settings = settings
 
         self.client_id = self.client_secret = self.oauth_url = None
         self.reddit_url = self.refresh_token = self.redirect_uri = None
@@ -106,6 +120,137 @@ class Config:
 
         # Environment variables have higher priority than praw.ini settings
         return env_value or ini_value or self.CONFIG_NOT_SET
+
+    def fetch_attribute(
+        self,
+        key,
+        convert_to_type: Optional[Union[Type[_T], Callable[[Any], _T]]] = None,
+        default: Union[_NotSet, Any] = CONFIG_NOT_SET,
+        environment_variable: bool = True,
+        required: bool = False,
+    ) -> Union[str, _T]:
+        """Fetch an attribute from the config.
+
+        Config hierarchy from lowest to highest:
+
+        1. ``praw.ini`` file
+        2. Environment variables
+        3. Hardcoded values
+
+        The highest priority is given to values that are passed as keyword
+        arguments into the Config class, and by extension, the Reddit class.
+
+        Environment variables have the second highest priority. Only
+        environment variables that start with ``praw_`` followed by the
+        attribute name will be looked at.
+
+        The lowest priority goes to values in a ``praw.ini`` file.
+
+        :param key: The key that you are trying to get the value of
+        :param convert_to_type: A class or other callable that returns an
+            instance of a type. If specified, the value will be converted to
+            the specified type, and an instance of that type will be returned.
+            If the type conversion returns an error, an instance of
+            :py:class:`ValueError` will be thrown. (Default: None)
+
+            .. note:: If a value is provided, it should only take one
+                positional argument, which will be the value of the key.
+
+        :param default: If no value is found for the key, then the default will
+            be returned. By default, the Config's ``NotSet`` instance will be
+            returned. In this way, it is possible to check if a key is set or
+            not, by checking for equality with ``Config.CONFIG_NOT_SET``.
+
+            .. note:: The default value will be converted to the type specified
+                in parameter ``convert_to_type``, so it is recommended to
+                either set a default value that can be converted (such as an
+                empty string ``""``), or to set the parameter ``required`` to
+                True.
+
+        :param environment_variable: If set to True, then environment variables
+            will be used as a source of the value. If set to False, then the
+            only sources of values will be parameters passed into the config
+            class and the ``praw.ini`` file. (Default: True)
+        :param required: If set to True, if a value is not found, an instance
+            of :py:class:`KeyError` will be raised, instead of returning the
+            default value. (Default: False)
+        :returns: An instance of ``convert_to_type`` if specified, else returns
+            a string.
+
+        For example, to fetch the value of key ``"subreddit"``, and convert the
+        value into an instance of :class:`.Subreddit`, while supplying a
+        default value of ``"test"``:
+
+        .. code-block:: python
+
+            subreddit = reddit.config.fetch_attribute("subreddit",
+                        convert_to_type=reddit.subreddit,
+                        default="test")
+
+        This code will first check if the Config instance, and by extension,
+        the Reddit instance, was provided a keyword argument containing the
+        key name and a value, such as the code below:
+
+        .. code-block:: python
+
+            reddit = Reddit(client_id="...",
+                            client_secret="...",
+                            subreddit="redditdev",
+                            user_agent="Subreddit Scraper Bot")
+
+        This would use the value ``"redditdev"``, and since the code earlier
+        also provided parameter ``convert_to_type`` with a value of
+        ``reddit.subreddit``, the return value will be the callable given the
+        value as the only parameter. Therefore, the return value will be
+
+        .. code-block:: python
+
+            subreddit = reddit.subreddit("redditdev")
+
+        The final value of ``subreddit`` will be an instance of
+        :class:`.Subreddit` with a display_name of ``"redditdev"``.
+        """
+        return_value = default
+        ini_value = self.file_settings.get(key)
+        if ini_value is not None:
+            return_value = ini_value
+        if environment_variable:
+            env_value = os.getenv("praw_{}".format(key))
+            if env_value is not None:
+                return_value = env_value
+        code_value = self.code_settings.get(key)
+        if code_value is not None:
+            return_value = code_value
+        if required and return_value == default:
+            message = (
+                "Required key {key} not found. Please provide the value in "
+                'the Reddit() call, such as ``Reddit({key}="value")`` or as '
+                'a line in the praw.ini file, such as ``{key}="value"``.'
+            )
+            if environment_variable:
+                message += (
+                    " In addition, you can specify the value as an "
+                    "environment variable, by running ``export praw_"
+                    '{key}="value"`` on a Unix system (Mac OS X and '
+                    "Linux systems), by running ``setx praw_{key} "
+                    '"value"`` on Windows Command Prompt (cmd.exe), or '
+                    'by running ``$Env:praw_{key}= "value"`` on Windows'
+                    " Powershell."
+                )
+            raise KeyError(message.format(key=key))
+        if convert_to_type is not None:
+            try:
+                return convert_to_type(return_value)
+            except Exception as exc:
+                raise ValueError(
+                    "The value {!r} (type {}) of key {} could not be converted"
+                    " to the requested type. Please ensure that the callable "
+                    "takes one positional parameter only, and that the value "
+                    "can be converted to the requested type.".format(
+                        return_value, type(return_value).__name__, key
+                    )
+                ) from exc
+        return return_value
 
     def _initialize_attributes(self):
         self._short_url = (


### PR DESCRIPTION
Fixes # (provide issue number if applicable)
Fix #1393 

Instead of using the old system, I decided to create a new method that does everything the loops in `_initialize_attributes` does, but can also be used by third parties. It also appropriately splits file values from hardcoded values, and does type conversions with callables. 

I would like the method to be reviewed before I get rid of the old methods and rewrite the code to use the new function.