### PR TITLE
Deprecate None return value on Reddit.user.me()

### DIFF
--- a/praw/exceptions.py
+++ b/praw/exceptions.py
@@ -166,7 +166,7 @@ class InvalidImplicitAuth(ClientException):
     """Indicate exceptions where an implicit auth type is used incorrectly."""
 
     def __init__(self):
-        """Instantize the class."""
+        """Instantiate the class."""
         super().__init__(
             "Implicit authorization can only be used with installed apps."
         )

--- a/praw/models/reddit/rules.py
+++ b/praw/models/reddit/rules.py
@@ -250,7 +250,7 @@ class RuleModeration:
     """
 
     def __init__(self, rule: Rule):
-        """Instantize the RuleModeration class."""
+        """Instantiate the RuleModeration class."""
         self.rule = rule
 
     def delete(self):
@@ -340,7 +340,7 @@ class SubredditRulesModeration:
     """
 
     def __init__(self, subreddit_rules: SubredditRules):
-        """Instantize the SubredditRulesModeration class."""
+        """Instantiate the SubredditRulesModeration class."""
         self.subreddit_rules = subreddit_rules
 
     def add(

--- a/praw/models/user.py
+++ b/praw/models/user.py
@@ -1,5 +1,6 @@
 """Provides the User class."""
 from typing import Dict, Iterator, List, Optional, TypeVar, Union
+from warnings import warn
 
 from ..const import API_PATH
 from ..models import Preferences
@@ -117,7 +118,10 @@ class User(PRAWBase):
     ) -> Optional[Redditor]:  # pylint: disable=invalid-name
         """Return a :class:`.Redditor` instance for the authenticated user.
 
-        In :attr:`~praw.Reddit.read_only` mode, this method returns ``None``.
+        In read-only mode this method returns ``None``, although you should
+        use :attr:`~praw.Reddit.read_only` to check if the client has a user
+        context. This may change in future to raise an error instead of
+        returning ``None``.
 
         :param use_cache: When true, and if this function has been previously
             called, returned the cached version (default: True).
@@ -128,6 +132,14 @@ class User(PRAWBase):
 
         """
         if self._reddit.read_only:
+            warn(
+                "The None return value is deprecated. Consider "
+                "testing Reddit.read_only before calling this method. "
+                "From PRAW 8 onwards this method will start raising an "
+                "error when called in read-only mode.",
+                category=DeprecationWarning,
+                stacklevel=2,
+            )
             return None
         if "_me" not in self.__dict__ or not use_cache:
             user_data = self._reddit.get(API_PATH["me"])

--- a/praw/models/user.py
+++ b/praw/models/user.py
@@ -120,8 +120,8 @@ class User(PRAWBase):
 
         In read-only mode this method returns ``None``, although you should
         use :attr:`~praw.Reddit.read_only` to check if the client has a user
-        context. This may change in future to raise an error instead of
-        returning ``None``.
+        context. This behavior is deprecated, and will raise an exception
+        in PRAW 8.
 
         :param use_cache: When true, and if this function has been previously
             called, returned the cached version (default: True).

--- a/tests/unit/test_deprecations.py
+++ b/tests/unit/test_deprecations.py
@@ -34,3 +34,8 @@ class TestDeprecation(UnitTest):
             excinfo.value.args[0] == "Calling SubredditRules to get a list of "
             "rules is deprecated. Remove the parentheses to use the iterator."
         )
+
+    def test_reddit_user_me_read_only(self):
+        self.reddit.read_only = True
+        with pytest.raises(DeprecationWarning):
+            self.reddit.user.me()


### PR DESCRIPTION
Back in issue #962 a choice of whether to raise a better exception or return `None` was put forward. I think the wrong decision was made.

See my reasoning in #963.