### PR TITLE
Create Reddit.delete() method

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -12,6 +12,8 @@ Unreleased
 * :class:`.PollData` and :class:`.PollOption`.
 * Ability to view poll data and poll options via the ``.poll_data`` attribute
   on poll submissions.
+* Add method :meth:`~.Reddit.delete` to :class:`.Reddit` class to support HTTP
+  DELETE requests.
 
 **Fixed**
 

--- a/praw/models/reddit/emoji.py
+++ b/praw/models/reddit/emoji.py
@@ -91,7 +91,7 @@ class Emoji(RedditBase):
         url = API_PATH["emoji_delete"].format(
             emoji_name=self.name, subreddit=self.subreddit
         )
-        self._reddit.request("DELETE", url)
+        self._reddit.delete(url)
 
     def update(
         self,

--- a/praw/models/reddit/modmail.py
+++ b/praw/models/reddit/modmail.py
@@ -294,9 +294,7 @@ class ModmailConversation(RedditBase):
            reddit.subreddit('redditdev').modmail('2gmz').unhighlight()
 
         """
-        self._reddit.request(
-            "DELETE", API_PATH["modmail_highlight"].format(id=self.id)
-        )
+        self._reddit.delete(API_PATH["modmail_highlight"].format(id=self.id))
 
     def unmute(self):
         """Unmute the non-mod user associated with the conversation.

--- a/praw/models/reddit/multi.py
+++ b/praw/models/reddit/multi.py
@@ -190,7 +190,7 @@ class Multireddit(SubredditListingMixin, RedditBase):
         path = API_PATH["multireddit_api"].format(
             multi=self.name, user=self._author.name
         )
-        self._reddit.request("DELETE", path)
+        self._reddit.delete(path)
 
     def remove(self, subreddit: Subreddit):
         """Remove a subreddit from this multireddit.
@@ -210,8 +210,8 @@ class Multireddit(SubredditListingMixin, RedditBase):
         url = API_PATH["multireddit_update"].format(
             multi=self.name, user=self._author, subreddit=subreddit
         )
-        self._reddit.request(
-            "DELETE", url, data={"model": dumps({"name": str(subreddit)})}
+        self._reddit.delete(
+            url, data={"model": dumps({"name": str(subreddit)})}
         )
         self._reset_attributes("subreddits")
 

--- a/praw/models/reddit/removal_reasons.py
+++ b/praw/models/reddit/removal_reasons.py
@@ -79,7 +79,7 @@ class RemovalReason(RedditBase):
         url = API_PATH["removal_reason"].format(
             subreddit=self.subreddit, id=self.id
         )
-        self.subreddit._reddit.request("DELETE", url)
+        self._reddit.delete(url)
 
     def update(self, message: str, title: str):
         """Update the removal reason from this subreddit.

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -1319,7 +1319,7 @@ class SubredditFilters:
             user=self.subreddit._reddit.user.me(),
             subreddit=str(subreddit),
         )
-        self.subreddit._reddit.request("DELETE", url, data={})
+        self.subreddit._reddit.delete(url)
 
 
 class SubredditFlair:

--- a/praw/models/reddit/widgets.py
+++ b/praw/models/reddit/widgets.py
@@ -1763,7 +1763,7 @@ class WidgetModeration:
         path = API_PATH["widget_modify"].format(
             widget_id=self.widget.id, subreddit=self._subreddit
         )
-        self._reddit.request("DELETE", path)
+        self._reddit.delete(path)
 
     def update(self, **kwargs):
         """Update the widget. Returns the updated widget.

--- a/praw/reddit.py
+++ b/praw/reddit.py
@@ -601,6 +601,28 @@ class Reddit:
                     return sleep_seconds
         return None
 
+    def delete(
+        self,
+        path: str,
+        data: Optional[
+            Union[Dict[str, Union[str, Any]], bytes, IO, str]
+        ] = None,
+        json=None,
+    ) -> Any:
+        """Return parsed objects returned from a DELETE request to ``path``.
+
+        :param path: The path to fetch.
+        :param data: Dictionary, bytes, or file-like object to send in the body
+            of the request (default: None).
+        :param json: JSON-serializable object to send in the body
+            of the request with a Content-Type header of application/json
+            (default: None). If ``json`` is provided, ``data`` should not be.
+
+        """
+        return self._objectify_request(
+            data=data, json=json, method="DELETE", path=path
+        )
+
     def patch(
         self,
         path: str,


### PR DESCRIPTION
## Feature Summary and Justification

This feature provides a `.delete()` method on the `Reddit` class. We already have similar methods `get`, `post`, `patch`, and `put`. It's nice to filter all the HTTP DELETE requests through this method to ensure consistency and reduce duplication.