### PR TITLE
Update `update`

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,17 @@
 Change Log
 ==========
 
+Unreleased
+----------
+
+**Fixed**
+
+* An issue where certain subreddit settings could not be set through
+  :meth:`.SubredditModeration.update`, such as ``welcome_message_enabled``
+  and ``welcome_message_text``. This change also removes the need for PRAW
+  to track current subreddit settings and send unmodified ones in the
+  update request.
+
 7.0.0 (2020/04/24)
 ------------------
 

--- a/praw/endpoints.py
+++ b/praw/endpoints.py
@@ -188,6 +188,7 @@ API_PATH = {
     "unread_message":          "api/unread_message/",
     "unsave":                  "api/unsave/",
     "unspoiler":               "api/unspoiler/",
+    "update_settings":         "api/v1/subreddit/update_settings",
     "upload_image":            "r/{subreddit}/api/upload_sr_img",
     "user":                    "user/{user}/",
     "user_about":              "user/{user}/about/",

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -2123,28 +2123,10 @@ class SubredditModeration:
         call to :meth:`.SubredditModeration.update` should retain their current
         value. If they do not please file a bug.
 
-        .. warning:: Undocumented settings, or settings that were very recently
-                     documented, may not retain their current value when
-                     updating. This often occurs when Reddit adds a new setting
-                     but forgets to add that setting to the API endpoint that
-                     is used to fetch the current settings.
-
         """
-        current_settings = self.settings()
-        fullname = current_settings.pop("subreddit_id")
-
-        # These attributes come out using different names than they go in.
-        remap = {
-            "allow_top": "default_set",
-            "lang": "language",
-            "link_type": "content_options",
-        }
-        for new, old in remap.items():
-            current_settings[new] = current_settings.pop(old)
-
-        current_settings.update(settings)
-        return Subreddit._create_or_update(
-            _reddit=self.subreddit._reddit, sr=fullname, **current_settings
+        settings["sr"] = self.subreddit.fullname
+        return self.subreddit._reddit.patch(
+            API_PATH["update_settings"], json=settings
         )
 
 

--- a/tests/integration/cassettes/TestSubredditModeration.test_update.json
+++ b/tests/integration/cassettes/TestSubredditModeration.test_update.json
@@ -1,7 +1,7 @@
 {
   "http_interactions": [
     {
-      "recorded_at": "2020-04-05T00:47:30",
+      "recorded_at": "2020-04-29T07:15:13",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -21,13 +21,13 @@
             "keep-alive"
           ],
           "Content-Length": [
-            "61"
+            "53"
           ],
           "Content-Type": [
             "application/x-www-form-urlencoded"
           ],
           "User-Agent": [
-            "<USER_AGENT> PRAW/7.0.0.dev0 prawcore/1.0.1"
+            "<USER_AGENT> PRAW/7.0.1.dev0 prawcore/1.3.0"
           ]
         },
         "method": "POST",
@@ -46,19 +46,19 @@
             "keep-alive"
           ],
           "Content-Length": [
-            "118"
+            "116"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Sun, 05 Apr 2020 00:47:30 GMT"
+            "Wed, 29 Apr 2020 07:15:13 GMT"
           ],
           "Server": [
             "snooserv"
           ],
           "Set-Cookie": [
-            "edgebucket=cLYzmfbvkBmniB1ccA; Domain=reddit.com; Max-Age=63071999; Path=/;  secure"
+            "edgebucket=GJdCncr0aRnJtDpkLi; Domain=reddit.com; Max-Age=63071999; Path=/;  secure"
           ],
           "Strict-Transport-Security": [
             "max-age=15552000; includeSubDomains; preload"
@@ -76,10 +76,10 @@
             "majestic"
           ],
           "X-Served-By": [
-            "cache-lga21977-LGA"
+            "cache-sjc10035-SJC"
           ],
           "X-Timer": [
-            "S1586047650.856629,VS0,VE312"
+            "S1588144513.189146,VS0,VE434"
           ],
           "cache-control": [
             "max-age=0, must-revalidate"
@@ -102,7 +102,7 @@
       }
     },
     {
-      "recorded_at": "2020-04-05T00:47:30",
+      "recorded_at": "2020-04-29T07:15:13",
       "request": {
         "body": {
           "encoding": "utf-8",
@@ -122,10 +122,10 @@
             "keep-alive"
           ],
           "Cookie": [
-            "edgebucket=cLYzmfbvkBmniB1ccA"
+            "edgebucket=GJdCncr0aRnJtDpkLi"
           ],
           "User-Agent": [
-            "<USER_AGENT> PRAW/7.0.0.dev0 prawcore/1.0.1"
+            "<USER_AGENT> PRAW/7.0.1.dev0 prawcore/1.3.0"
           ]
         },
         "method": "GET",
@@ -134,7 +134,7 @@
       "response": {
         "body": {
           "encoding": "UTF-8",
-          "string": "{\"kind\": \"subreddit_settings\", \"data\": {\"default_set\": false, \"toxicity_threshold_chat_level\": 1, \"crowd_control_chat_level\": 1, \"restrict_posting\": true, \"subreddit_id\": \"t5_2bhxu0\", \"allow_images\": true, \"free_form_reports\": true, \"domain\": null, \"show_media\": false, \"wiki_edit_age\": 0, \"submit_text\": \"\", \"spam_selfposts\": \"high\", \"title\": \"<TEST_SUBREDDIT>x\", \"collapse_deleted_comments\": false, \"wikimode\": \"disabled\", \"over_18\": false, \"allow_videos\": true, \"spoilers_enabled\": false, \"crowd_control_level\": 0, \"crowd_control_mode\": false, \"welcome_message_enabled\": false, \"welcome_message_text\": null, \"suggested_comment_sort\": null, \"disable_contributor_requests\": false, \"original_content_tag_enabled\": false, \"description\": \"\", \"submit_link_label\": \"\", \"allow_post_crossposts\": true, \"spam_comments\": \"low\", \"public_traffic\": false, \"restrict_commenting\": false, \"allow_polls\": true, \"submit_text_label\": \"\", \"all_original_content\": false, \"key_color\": \"\", \"language\": \"en\", \"wiki_edit_karma\": 0, \"hide_ads\": false, \"header_hover_text\": \"\", \"allow_chat_post_creation\": false, \"allow_discovery\": false, \"public_description\": \"\", \"show_media_preview\": false, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"public\", \"spam_links\": \"high\", \"exclude_banned_modqueue\": false, \"content_options\": \"any\"}}"
+          "string": "{\"kind\": \"subreddit_settings\", \"data\": {\"default_set\": true, \"toxicity_threshold_chat_level\": 1, \"crowd_control_chat_level\": 1, \"restrict_posting\": true, \"subreddit_id\": \"t5_3nwlq\", \"allow_images\": true, \"free_form_reports\": true, \"domain\": null, \"show_media\": true, \"wiki_edit_age\": 0, \"submit_text\": \"\", \"spam_selfposts\": \"high\", \"title\": \"Testing 22!\", \"collapse_deleted_comments\": false, \"wikimode\": \"disabled\", \"over_18\": false, \"allow_videos\": true, \"spoilers_enabled\": true, \"crowd_control_level\": 0, \"crowd_control_mode\": false, \"welcome_message_enabled\": true, \"welcome_message_text\": \"This is the welcome message now!\", \"suggested_comment_sort\": null, \"disable_contributor_requests\": false, \"original_content_tag_enabled\": false, \"description\": \"heyo whale\", \"submit_link_label\": \"\", \"allow_post_crossposts\": true, \"spam_comments\": \"low\", \"public_traffic\": false, \"restrict_commenting\": false, \"allow_polls\": true, \"submit_text_label\": \"\", \"all_original_content\": false, \"key_color\": \"\", \"language\": \"en\", \"wiki_edit_karma\": 100, \"hide_ads\": false, \"header_hover_text\": \"\", \"allow_chat_post_creation\": false, \"allow_discovery\": false, \"public_description\": \"Here's a newer description\", \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"restricted\", \"spam_links\": \"high\", \"exclude_banned_modqueue\": false, \"content_options\": \"any\"}}"
         },
         "headers": {
           "Accept-Ranges": [
@@ -144,20 +144,20 @@
             "keep-alive"
           ],
           "Content-Length": [
-            "1308"
+            "1369"
           ],
           "Content-Type": [
             "application/json; charset=UTF-8"
           ],
           "Date": [
-            "Sun, 05 Apr 2020 00:47:30 GMT"
+            "Wed, 29 Apr 2020 07:15:13 GMT"
           ],
           "Server": [
             "snooserv"
           ],
           "Set-Cookie": [
-            "loid=00000000005bn5wlvy.2.1577584524387.Z0FBQUFBQmVpU3FpUHBoLUs1M0V5V1hNMlNrei1FbUdENFc2UFlPQl9vU1UycnVTREtJdnlMcnJjVTdfT0EtbWxQTFF5cEpwVU1kMUgxVktFNzlOazVmRm9qMW1OTDI3ckJqbG84dGJEX3pLVVRDQTJudEZXVnByNTlnN2RsSF91a0V3a3YxWVdoOFo; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Tue, 05-Apr-2022 00:47:30 GMT; secure; SameSite=None; Secure",
-            "session_tracker=dQVjKrhpv5DzWyqtMb.0.1586047650451.Z0FBQUFBQmVpU3Fpb3FxQmlyYmN1WVN4NHhvNkNJZEdkUmNiYXBnMWlnbnlrel8tMnFGMnhseW1Yd0dMckFrRUxRRDhIUERCX3hhNW5YUnNycklpTEoxd0RqZTlabXA1NU01akg5WnFBYjN1VnRSRXRxZm9TaV96M3ZRZ091b05NeHVqenFMSXl3Sjk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 05-Apr-2020 02:47:30 GMT; secure; SameSite=None; Secure",
+            "session_tracker=4bN4U6H1I1Qw8Wb9qF.0.1588144513777.Z0FBQUFBQmVxU21COERmeEgteXNrTllhOUs2aWppSjNVdjJxYUxkd2I1eEprMTBZRjFITkFuV0lvUjBoRlNQNmM2UW43Q0ZScWtrUXJNZmRCaF9nUVpvaVpTY1hra0tHaThuMkNkRnFuTmw0VlJqVGN3bHJPcmJnLXoxRmlweVlpNzBWYXE5bkJ3cTU; Domain=reddit.com; Max-Age=7199; Path=/; expires=Wed, 29-Apr-2020 09:15:13 GMT; secure; SameSite=None; Secure",
+            "redesign_optout=true; Domain=reddit.com; Max-Age=94607999; Path=/; expires=Sat, 29-Apr-2023 07:15:13 GMT; secure",
             "csv=1; Max-Age=63072000; Domain=.reddit.com; Path=/; Secure; SameSite=None"
           ],
           "Strict-Transport-Security": [
@@ -179,10 +179,477 @@
             "majestic"
           ],
           "X-Served-By": [
-            "cache-lga21964-LGA"
+            "cache-sjc10033-SJC"
           ],
           "X-Timer": [
-            "S1586047650.421632,VS0,VE69"
+            "S1588144514.707057,VS0,VE142"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, no-store, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "599.0"
+          ],
+          "x-ratelimit-reset": [
+            "287"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/about/edit/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-04-29T07:15:14",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "csv=1; edgebucket=GJdCncr0aRnJtDpkLi; redesign_optout=true; session_tracker=4bN4U6H1I1Qw8Wb9qF.0.1588144513777.Z0FBQUFBQmVxU21COERmeEgteXNrTllhOUs2aWppSjNVdjJxYUxkd2I1eEprMTBZRjFITkFuV0lvUjBoRlNQNmM2UW43Q0ZScWtrUXJNZmRCaF9nUVpvaVpTY1hra0tHaThuMkNkRnFuTmw0VlJqVGN3bHJPcmJnLXoxRmlweVlpNzBWYXE5bkJ3cTU"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/7.0.1.dev0 prawcore/1.3.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t5\", \"data\": {\"user_flair_background_color\": \"\", \"submit_text_html\": null, \"restrict_posting\": true, \"user_is_banned\": false, \"free_form_reports\": true, \"wiki_enabled\": true, \"user_is_muted\": false, \"user_can_flair_in_sr\": true, \"display_name\": \"<TEST_SUBREDDIT>\", \"header_img\": null, \"title\": \"Testing 22!\", \"icon_size\": null, \"primary_color\": \"\", \"active_user_count\": 8, \"icon_img\": null, \"display_name_prefixed\": \"r/<TEST_SUBREDDIT>\", \"accounts_active\": 8, \"public_traffic\": false, \"subscribers\": 1, \"user_flair_richtext\": [{\"e\": \"text\", \"t\": \"\\\"test\\\"ing 2\\\"\"}], \"videostream_links_count\": 0, \"name\": \"t5_3nwlq\", \"quarantine\": false, \"hide_ads\": false, \"emojis_enabled\": true, \"advertiser_category\": \"\", \"public_description\": \"Here's a newer description\", \"comment_score_hide_mins\": 0, \"user_has_favorited\": false, \"user_flair_template_id\": null, \"community_icon\": \"\", \"banner_background_image\": \"https://styles.redditmedia.com/t5_3nwlq/styles/bannerBackgroundImage_ok43sbl5d9i21.jpg\", \"original_content_tag_enabled\": false, \"submit_text\": \"\", \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Eheyo whale\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"spoilers_enabled\": true, \"header_title\": \"\", \"header_size\": null, \"user_flair_position\": \"right\", \"all_original_content\": false, \"collections_enabled\": true, \"is_enrolled_in_new_modmail\": true, \"key_color\": \"\", \"event_posts_enabled\": true, \"can_assign_user_flair\": false, \"created\": 1503566715.0, \"wls\": null, \"show_media_preview\": true, \"submission_type\": \"any\", \"user_is_subscriber\": false, \"disable_contributor_requests\": false, \"allow_videogifs\": true, \"user_flair_type\": \"richtext\", \"allow_polls\": true, \"collapse_deleted_comments\": false, \"coins\": 0, \"emojis_custom_size\": null, \"public_description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EHere\\u0026#39;s a newer description\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"allow_videos\": true, \"is_crosspostable_subreddit\": true, \"notification_level\": null, \"can_assign_link_flair\": true, \"has_menu_widget\": false, \"accounts_active_is_fuzzed\": false, \"submit_text_label\": \"\", \"link_flair_position\": \"left\", \"user_sr_flair_enabled\": true, \"user_flair_enabled_in_sr\": true, \"allow_chat_post_creation\": false, \"allow_discovery\": false, \"user_sr_theme_enabled\": true, \"link_flair_enabled\": true, \"subreddit_type\": \"restricted\", \"suggested_comment_sort\": null, \"banner_img\": null, \"user_flair_text\": \"\\\"test\\\"ing 2\\\"\", \"banner_background_color\": \"\", \"show_media\": true, \"id\": \"3nwlq\", \"user_is_moderator\": true, \"over18\": false, \"description\": \"heyo whale\", \"is_chat_post_feature_enabled\": true, \"submit_link_label\": \"\", \"user_flair_text_color\": \"dark\", \"restrict_commenting\": false, \"user_flair_css_class\": \"\", \"allow_images\": true, \"lang\": \"en\", \"whitelist_status\": null, \"url\": \"/r/<TEST_SUBREDDIT>/\", \"created_utc\": 1503537915.0, \"banner_size\": null, \"mobile_banner_image\": \"\", \"user_is_contributor\": false}}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2987"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 29 Apr 2020 07:15:14 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "session_tracker=4bN4U6H1I1Qw8Wb9qF.0.1588144513938.Z0FBQUFBQmVxU21CQ1ZIYTJxbFJ2RUhvV0QtVFVZdVNJbHZEMVhPeWEzUlhBQ0ZrZGoxeFcxckV4M2pKUkVBMElEdHcyQUl1RDZfZHFXbEFDNGZYMmhSRkpWTUVhT2pfRXFvYm1CY3lacWZFbGE2Sm5Dd1IwUjJsbTlsSEdFRDRGVmgxYkJQVWZYZXM; Domain=reddit.com; Max-Age=7199; Path=/; expires=Wed, 29-Apr-2020 09:15:13 GMT; secure; SameSite=None; Secure"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Vary": [
+            "accept-encoding"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-sjc10033-SJC"
+          ],
+          "X-Timer": [
+            "S1588144514.862189,VS0,VE190"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, no-store, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "598.0"
+          ],
+          "x-ratelimit-reset": [
+            "287"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/about/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-04-29T07:15:14",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "{\"title\": \"Testing 22!x\", \"sr\": \"t5_3nwlq\"}"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "43"
+          ],
+          "Content-Type": [
+            "application/json"
+          ],
+          "Cookie": [
+            "csv=1; edgebucket=GJdCncr0aRnJtDpkLi; redesign_optout=true; session_tracker=4bN4U6H1I1Qw8Wb9qF.0.1588144513938.Z0FBQUFBQmVxU21CQ1ZIYTJxbFJ2RUhvV0QtVFVZdVNJbHZEMVhPeWEzUlhBQ0ZrZGoxeFcxckV4M2pKUkVBMElEdHcyQUl1RDZfZHFXbEFDNGZYMmhSRkpWTUVhT2pfRXFvYm1CY3lacWZFbGE2Sm5Dd1IwUjJsbTlsSEdFRDRGVmgxYkJQVWZYZXM"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/7.0.1.dev0 prawcore/1.3.0"
+          ]
+        },
+        "method": "PATCH",
+        "uri": "https://oauth.reddit.com/api/v1/subreddit/update_settings?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"title\": \"Testing 22!x\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "25"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 29 Apr 2020 07:15:14 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-sjc10033-SJC"
+          ],
+          "X-Timer": [
+            "S1588144514.065208,VS0,VE211"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, no-store, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "set-cookie": [
+            "session_tracker=4bN4U6H1I1Qw8Wb9qF.0.1588144514130.Z0FBQUFBQmVxU21DdzIzeUphSVNzbW82SHh6c3dabVhRYzFxcGhjRDhzdERDYWNzbVptbV9mTWdPeTBLTnRzRjU3emFxTTJaTU50RTR5YmI4aHVfanhfNmtOVjNORFpJbl9LRFpXSEltRExjdjhndmdCUDN0ckhFVTFJOUJxQU8yZy1lYWh6V09yMXA; Domain=reddit.com; Max-Age=7199; Path=/; expires=Wed, 29-Apr-2020 09:15:14 GMT; secure"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "597.0"
+          ],
+          "x-ratelimit-reset": [
+            "286"
+          ],
+          "x-ratelimit-used": [
+            "3"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/v1/subreddit/update_settings?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-04-29T07:15:14",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "csv=1; edgebucket=GJdCncr0aRnJtDpkLi; redesign_optout=true; session_tracker=4bN4U6H1I1Qw8Wb9qF.0.1588144514130.Z0FBQUFBQmVxU21DdzIzeUphSVNzbW82SHh6c3dabVhRYzFxcGhjRDhzdERDYWNzbVptbV9mTWdPeTBLTnRzRjU3emFxTTJaTU50RTR5YmI4aHVfanhfNmtOVjNORFpJbl9LRFpXSEltRExjdjhndmdCUDN0ckhFVTFJOUJxQU8yZy1lYWh6V09yMXA"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/7.0.1.dev0 prawcore/1.3.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/about/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"t5\", \"data\": {\"user_flair_background_color\": \"\", \"submit_text_html\": null, \"restrict_posting\": true, \"user_is_banned\": false, \"free_form_reports\": true, \"wiki_enabled\": true, \"user_is_muted\": false, \"user_can_flair_in_sr\": true, \"display_name\": \"<TEST_SUBREDDIT>\", \"header_img\": null, \"title\": \"Testing 22!x\", \"icon_size\": null, \"primary_color\": \"\", \"active_user_count\": 8, \"icon_img\": null, \"display_name_prefixed\": \"r/<TEST_SUBREDDIT>\", \"accounts_active\": 8, \"public_traffic\": false, \"subscribers\": 1, \"user_flair_richtext\": [{\"e\": \"text\", \"t\": \"\\\"test\\\"ing 2\\\"\"}], \"videostream_links_count\": 0, \"name\": \"t5_3nwlq\", \"quarantine\": false, \"hide_ads\": false, \"emojis_enabled\": true, \"advertiser_category\": \"\", \"public_description\": \"Here's a newer description\", \"comment_score_hide_mins\": 0, \"user_has_favorited\": false, \"user_flair_template_id\": null, \"community_icon\": \"\", \"banner_background_image\": \"https://styles.redditmedia.com/t5_3nwlq/styles/bannerBackgroundImage_ok43sbl5d9i21.jpg\", \"original_content_tag_enabled\": false, \"submit_text\": \"\", \"description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003Eheyo whale\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"spoilers_enabled\": true, \"header_title\": \"\", \"header_size\": null, \"user_flair_position\": \"right\", \"all_original_content\": false, \"collections_enabled\": true, \"is_enrolled_in_new_modmail\": true, \"key_color\": \"\", \"event_posts_enabled\": true, \"can_assign_user_flair\": false, \"created\": 1503566715.0, \"wls\": null, \"show_media_preview\": true, \"submission_type\": \"any\", \"user_is_subscriber\": false, \"disable_contributor_requests\": false, \"allow_videogifs\": true, \"user_flair_type\": \"richtext\", \"allow_polls\": true, \"collapse_deleted_comments\": false, \"coins\": 0, \"emojis_custom_size\": null, \"public_description_html\": \"\\u003C!-- SC_OFF --\\u003E\\u003Cdiv class=\\\"md\\\"\\u003E\\u003Cp\\u003EHere\\u0026#39;s a newer description\\u003C/p\\u003E\\n\\u003C/div\\u003E\\u003C!-- SC_ON --\\u003E\", \"allow_videos\": true, \"is_crosspostable_subreddit\": true, \"notification_level\": null, \"can_assign_link_flair\": true, \"has_menu_widget\": false, \"accounts_active_is_fuzzed\": false, \"submit_text_label\": \"\", \"link_flair_position\": \"left\", \"user_sr_flair_enabled\": true, \"user_flair_enabled_in_sr\": true, \"allow_chat_post_creation\": false, \"allow_discovery\": false, \"user_sr_theme_enabled\": true, \"link_flair_enabled\": true, \"subreddit_type\": \"restricted\", \"suggested_comment_sort\": null, \"banner_img\": null, \"user_flair_text\": \"\\\"test\\\"ing 2\\\"\", \"banner_background_color\": \"\", \"show_media\": true, \"id\": \"3nwlq\", \"user_is_moderator\": true, \"over18\": false, \"description\": \"heyo whale\", \"is_chat_post_feature_enabled\": true, \"submit_link_label\": \"\", \"user_flair_text_color\": \"dark\", \"restrict_commenting\": false, \"user_flair_css_class\": \"\", \"allow_images\": true, \"lang\": \"en\", \"whitelist_status\": null, \"url\": \"/r/<TEST_SUBREDDIT>/\", \"created_utc\": 1503537915.0, \"banner_size\": null, \"mobile_banner_image\": \"\", \"user_is_contributor\": false}}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "2988"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 29 Apr 2020 07:15:14 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "session_tracker=4bN4U6H1I1Qw8Wb9qF.0.1588144514494.Z0FBQUFBQmVxU21DSHB3VllPM2lCd3NfbUR1QnpMYU11Ti1zemM0dXpDTVBCM1I4MWRnRVVtbEgtbHg5WVU1bmVveGFmclplVnQ0X2JPQkZoVGQ3T2F3cUFRb25GLVMyelVQRFlrbGVvZkNha2RRaGJxazJlWFN6RGhpTjh2WmJXQzhNMVlpcHBRdGo; Domain=reddit.com; Max-Age=7199; Path=/; expires=Wed, 29-Apr-2020 09:15:14 GMT; secure; SameSite=None; Secure"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Vary": [
+            "accept-encoding"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-sjc10033-SJC"
+          ],
+          "X-Timer": [
+            "S1588144514.384099,VS0,VE231"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, no-store, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "596.0"
+          ],
+          "x-ratelimit-reset": [
+            "286"
+          ],
+          "x-ratelimit-used": [
+            "4"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/about/?raw_json=1"
+      }
+    },
+    {
+      "recorded_at": "2020-04-29T07:15:14",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "csv=1; edgebucket=GJdCncr0aRnJtDpkLi; redesign_optout=true; session_tracker=4bN4U6H1I1Qw8Wb9qF.0.1588144514494.Z0FBQUFBQmVxU21DSHB3VllPM2lCd3NfbUR1QnpMYU11Ti1zemM0dXpDTVBCM1I4MWRnRVVtbEgtbHg5WVU1bmVveGFmclplVnQ0X2JPQkZoVGQ3T2F3cUFRb25GLVMyelVQRFlrbGVvZkNha2RRaGJxazJlWFN6RGhpTjh2WmJXQzhNMVlpcHBRdGo"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/7.0.1.dev0 prawcore/1.3.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/about/edit/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"subreddit_settings\", \"data\": {\"default_set\": true, \"toxicity_threshold_chat_level\": 1, \"crowd_control_chat_level\": 1, \"restrict_posting\": true, \"subreddit_id\": \"t5_3nwlq\", \"allow_images\": true, \"free_form_reports\": true, \"domain\": null, \"show_media\": true, \"wiki_edit_age\": 0, \"submit_text\": \"\", \"spam_selfposts\": \"high\", \"title\": \"Testing 22!x\", \"collapse_deleted_comments\": false, \"wikimode\": \"disabled\", \"over_18\": false, \"allow_videos\": true, \"spoilers_enabled\": true, \"crowd_control_level\": 0, \"crowd_control_mode\": false, \"welcome_message_enabled\": true, \"welcome_message_text\": \"This is the welcome message now!\", \"suggested_comment_sort\": null, \"disable_contributor_requests\": false, \"original_content_tag_enabled\": false, \"description\": \"heyo whale\", \"submit_link_label\": \"\", \"allow_post_crossposts\": true, \"spam_comments\": \"low\", \"public_traffic\": false, \"restrict_commenting\": false, \"allow_polls\": true, \"submit_text_label\": \"\", \"all_original_content\": false, \"key_color\": \"\", \"language\": \"en\", \"wiki_edit_karma\": 100, \"hide_ads\": false, \"header_hover_text\": \"\", \"allow_chat_post_creation\": false, \"allow_discovery\": false, \"public_description\": \"Here's a newer description\", \"show_media_preview\": true, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"restricted\", \"spam_links\": \"high\", \"exclude_banned_modqueue\": false, \"content_options\": \"any\"}}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "1370"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 29 Apr 2020 07:15:14 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "session_tracker=4bN4U6H1I1Qw8Wb9qF.0.1588144514754.Z0FBQUFBQmVxU21DbjJpSWxQb2hGWWpQVVRCTWVMZ0x2RVAyUE9QZEF6bmY3Mm9mbzZtWnhseW40UGk1TGRPTVlwQlVndkNZazdlcXJ0cUpfSFBtVzlEMkk0eVRyZ3o1bnAxdDRwOGJ4UlEwdkxTcy1sUjlObmN1WDktY2xZOGVrRUdmNjM1Ukp4WlU; Domain=reddit.com; Max-Age=7199; Path=/; expires=Wed, 29-Apr-2020 09:15:14 GMT; secure; SameSite=None; Secure"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Vary": [
+            "accept-encoding"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Cache": [
+            "MISS"
+          ],
+          "X-Cache-Hits": [
+            "0"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "X-Served-By": [
+            "cache-sjc10033-SJC"
+          ],
+          "X-Timer": [
+            "S1588144515.691459,VS0,VE135"
           ],
           "cache-control": [
             "private, s-maxage=0, max-age=0, must-revalidate, no-store, max-age=0, must-revalidate"
@@ -200,477 +667,10 @@
             "595.0"
           ],
           "x-ratelimit-reset": [
-            "150"
+            "286"
           ],
           "x-ratelimit-used": [
             "5"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/about/edit/?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2020-04-05T00:47:30",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "identity"
-          ],
-          "Authorization": [
-            "bearer <ACCESS_TOKEN>"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "csv=1; edgebucket=cLYzmfbvkBmniB1ccA; loid=00000000005bn5wlvy.2.1577584524387.Z0FBQUFBQmVpU3FpUHBoLUs1M0V5V1hNMlNrei1FbUdENFc2UFlPQl9vU1UycnVTREtJdnlMcnJjVTdfT0EtbWxQTFF5cEpwVU1kMUgxVktFNzlOazVmRm9qMW1OTDI3ckJqbG84dGJEX3pLVVRDQTJudEZXVnByNTlnN2RsSF91a0V3a3YxWVdoOFo; session_tracker=dQVjKrhpv5DzWyqtMb.0.1586047650451.Z0FBQUFBQmVpU3Fpb3FxQmlyYmN1WVN4NHhvNkNJZEdkUmNiYXBnMWlnbnlrel8tMnFGMnhseW1Yd0dMckFrRUxRRDhIUERCX3hhNW5YUnNycklpTEoxd0RqZTlabXA1NU01akg5WnFBYjN1VnRSRXRxZm9TaV96M3ZRZ091b05NeHVqenFMSXl3Sjk"
-          ],
-          "User-Agent": [
-            "<USER_AGENT> PRAW/7.0.0.dev0 prawcore/1.0.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/about/edit/?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"kind\": \"subreddit_settings\", \"data\": {\"default_set\": false, \"toxicity_threshold_chat_level\": 1, \"crowd_control_chat_level\": 1, \"restrict_posting\": true, \"subreddit_id\": \"t5_2bhxu0\", \"allow_images\": true, \"free_form_reports\": true, \"domain\": null, \"show_media\": false, \"wiki_edit_age\": 0, \"submit_text\": \"\", \"spam_selfposts\": \"high\", \"title\": \"<TEST_SUBREDDIT>x\", \"collapse_deleted_comments\": false, \"wikimode\": \"disabled\", \"over_18\": false, \"allow_videos\": true, \"spoilers_enabled\": false, \"crowd_control_level\": 0, \"crowd_control_mode\": false, \"welcome_message_enabled\": false, \"welcome_message_text\": null, \"suggested_comment_sort\": null, \"disable_contributor_requests\": false, \"original_content_tag_enabled\": false, \"description\": \"\", \"submit_link_label\": \"\", \"allow_post_crossposts\": true, \"spam_comments\": \"low\", \"public_traffic\": false, \"restrict_commenting\": false, \"allow_polls\": true, \"submit_text_label\": \"\", \"all_original_content\": false, \"key_color\": \"\", \"language\": \"en\", \"wiki_edit_karma\": 0, \"hide_ads\": false, \"header_hover_text\": \"\", \"allow_chat_post_creation\": false, \"allow_discovery\": false, \"public_description\": \"\", \"show_media_preview\": false, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"public\", \"spam_links\": \"high\", \"exclude_banned_modqueue\": false, \"content_options\": \"any\"}}"
-        },
-        "headers": {
-          "Accept-Ranges": [
-            "bytes"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "1308"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Sun, 05 Apr 2020 00:47:30 GMT"
-          ],
-          "Server": [
-            "snooserv"
-          ],
-          "Set-Cookie": [
-            "session_tracker=dQVjKrhpv5DzWyqtMb.0.1586047650555.Z0FBQUFBQmVpU3FpVFFEM1JITVVaQ3g0Qjk4a1dPcXliV3V3Qi1xb0RZT1N5cE9ncTNJMFBhcEJOWHZIUlpMbFZqNGpZZDc2cWo4bThZQnNpWTIwMVdVTEJQQ2stNHNiMkc3TlRBdkpoMHN3cm50TmYzVkt4cWhhVC1ySzRTV202ZW1nS01KQ0EwdjU; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 05-Apr-2020 02:47:30 GMT; secure; SameSite=None; Secure"
-          ],
-          "Strict-Transport-Security": [
-            "max-age=15552000; includeSubDomains; preload"
-          ],
-          "Vary": [
-            "accept-encoding"
-          ],
-          "Via": [
-            "1.1 varnish"
-          ],
-          "X-Cache": [
-            "MISS"
-          ],
-          "X-Cache-Hits": [
-            "0"
-          ],
-          "X-Moose": [
-            "majestic"
-          ],
-          "X-Served-By": [
-            "cache-lga21964-LGA"
-          ],
-          "X-Timer": [
-            "S1586047651.521322,VS0,VE89"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate, no-store, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "594.0"
-          ],
-          "x-ratelimit-reset": [
-            "150"
-          ],
-          "x-ratelimit-used": [
-            "6"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/about/edit/?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2020-04-05T00:47:30",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": "all_original_content=False&allow_chat_post_creation=False&allow_discovery=False&allow_images=True&allow_polls=True&allow_post_crossposts=True&allow_top=False&allow_videos=True&api_type=json&collapse_deleted_comments=False&comment_score_hide_mins=0&crowd_control_chat_level=1&crowd_control_level=0&crowd_control_mode=False&description=&disable_contributor_requests=False&exclude_banned_modqueue=False&free_form_reports=True&header-title=&hide_ads=False&key_color=&lang=en&link_type=any&original_content_tag_enabled=False&over_18=False&public_description=&public_traffic=False&restrict_commenting=False&restrict_posting=True&show_media=False&show_media_preview=False&spam_comments=low&spam_links=high&spam_selfposts=high&spoilers_enabled=False&sr=t5_2bhxu0&submit_link_label=&submit_text=&submit_text_label=&title=<TEST_SUBREDDIT>xx&toxicity_threshold_chat_level=1&type=public&welcome_message_enabled=False&wiki_edit_age=0&wiki_edit_karma=0&wikimode=disabled"
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "identity"
-          ],
-          "Authorization": [
-            "bearer <ACCESS_TOKEN>"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "955"
-          ],
-          "Content-Type": [
-            "application/x-www-form-urlencoded"
-          ],
-          "Cookie": [
-            "csv=1; edgebucket=cLYzmfbvkBmniB1ccA; loid=00000000005bn5wlvy.2.1577584524387.Z0FBQUFBQmVpU3FpUHBoLUs1M0V5V1hNMlNrei1FbUdENFc2UFlPQl9vU1UycnVTREtJdnlMcnJjVTdfT0EtbWxQTFF5cEpwVU1kMUgxVktFNzlOazVmRm9qMW1OTDI3ckJqbG84dGJEX3pLVVRDQTJudEZXVnByNTlnN2RsSF91a0V3a3YxWVdoOFo; session_tracker=dQVjKrhpv5DzWyqtMb.0.1586047650555.Z0FBQUFBQmVpU3FpVFFEM1JITVVaQ3g0Qjk4a1dPcXliV3V3Qi1xb0RZT1N5cE9ncTNJMFBhcEJOWHZIUlpMbFZqNGpZZDc2cWo4bThZQnNpWTIwMVdVTEJQQ2stNHNiMkc3TlRBdkpoMHN3cm50TmYzVkt4cWhhVC1ySzRTV202ZW1nS01KQ0EwdjU"
-          ],
-          "User-Agent": [
-            "<USER_AGENT> PRAW/7.0.0.dev0 prawcore/1.0.1"
-          ]
-        },
-        "method": "POST",
-        "uri": "https://oauth.reddit.com/api/site_admin/?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"json\": {\"errors\": []}}"
-        },
-        "headers": {
-          "Accept-Ranges": [
-            "bytes"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "24"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Sun, 05 Apr 2020 00:47:30 GMT"
-          ],
-          "Server": [
-            "snooserv"
-          ],
-          "Strict-Transport-Security": [
-            "max-age=15552000; includeSubDomains; preload"
-          ],
-          "Via": [
-            "1.1 varnish"
-          ],
-          "X-Cache": [
-            "MISS"
-          ],
-          "X-Cache-Hits": [
-            "0"
-          ],
-          "X-Moose": [
-            "majestic"
-          ],
-          "X-Served-By": [
-            "cache-lga21964-LGA"
-          ],
-          "X-Timer": [
-            "S1586047651.655462,VS0,VE135"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate, no-store, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "set-cookie": [
-            "session_tracker=dQVjKrhpv5DzWyqtMb.0.1586047650683.Z0FBQUFBQmVpU3FpNGpRYUdycFBONTRqYUlLNF9UNmlOVnZJaHVvdVZGQUh4RW1VenRRNlRzRmQwbWktOThCRzIyeFl4TENkbmI1c3RCT3NqUVdmcXU2bFluQ0tBelMwb2pKWWRZWTh5ZlVjeGljcmhCOHdoSm56bFFaVExGdWVEVUpqc3BDSDJHRW0; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 05-Apr-2020 02:47:30 GMT; secure"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "593.0"
-          ],
-          "x-ratelimit-reset": [
-            "150"
-          ],
-          "x-ratelimit-used": [
-            "7"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://oauth.reddit.com/api/site_admin/?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2020-04-05T00:47:30",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "identity"
-          ],
-          "Authorization": [
-            "bearer <ACCESS_TOKEN>"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "csv=1; edgebucket=cLYzmfbvkBmniB1ccA; loid=00000000005bn5wlvy.2.1577584524387.Z0FBQUFBQmVpU3FpUHBoLUs1M0V5V1hNMlNrei1FbUdENFc2UFlPQl9vU1UycnVTREtJdnlMcnJjVTdfT0EtbWxQTFF5cEpwVU1kMUgxVktFNzlOazVmRm9qMW1OTDI3ckJqbG84dGJEX3pLVVRDQTJudEZXVnByNTlnN2RsSF91a0V3a3YxWVdoOFo; session_tracker=dQVjKrhpv5DzWyqtMb.0.1586047650683.Z0FBQUFBQmVpU3FpNGpRYUdycFBONTRqYUlLNF9UNmlOVnZJaHVvdVZGQUh4RW1VenRRNlRzRmQwbWktOThCRzIyeFl4TENkbmI1c3RCT3NqUVdmcXU2bFluQ0tBelMwb2pKWWRZWTh5ZlVjeGljcmhCOHdoSm56bFFaVExGdWVEVUpqc3BDSDJHRW0"
-          ],
-          "User-Agent": [
-            "<USER_AGENT> PRAW/7.0.0.dev0 prawcore/1.0.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/about/?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"kind\": \"t5\", \"data\": {\"user_flair_background_color\": \"#00ffff\", \"submit_text_html\": null, \"restrict_posting\": true, \"user_is_banned\": false, \"free_form_reports\": true, \"wiki_enabled\": true, \"user_is_muted\": false, \"user_can_flair_in_sr\": true, \"display_name\": \"<TEST_SUBREDDIT>\", \"header_img\": null, \"title\": \"<TEST_SUBREDDIT>xx\", \"icon_size\": null, \"primary_color\": \"#ffd635\", \"active_user_count\": 5, \"icon_img\": \"\", \"display_name_prefixed\": \"r/<TEST_SUBREDDIT>\", \"accounts_active\": 5, \"public_traffic\": false, \"subscribers\": 1, \"user_flair_richtext\": [{\"e\": \"text\", \"t\": \"PRAW updated\"}], \"videostream_links_count\": 0, \"name\": \"t5_2bhxu0\", \"quarantine\": false, \"hide_ads\": false, \"emojis_enabled\": true, \"advertiser_category\": \"\", \"public_description\": \"\", \"comment_score_hide_mins\": 0, \"user_has_favorited\": false, \"user_flair_template_id\": \"488f9b30-2a6e-11ea-a5e1-0e48d7ccc6bf\", \"community_icon\": \"\", \"banner_background_image\": \"https://styles.redditmedia.com/t5_2bhxu0/styles/bannerBackgroundImage_278fuhh3t8941.png\", \"original_content_tag_enabled\": false, \"submit_text\": \"\", \"description_html\": null, \"spoilers_enabled\": false, \"header_title\": \"\", \"header_size\": null, \"user_flair_position\": \"right\", \"all_original_content\": false, \"collections_enabled\": true, \"is_enrolled_in_new_modmail\": true, \"key_color\": \"\", \"event_posts_enabled\": true, \"can_assign_user_flair\": true, \"created\": 1577618351.0, \"wls\": null, \"show_media_preview\": false, \"submission_type\": \"any\", \"user_is_subscriber\": true, \"disable_contributor_requests\": false, \"allow_videogifs\": true, \"user_flair_type\": \"richtext\", \"allow_polls\": true, \"collapse_deleted_comments\": false, \"coins\": 0, \"emojis_custom_size\": null, \"public_description_html\": null, \"allow_videos\": true, \"is_crosspostable_subreddit\": true, \"notification_level\": \"low\", \"can_assign_link_flair\": true, \"has_menu_widget\": false, \"accounts_active_is_fuzzed\": false, \"submit_text_label\": \"\", \"link_flair_position\": \"right\", \"user_sr_flair_enabled\": true, \"user_flair_enabled_in_sr\": true, \"allow_discovery\": false, \"user_sr_theme_enabled\": true, \"link_flair_enabled\": true, \"subreddit_type\": \"public\", \"suggested_comment_sort\": null, \"banner_img\": \"\", \"user_flair_text\": \"PRAW updated\", \"banner_background_color\": \"\", \"show_media\": false, \"id\": \"2bhxu0\", \"user_is_moderator\": true, \"over18\": false, \"description\": \"\", \"submit_link_label\": \"\", \"user_flair_text_color\": \"dark\", \"restrict_commenting\": false, \"user_flair_css_class\": \"myCSS\", \"allow_images\": true, \"lang\": \"en\", \"whitelist_status\": null, \"url\": \"/r/<TEST_SUBREDDIT>/\", \"created_utc\": 1577589551.0, \"banner_size\": null, \"mobile_banner_image\": \"\", \"user_is_contributor\": false}}"
-        },
-        "headers": {
-          "Accept-Ranges": [
-            "bytes"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "2677"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Sun, 05 Apr 2020 00:47:30 GMT"
-          ],
-          "Server": [
-            "snooserv"
-          ],
-          "Set-Cookie": [
-            "session_tracker=dQVjKrhpv5DzWyqtMb.0.1586047650854.Z0FBQUFBQmVpU3Fpa0pDSUYwbWdXVGRVSE9mWjd1QTdwNVNCUHdwRHJHandZUTNLSWpLU25WbFBwMXhlWmlmT0VyTnZnWWlxaUtRYzgtWlJVVVZ0dTlXcEx5M19Vamg0OG5WanZld1VyMUdOanoxMkVwMjJ5bEQyOUJiYWI0NTJVbzRHemdBb2VNcEY; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 05-Apr-2020 02:47:30 GMT; secure; SameSite=None; Secure"
-          ],
-          "Strict-Transport-Security": [
-            "max-age=15552000; includeSubDomains; preload"
-          ],
-          "Vary": [
-            "accept-encoding"
-          ],
-          "Via": [
-            "1.1 varnish"
-          ],
-          "X-Cache": [
-            "MISS"
-          ],
-          "X-Cache-Hits": [
-            "0"
-          ],
-          "X-Moose": [
-            "majestic"
-          ],
-          "X-Served-By": [
-            "cache-lga21964-LGA"
-          ],
-          "X-Timer": [
-            "S1586047651.813733,VS0,VE138"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate, no-store, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "592.0"
-          ],
-          "x-ratelimit-reset": [
-            "150"
-          ],
-          "x-ratelimit-used": [
-            "8"
-          ],
-          "x-ua-compatible": [
-            "IE=edge"
-          ],
-          "x-xss-protection": [
-            "1; mode=block"
-          ]
-        },
-        "status": {
-          "code": 200,
-          "message": "OK"
-        },
-        "url": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/about/?raw_json=1"
-      }
-    },
-    {
-      "recorded_at": "2020-04-05T00:47:31",
-      "request": {
-        "body": {
-          "encoding": "utf-8",
-          "string": ""
-        },
-        "headers": {
-          "Accept": [
-            "*/*"
-          ],
-          "Accept-Encoding": [
-            "identity"
-          ],
-          "Authorization": [
-            "bearer <ACCESS_TOKEN>"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Cookie": [
-            "csv=1; edgebucket=cLYzmfbvkBmniB1ccA; loid=00000000005bn5wlvy.2.1577584524387.Z0FBQUFBQmVpU3FpUHBoLUs1M0V5V1hNMlNrei1FbUdENFc2UFlPQl9vU1UycnVTREtJdnlMcnJjVTdfT0EtbWxQTFF5cEpwVU1kMUgxVktFNzlOazVmRm9qMW1OTDI3ckJqbG84dGJEX3pLVVRDQTJudEZXVnByNTlnN2RsSF91a0V3a3YxWVdoOFo; session_tracker=dQVjKrhpv5DzWyqtMb.0.1586047650854.Z0FBQUFBQmVpU3Fpa0pDSUYwbWdXVGRVSE9mWjd1QTdwNVNCUHdwRHJHandZUTNLSWpLU25WbFBwMXhlWmlmT0VyTnZnWWlxaUtRYzgtWlJVVVZ0dTlXcEx5M19Vamg0OG5WanZld1VyMUdOanoxMkVwMjJ5bEQyOUJiYWI0NTJVbzRHemdBb2VNcEY"
-          ],
-          "User-Agent": [
-            "<USER_AGENT> PRAW/7.0.0.dev0 prawcore/1.0.1"
-          ]
-        },
-        "method": "GET",
-        "uri": "https://oauth.reddit.com/r/<TEST_SUBREDDIT>/about/edit/?raw_json=1"
-      },
-      "response": {
-        "body": {
-          "encoding": "UTF-8",
-          "string": "{\"kind\": \"subreddit_settings\", \"data\": {\"default_set\": false, \"toxicity_threshold_chat_level\": 1, \"crowd_control_chat_level\": 1, \"restrict_posting\": true, \"subreddit_id\": \"t5_2bhxu0\", \"allow_images\": true, \"free_form_reports\": true, \"domain\": null, \"show_media\": false, \"wiki_edit_age\": 0, \"submit_text\": \"\", \"spam_selfposts\": \"high\", \"title\": \"<TEST_SUBREDDIT>xx\", \"collapse_deleted_comments\": false, \"wikimode\": \"disabled\", \"over_18\": false, \"allow_videos\": true, \"spoilers_enabled\": false, \"crowd_control_level\": 0, \"crowd_control_mode\": false, \"welcome_message_enabled\": false, \"welcome_message_text\": null, \"suggested_comment_sort\": null, \"disable_contributor_requests\": false, \"original_content_tag_enabled\": false, \"description\": \"\", \"submit_link_label\": \"\", \"allow_post_crossposts\": true, \"spam_comments\": \"low\", \"public_traffic\": false, \"restrict_commenting\": false, \"allow_polls\": true, \"submit_text_label\": \"\", \"all_original_content\": false, \"key_color\": \"\", \"language\": \"en\", \"wiki_edit_karma\": 0, \"hide_ads\": false, \"header_hover_text\": \"\", \"allow_chat_post_creation\": false, \"allow_discovery\": false, \"public_description\": \"\", \"show_media_preview\": false, \"comment_score_hide_mins\": 0, \"subreddit_type\": \"public\", \"spam_links\": \"high\", \"exclude_banned_modqueue\": false, \"content_options\": \"any\"}}"
-        },
-        "headers": {
-          "Accept-Ranges": [
-            "bytes"
-          ],
-          "Connection": [
-            "keep-alive"
-          ],
-          "Content-Length": [
-            "1309"
-          ],
-          "Content-Type": [
-            "application/json; charset=UTF-8"
-          ],
-          "Date": [
-            "Sun, 05 Apr 2020 00:47:31 GMT"
-          ],
-          "Server": [
-            "snooserv"
-          ],
-          "Set-Cookie": [
-            "session_tracker=dQVjKrhpv5DzWyqtMb.0.1586047651010.Z0FBQUFBQmVpU3FqRTBSZmhIZ0hxZTJxVGJXUFJFMVRpRy1EcWExVlVCV3FIbVFnM1BZbHNVTnZ5aWM2M2paVHVGbmNRY040eVhBdjZnd1hZQk5EWno1NVRfemMwX2luTTFvRkxVaVh2NWc2ZHlJWG5SXzhRWmdwUFBRa08yYWNXS1EtVER4QWNwVnE; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 05-Apr-2020 02:47:31 GMT; secure; SameSite=None; Secure"
-          ],
-          "Strict-Transport-Security": [
-            "max-age=15552000; includeSubDomains; preload"
-          ],
-          "Vary": [
-            "accept-encoding"
-          ],
-          "Via": [
-            "1.1 varnish"
-          ],
-          "X-Cache": [
-            "MISS"
-          ],
-          "X-Cache-Hits": [
-            "0"
-          ],
-          "X-Moose": [
-            "majestic"
-          ],
-          "X-Served-By": [
-            "cache-lga21964-LGA"
-          ],
-          "X-Timer": [
-            "S1586047651.980831,VS0,VE70"
-          ],
-          "cache-control": [
-            "private, s-maxage=0, max-age=0, must-revalidate, no-store, max-age=0, must-revalidate"
-          ],
-          "expires": [
-            "-1"
-          ],
-          "x-content-type-options": [
-            "nosniff"
-          ],
-          "x-frame-options": [
-            "SAMEORIGIN"
-          ],
-          "x-ratelimit-remaining": [
-            "591.0"
-          ],
-          "x-ratelimit-reset": [
-            "149"
-          ],
-          "x-ratelimit-used": [
-            "9"
           ],
           "x-ua-compatible": [
             "IE=edge"


### PR DESCRIPTION
Fixes #1452

## Feature Summary and Justification

There's a newer endpoint (that uses PATCH) to update subreddit settings that takes only the settings that are being updated. Also, it supports the welcome message stuff from #1452. This feeds two birds with one scone, so to speak, because we get welcome message support and we can cut out the messiness of fetching (and remapping!) all current settings just to update a few.