### PR TITLE
Generator -> Iterator, and other type fixes

### DIFF
--- a/praw/models/front.py
+++ b/praw/models/front.py
@@ -1,5 +1,5 @@
 """Provide the Front class."""
-from typing import Generator, TypeVar, Union
+from typing import Iterator, TypeVar, Union
 from urllib.parse import urljoin
 
 from .listing.generator import ListingGenerator
@@ -19,7 +19,7 @@ class Front(SubredditListingMixin):
 
     def best(
         self, **generator_kwargs: Union[str, int]
-    ) -> Generator[Submission, None, None]:
+    ) -> Iterator[Submission]:
         """Return a :class:`.ListingGenerator` for best items.
 
         Additional keyword arguments are passed in the initialization of

--- a/praw/models/inbox.py
+++ b/praw/models/inbox.py
@@ -1,5 +1,5 @@
 """Provide the Front class."""
-from typing import Dict, Generator, List, TypeVar, Union
+from typing import Dict, Iterator, List, TypeVar, Union
 
 from ..const import API_PATH
 from .base import PRAWBase
@@ -15,7 +15,7 @@ class Inbox(PRAWBase):
 
     def all(
         self, **generator_kwargs: Union[str, int, Dict[str, str]]
-    ) -> Generator[Union[Message, Comment], None, None]:
+    ) -> Iterator[Union[Message, Comment]]:
         """Return a :class:`.ListingGenerator` for all inbox comments and messages.
 
         Additional keyword arguments are passed in the initialization of
@@ -63,7 +63,7 @@ class Inbox(PRAWBase):
 
     def comment_replies(
         self, **generator_kwargs: Union[str, int, Dict[str, str]]
-    ) -> Generator[Comment, None, None]:
+    ) -> Iterator[Comment]:
         """Return a :class:`.ListingGenerator` for comment replies.
 
         Additional keyword arguments are passed in the initialization of
@@ -139,7 +139,7 @@ class Inbox(PRAWBase):
 
     def mentions(
         self, **generator_kwargs: Union[str, int, Dict[str, str]]
-    ) -> Generator[Comment, None, None]:
+    ) -> Iterator[Comment]:
         r"""Return a :class:`.ListingGenerator` for mentions.
 
         A mention is :class:`.Comment` in which the authorized redditor is
@@ -182,7 +182,7 @@ class Inbox(PRAWBase):
 
     def messages(
         self, **generator_kwargs: Union[str, int, Dict[str, str]]
-    ) -> Generator[Message, None, None]:
+    ) -> Iterator[Message]:
         """Return a :class:`.ListingGenerator` for inbox messages.
 
         Additional keyword arguments are passed in the initialization of
@@ -202,7 +202,7 @@ class Inbox(PRAWBase):
 
     def sent(
         self, **generator_kwargs: Union[str, int, Dict[str, str]]
-    ) -> Generator[Message, None, None]:
+    ) -> Iterator[Message]:
         """Return a :class:`.ListingGenerator` for sent messages.
 
         Additional keyword arguments are passed in the initialization of
@@ -223,7 +223,7 @@ class Inbox(PRAWBase):
 
     def stream(
         self, **stream_options: Union[str, int, Dict[str, str]]
-    ) -> Generator[Union[Comment, Message], None, None]:
+    ) -> Iterator[Union[Comment, Message]]:
         """Yield new inbox items as they become available.
 
         Items are yielded oldest first. Up to 100 historical items will
@@ -243,7 +243,7 @@ class Inbox(PRAWBase):
 
     def submission_replies(
         self, **generator_kwargs: Union[str, int, Dict[str, str]]
-    ) -> Generator[Comment, None, None]:
+    ) -> Iterator[Comment]:
         """Return a :class:`.ListingGenerator` for submission replies.
 
         Additional keyword arguments are passed in the initialization of
@@ -293,7 +293,7 @@ class Inbox(PRAWBase):
         self,
         mark_read: bool = False,
         **generator_kwargs: Union[str, int, Dict[str, str]]
-    ) -> Generator[Union[Comment, Message], None, None]:
+    ) -> Iterator[Union[Comment, Message]]:
         """Return a :class:`.ListingGenerator` for unread comments and messages.
 
         :param mark_read: Marks the inbox as read (default: False).

--- a/praw/models/listing/generator.py
+++ b/praw/models/listing/generator.py
@@ -1,6 +1,6 @@
 """Provide the ListingGenerator class."""
 from copy import deepcopy
-from typing import Any, Dict, Iterator, Optional, TypeVar
+from typing import Any, Dict, Iterator, Optional, TypeVar, Union
 
 from ..base import PRAWBase
 from .listing import FlairListing
@@ -23,7 +23,7 @@ class ListingGenerator(PRAWBase):
         reddit: Reddit,
         url: str,
         limit: int = 100,
-        params: Optional[Dict[str, str]] = None,
+        params: Optional[Dict[str, Union[str, int]]] = None,
     ):
         """Initialize a ListingGenerator instance.
 

--- a/praw/models/listing/generator.py
+++ b/praw/models/listing/generator.py
@@ -8,7 +8,7 @@ from .listing import FlairListing
 Reddit = TypeVar("Reddit")
 
 
-class ListingGenerator(PRAWBase):
+class ListingGenerator(PRAWBase, Iterator):
     """Instances of this class generate :class:`.RedditBase` instances.
 
     .. warning:: This class should not be directly utilized. Instead you will

--- a/praw/models/listing/mixins/base.py
+++ b/praw/models/listing/mixins/base.py
@@ -1,5 +1,5 @@
 """Provide the BaseListingMixin class."""
-from typing import Any, Dict, Generator, Union
+from typing import Any, Dict, Iterator, Union
 from urllib.parse import urljoin
 
 from ...base import PRAWBase
@@ -33,7 +33,7 @@ class BaseListingMixin(PRAWBase):
         self,
         time_filter: str = "all",
         **generator_kwargs: Union[str, int, Dict[str, str]]
-    ) -> Generator[Any, None, None]:
+    ) -> Iterator[Any]:
         """Return a :class:`.ListingGenerator` for controversial submissions.
 
         :param time_filter: Can be one of: all, day, hour, month, week, year
@@ -63,7 +63,7 @@ class BaseListingMixin(PRAWBase):
 
     def hot(
         self, **generator_kwargs: Union[str, int, Dict[str, str]]
-    ) -> Generator[Any, None, None]:
+    ) -> Iterator[Any]:
         """Return a :class:`.ListingGenerator` for hot items.
 
         Additional keyword arguments are passed in the initialization of
@@ -87,7 +87,7 @@ class BaseListingMixin(PRAWBase):
 
     def new(
         self, **generator_kwargs: Union[str, int, Dict[str, str]]
-    ) -> Generator[Any, None, None]:
+    ) -> Iterator[Any]:
         """Return a :class:`.ListingGenerator` for new items.
 
         Additional keyword arguments are passed in the initialization of
@@ -113,7 +113,7 @@ class BaseListingMixin(PRAWBase):
         self,
         time_filter: str = "all",
         **generator_kwargs: Union[str, int, Dict[str, str]]
-    ) -> Generator[Any, None, None]:
+    ) -> Iterator[Any]:
         """Return a :class:`.ListingGenerator` for top submissions.
 
         :param time_filter: Can be one of: all, day, hour, month, week, year

--- a/praw/models/listing/mixins/gilded.py
+++ b/praw/models/listing/mixins/gilded.py
@@ -1,5 +1,5 @@
 """Provide the GildedListingMixin class."""
-from typing import Any, Dict, Generator, Union
+from typing import Any, Dict, Iterator, Union
 from urllib.parse import urljoin
 
 from ...base import PRAWBase
@@ -11,7 +11,7 @@ class GildedListingMixin(PRAWBase):
 
     def gilded(
         self, **generator_kwargs: Union[str, int, Dict[str, str]]
-    ) -> Generator[Any, None, None]:
+    ) -> Iterator[Any]:
         """Return a :class:`.ListingGenerator` for gilded items.
 
         Additional keyword arguments are passed in the initialization of

--- a/praw/models/listing/mixins/redditor.py
+++ b/praw/models/listing/mixins/redditor.py
@@ -1,5 +1,5 @@
 """Provide the RedditorListingMixin class."""
-from typing import Any, Dict, Generator, TypeVar, Union
+from typing import Any, Dict, Iterator, TypeVar, Union
 from urllib.parse import urljoin
 
 from ....util.cache import cachedproperty
@@ -62,7 +62,7 @@ class RedditorListingMixin(BaseListingMixin, GildedListingMixin):
 
     def downvoted(
         self, **generator_kwargs: Union[str, int, Dict[str, str]]
-    ) -> Generator[Any, None, None]:
+    ) -> Iterator[Any]:
         """Return a :class:`.ListingGenerator` for items the user has downvoted.
 
         May raise ``prawcore.Forbidden`` after issuing the request if the user
@@ -87,7 +87,7 @@ class RedditorListingMixin(BaseListingMixin, GildedListingMixin):
 
     def gildings(
         self, **generator_kwargs: Union[str, int, Dict[str, str]]
-    ) -> Generator[Any, None, None]:
+    ) -> Iterator[Any]:
         """Return a :class:`.ListingGenerator` for items the user has gilded.
 
         May raise ``prawcore.Forbidden`` after issuing the request if the user
@@ -114,7 +114,7 @@ class RedditorListingMixin(BaseListingMixin, GildedListingMixin):
 
     def hidden(
         self, **generator_kwargs: Union[str, int, Dict[str, str]]
-    ) -> Generator[Any, None, None]:
+    ) -> Iterator[Any]:
         """Return a :class:`.ListingGenerator` for items the user has hidden.
 
         May raise ``prawcore.Forbidden`` after issuing the request if the user
@@ -139,7 +139,7 @@ class RedditorListingMixin(BaseListingMixin, GildedListingMixin):
 
     def saved(
         self, **generator_kwargs: Union[str, int, Dict[str, str]]
-    ) -> Generator[Any, None, None]:
+    ) -> Iterator[Any]:
         """Return a :class:`.ListingGenerator` for items the user has saved.
 
         May raise ``prawcore.Forbidden`` after issuing the request if the user
@@ -164,7 +164,7 @@ class RedditorListingMixin(BaseListingMixin, GildedListingMixin):
 
     def upvoted(
         self, **generator_kwargs: Union[str, int, Dict[str, str]]
-    ) -> Generator[Any, None, None]:
+    ) -> Iterator[Any]:
         """Return a :class:`.ListingGenerator` for items the user has upvoted.
 
         May raise ``prawcore.Forbidden`` after issuing the request if the user

--- a/praw/models/listing/mixins/rising.py
+++ b/praw/models/listing/mixins/rising.py
@@ -1,5 +1,5 @@
 """Provide the RisingListingMixin class."""
-from typing import Dict, Generator, TypeVar, Union
+from typing import Dict, Iterator, TypeVar, Union
 from urllib.parse import urljoin
 
 from ...base import PRAWBase
@@ -13,7 +13,7 @@ class RisingListingMixin(PRAWBase):
 
     def random_rising(
         self, **generator_kwargs: Union[str, int, Dict[str, str]]
-    ) -> Generator[Submission, None, None]:
+    ) -> Iterator[Submission]:
         """Return a :class:`.ListingGenerator` for random rising submissions.
 
         Additional keyword arguments are passed in the initialization of
@@ -35,7 +35,7 @@ class RisingListingMixin(PRAWBase):
 
     def rising(
         self, **generator_kwargs: Union[str, int, Dict[str, str]]
-    ) -> Generator[Submission, None, None]:
+    ) -> Iterator[Submission]:
         """Return a :class:`.ListingGenerator` for rising submissions.
 
         Additional keyword arguments are passed in the initialization of

--- a/praw/models/listing/mixins/submission.py
+++ b/praw/models/listing/mixins/submission.py
@@ -1,5 +1,5 @@
 """Provide the SubmissionListingMixin class."""
-from typing import Dict, Generator, TypeVar, Union
+from typing import Dict, Iterator, TypeVar, Union
 
 from ....const import API_PATH
 from ...base import PRAWBase
@@ -13,7 +13,7 @@ class SubmissionListingMixin(PRAWBase):
 
     def duplicates(
         self, **generator_kwargs: Union[str, int, Dict[str, str]]
-    ) -> Generator[Submission, None, None]:
+    ) -> Iterator[Submission]:
         """Return a :class:`.ListingGenerator` for the submission's duplicates.
 
         Additional keyword arguments are passed in the initialization of

--- a/praw/models/listing/mixins/subreddit.py
+++ b/praw/models/listing/mixins/subreddit.py
@@ -1,5 +1,5 @@
 """Provide the SubredditListingMixin class."""
-from typing import Any, Dict, Generator, Optional, TypeVar, Union
+from typing import Any, Dict, Iterator, Optional, TypeVar, Union
 from urllib.parse import urljoin
 
 from ....util.cache import cachedproperty
@@ -28,7 +28,7 @@ class CommentHelper(PRAWBase):
 
     def __call__(
         self, **generator_kwargs: Union[str, int, Dict[str, str]]
-    ) -> Generator[Any, None, None]:
+    ) -> Iterator[Any]:
         """Return a :class:`.ListingGenerator` for the Subreddit's comments.
 
         Additional keyword arguments are passed in the initialization of

--- a/praw/models/listing/mixins/subreddit.py
+++ b/praw/models/listing/mixins/subreddit.py
@@ -1,5 +1,5 @@
 """Provide the SubredditListingMixin class."""
-from typing import Any, Dict, Generator, TypeVar, Union
+from typing import Any, Dict, Generator, Optional, TypeVar, Union
 from urllib.parse import urljoin
 
 from ....util.cache import cachedproperty
@@ -65,7 +65,7 @@ class SubredditListingMixin(
         """
         return CommentHelper(self)
 
-    def __init__(self, reddit: Reddit, _data: Dict[str, Any]):
+    def __init__(self, reddit: Reddit, _data: Optional[Dict[str, Any]]):
         """Initialize a SubredditListingMixin instance.
 
         :param reddit: An instance of :class:`.Reddit`.

--- a/praw/models/reddit/base.py
+++ b/praw/models/reddit/base.py
@@ -1,5 +1,5 @@
 """Provide the RedditBase class."""
-from typing import Any, Dict, TypeVar, Union
+from typing import Any, Dict, Optional, TypeVar, Union
 from urllib.parse import urlparse
 
 from ...exceptions import InvalidURL
@@ -42,7 +42,7 @@ class RedditBase(PRAWBase):
         """Return the hash of the current instance."""
         return hash(self.__class__.__name__) ^ hash(str(self).lower())
 
-    def __init__(self, reddit: Reddit, _data: Dict[str, Any]):
+    def __init__(self, reddit: Reddit, _data: Optional[Dict[str, Any]]):
         """Initialize a RedditBase instance (or a subclass).
 
         :param reddit: An instance of :class:`~.Reddit`.

--- a/praw/models/reddit/live.py
+++ b/praw/models/reddit/live.py
@@ -1,5 +1,5 @@
 """Provide the LiveThread class."""
-from typing import Any, Dict, Generator, List, Optional, TypeVar, Union
+from typing import Any, Dict, Iterator, List, Optional, TypeVar, Union
 
 from ...const import API_PATH
 from ...util.cache import cachedproperty
@@ -389,7 +389,7 @@ class LiveThread(RedditBase):
 
     def discussions(
         self, **generator_kwargs: Union[str, int, Dict[str, str]]
-    ) -> Generator[Submission, None, None]:
+    ) -> Iterator[Submission]:
         """Get submissions linking to the thread.
 
         :param generator_kwargs: keyword arguments passed to
@@ -432,7 +432,7 @@ class LiveThread(RedditBase):
 
     def updates(
         self, **generator_kwargs: Union[str, int, Dict[str, str]]
-    ) -> Generator[_LiveUpdate, None, None]:
+    ) -> Iterator[_LiveUpdate]:
         """Return a :class:`.ListingGenerator` yields :class:`.LiveUpdate` s.
 
         :param generator_kwargs: keyword arguments passed to

--- a/praw/models/reddit/multi.py
+++ b/praw/models/reddit/multi.py
@@ -216,7 +216,10 @@ class Multireddit(SubredditListingMixin, RedditBase):
         self._reset_attributes("subreddits")
 
     def update(
-        self, **updated_settings: Union[str, List[Union[str, Subreddit]]]
+        self,
+        **updated_settings: Union[
+            str, List[Union[str, Subreddit, Dict[str, str]]]
+        ]
     ):
         """Update this multireddit.
 

--- a/praw/models/redditors.py
+++ b/praw/models/redditors.py
@@ -1,7 +1,7 @@
 """Provide the Redditors class."""
 from itertools import islice
 from types import SimpleNamespace
-from typing import Dict, Generator, Iterable, TypeVar, Union
+from typing import Dict, Iterable, Iterator, TypeVar, Union
 
 import prawcore
 
@@ -22,7 +22,7 @@ class Redditors(PRAWBase):
 
     def new(
         self, **generator_kwargs: Union[str, int, Dict[str, str]]
-    ) -> Generator[Subreddit, None, None]:
+    ) -> Iterator[Subreddit]:
         """Return a :class:`.ListingGenerator` for new Redditors.
 
         :returns: Redditor profiles, which are a type of :class:`.Subreddit`.
@@ -36,7 +36,7 @@ class Redditors(PRAWBase):
 
     def popular(
         self, **generator_kwargs: Union[str, int, Dict[str, str]]
-    ) -> Generator[Subreddit, None, None]:
+    ) -> Iterator[Subreddit]:
         """Return a :class:`.ListingGenerator` for popular Redditors.
 
         :returns: Redditor profiles, which are a type of :class:`.Subreddit`.
@@ -50,7 +50,7 @@ class Redditors(PRAWBase):
 
     def search(
         self, query: str, **generator_kwargs: Union[str, int, Dict[str, str]]
-    ) -> Generator[Subreddit, None, None]:
+    ) -> Iterator[Subreddit]:
         r"""Return a :class:`.ListingGenerator` of Redditors for ``query``.
 
         :param query: The query string to filter Redditors by.
@@ -67,7 +67,7 @@ class Redditors(PRAWBase):
 
     def stream(
         self, **stream_options: Union[str, int, Dict[str, str]]
-    ) -> Generator[Subreddit, None, None]:
+    ) -> Iterator[Subreddit]:
         """Yield new Redditors as they are created.
 
         Redditors are yielded oldest first. Up to 100 historical Redditors
@@ -81,7 +81,7 @@ class Redditors(PRAWBase):
 
     def partial_redditors(
         self, ids: Iterable[str]
-    ) -> Generator[PartialRedditor, None, None]:
+    ) -> Iterator[PartialRedditor]:
         """Get user summary data by redditor IDs.
 
         :param ids: An iterable of redditor fullname IDs.

--- a/praw/models/subreddits.py
+++ b/praw/models/subreddits.py
@@ -1,5 +1,5 @@
 """Provide the Subreddits class."""
-from typing import Dict, Generator, List, Optional, Union
+from typing import Dict, Iterator, List, Optional, Union
 
 from ..const import API_PATH
 from . import Subreddit
@@ -17,7 +17,7 @@ class Subreddits(PRAWBase):
 
     def default(
         self, **generator_kwargs: Union[str, int, Dict[str, str]]
-    ) -> Generator[Subreddit, None, None]:
+    ) -> Iterator[Subreddit]:
         """Return a :class:`.ListingGenerator` for default subreddits.
 
         Additional keyword arguments are passed in the initialization of
@@ -29,7 +29,7 @@ class Subreddits(PRAWBase):
 
     def gold(
         self, **generator_kwargs: Union[str, int, Dict[str, str]]
-    ) -> Generator[Subreddit, None, None]:
+    ) -> Iterator[Subreddit]:
         """Return a :class:`.ListingGenerator` for gold subreddits.
 
         Additional keyword arguments are passed in the initialization of
@@ -41,7 +41,7 @@ class Subreddits(PRAWBase):
 
     def new(
         self, **generator_kwargs: Union[str, int, Dict[str, str]]
-    ) -> Generator[Subreddit, None, None]:
+    ) -> Iterator[Subreddit]:
         """Return a :class:`.ListingGenerator` for new subreddits.
 
         Additional keyword arguments are passed in the initialization of
@@ -53,7 +53,7 @@ class Subreddits(PRAWBase):
 
     def popular(
         self, **generator_kwargs: Union[str, int, Dict[str, str]]
-    ) -> Generator[Subreddit, None, None]:
+    ) -> Iterator[Subreddit]:
         """Return a :class:`.ListingGenerator` for popular subreddits.
 
         Additional keyword arguments are passed in the initialization of
@@ -95,7 +95,7 @@ class Subreddits(PRAWBase):
 
     def search(
         self, query: str, **generator_kwargs: Union[str, int, Dict[str, str]]
-    ) -> Generator[Subreddit, None, None]:
+    ) -> Iterator[Subreddit]:
         """Return a :class:`.ListingGenerator` of subreddits matching ``query``.
 
         Subreddits are searched by both their title and description.
@@ -148,7 +148,7 @@ class Subreddits(PRAWBase):
 
     def stream(
         self, **stream_options: Union[str, int, Dict[str, str]]
-    ) -> Generator[Subreddit, None, None]:
+    ) -> Iterator[Subreddit]:
         """Yield new subreddits as they are created.
 
         Subreddits are yielded oldest first. Up to 100 historical subreddits

--- a/praw/models/user.py
+++ b/praw/models/user.py
@@ -1,5 +1,5 @@
 """Provides the User class."""
-from typing import Dict, Generator, List, Optional, TypeVar, Union
+from typing import Dict, Iterator, List, Optional, TypeVar, Union
 
 from ..const import API_PATH
 from ..models import Preferences
@@ -62,7 +62,7 @@ class User(PRAWBase):
 
     def contributor_subreddits(
         self, **generator_kwargs: Union[str, int, Dict[str, str]]
-    ) -> Generator[Subreddit, None, None]:
+    ) -> Iterator[Subreddit]:
         """Return a :class:`.ListingGenerator` of contributor subreddits.
 
         These are subreddits that the user is a contributor of.
@@ -140,7 +140,7 @@ class User(PRAWBase):
 
     def subreddits(
         self, **generator_kwargs: Union[str, int, Dict[str, str]]
-    ) -> Generator[Subreddit, None, None]:
+    ) -> Iterator[Subreddit]:
         """Return a :class:`.ListingGenerator` of subreddits the user is subscribed to.
 
         Additional keyword arguments are passed in the initialization of

--- a/praw/reddit.py
+++ b/praw/reddit.py
@@ -479,7 +479,9 @@ class Reddit:
         return models.DomainListing(self, domain)
 
     def get(
-        self, path: str, params: Optional[Union[str, Dict[str, str]]] = None
+        self,
+        path: str,
+        params: Optional[Union[str, Dict[str, Union[str, int]]]] = None,
     ):
         """Return parsed objects returned from a GET request to ``path``.
 
@@ -587,7 +589,7 @@ class Reddit:
 
     def _handle_rate_limit(
         self, exception: RedditAPIException
-    ) -> Optional[Union[int]]:
+    ) -> Optional[Union[int, float]]:
         for item in exception.items:
             if item.error_type == "RATELIMIT":
                 amount_search = self._ratelimit_regex.search(item.message)


### PR DESCRIPTION
## Feature Summary and Justification

This is two different type-related fixes:

First, a bunch of functions claim to return a `Generator` while returning a `ListingGenerator` which technically does not satisfy the contract to be a `Generator`, though it does satisfy the `Iterator` contract. I've updated the `ListingGenerator` class to inherit from `Iterator` and updated the type signatures referencing `Generator`.

Second, I updated miscellaneous type signatures in places where PyCharm indicated they were incorrect.

## References

https://docs.python.org/3/library/typing.html#typing.Generator
