### PR TITLE
NETWORK_TEST env variable no longer needed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,7 +163,6 @@ jobs:
     - name: Run network test
       run: pytest tests/integration/test_github_actions.py::test_github_actions
       env:
-        NETWORK_TEST: true
         NETWORK_TEST_CLIENT_ID: ${{ secrets.NETWORK_TEST_CLIENT_ID }}
         NETWORK_TEST_CLIENT_SECRET: ${{ secrets.NETWORK_TEST_CLIENT_SECRET }}
 


### PR DESCRIPTION
The purpose of this environment variable was to let the action know it's running from Github Actions, but since we directly test the presence of the client-id, it is no longer needed.