### PR TITLE
Config and praw.ini changes

### DIFF
--- a/praw/config.py
+++ b/praw/config.py
@@ -1,162 +1,41 @@
 """Provides the code to load PRAW's configuration file `praw.ini`."""
-import configparser
-import os
+from os import path as op
+from os import environ, getenv
 import sys
-from threading import Lock
-from typing import Optional
-
-from .exceptions import ClientException
+from configparser import ConfigParser
+from typing import Dict, Sequence
 
 
-class _NotSet:
-    def __bool__(self):
-        return False
+def get_praw_environment_settings() -> Dict[str, str]:
+    return {k[len("praw_"):]: v for k, v in environ.items() if k.startswith("praw_")}
 
-    __nonzero__ = __bool__
+def get_potential_praw_ini_locations() -> Sequence[str]:
+    inifile = 'praw.ini'
 
-    def __str__(self):
-        return "NotSet"
+    tlp_dir = ''
+    if __name__ != '__main__':
+        top_level_package_name, _, _ = __name__.partition('.')
+        tlp_module = sys.modules[top_level_package_name]
+        tlp_dir = op.dirname(tlp_module.__file__)
 
+    getenv2 = lambda key: getenv(key, '')
+    location_components = [
+        (tlp_dir,),  # Package default
+        (getenv2('APPDATA'),),  # Windows
+        (getenv2('HOME'), '.config'),  # Legacy Linux, and macOS
+        (getenv2('XDG_CONFIG_HOME'),),  # Modern Linux
+        ('.',),  # Current working directory
+    ]
 
-class Config:
-    """A class containing the configuration for a reddit site."""
+    locations = [
+        op.join(*comps, inifile)
+        for comps in location_components
+        if comps[0]
+    ]
+    return locations
 
-    CONFIG = None
-    CONFIG_NOT_SET = _NotSet()  # Represents a config value that is not set.
-    LOCK = Lock()
-    INTERPOLATION_LEVEL = {
-        "basic": configparser.BasicInterpolation,
-        "extended": configparser.ExtendedInterpolation,
-    }
-
-    @staticmethod
-    def _config_boolean(item):
-        if isinstance(item, bool):
-            return item
-        return item.lower() in {"1", "yes", "true", "on"}
-
-    @classmethod
-    def _load_config(cls, config_interpolation: Optional[str] = None):
-        """Attempt to load settings from various praw.ini files."""
-        if config_interpolation is not None:
-            interpolator_class = cls.INTERPOLATION_LEVEL[
-                config_interpolation
-            ]()
-        else:
-            interpolator_class = None
-        config = configparser.ConfigParser(interpolation=interpolator_class)
-        module_dir = os.path.dirname(sys.modules[__name__].__file__)
-        if "APPDATA" in os.environ:  # Windows
-            os_config_path = os.environ["APPDATA"]
-        elif "XDG_CONFIG_HOME" in os.environ:  # Modern Linux
-            os_config_path = os.environ["XDG_CONFIG_HOME"]
-        elif "HOME" in os.environ:  # Legacy Linux
-            os_config_path = os.path.join(os.environ["HOME"], ".config")
-        else:
-            os_config_path = None
-        locations = [os.path.join(module_dir, "praw.ini"), "praw.ini"]
-        if os_config_path is not None:
-            locations.insert(1, os.path.join(os_config_path, "praw.ini"))
-        config.read(locations)
-        cls.CONFIG = config
-
-    @property
-    def short_url(self) -> str:
-        """Return the short url or raise a ClientException when not set."""
-        if self._short_url is self.CONFIG_NOT_SET:
-            raise ClientException("No short domain specified.")
-        return self._short_url
-
-    def __init__(
-        self,
-        site_name: str,
-        config_interpolation: Optional[str] = None,
-        **settings: str
-    ):
-        """Initialize a Config instance."""
-        with Config.LOCK:
-            if Config.CONFIG is None:
-                self._load_config(config_interpolation)
-
-        self._settings = settings
-        self.custom = dict(Config.CONFIG.items(site_name), **settings)
-
-        self.client_id = self.client_secret = self.oauth_url = None
-        self.reddit_url = self.refresh_token = self.redirect_uri = None
-        self.password = self.user_agent = self.username = None
-
-        self._initialize_attributes()
-
-    def _fetch(self, key):
-        value = self.custom[key]
-        del self.custom[key]
-        return value
-
-    def _fetch_default(self, key, default=None):
-        if key not in self.custom:
-            return default
-        return self._fetch(key)
-
-    def _fetch_or_not_set(self, key):
-        if key in self._settings:  # Passed in values have the highest priority
-            return self._fetch(key)
-
-        env_value = os.getenv("praw_{}".format(key))
-        ini_value = self._fetch_default(key)  # Needed to remove from custom
-
-        # Environment variables have higher priority than praw.ini settings
-        return env_value or ini_value or self.CONFIG_NOT_SET
-
-    def _initialize_attributes(self):
-        self._short_url = (
-            self._fetch_default("short_url") or self.CONFIG_NOT_SET
-        )
-        self.check_for_updates = self._config_boolean(
-            self._fetch_or_not_set("check_for_updates")
-        )
-        self.kinds = {
-            x: self._fetch("{}_kind".format(x))
-            for x in [
-                "comment",
-                "message",
-                "redditor",
-                "submission",
-                "subreddit",
-                "trophy",
-            ]
-        }
-
-        for attribute in (
-            "client_id",
-            "client_secret",
-            "redirect_uri",
-            "refresh_token",
-            "password",
-            "user_agent",
-            "username",
-        ):
-            setattr(self, attribute, self._fetch_or_not_set(attribute))
-
-        for required_attribute in (
-            "oauth_url",
-            "ratelimit_seconds",
-            "reddit_url",
-            "timeout",
-        ):
-            setattr(self, required_attribute, self._fetch(required_attribute))
-
-        for attribute, conversion in {
-            "ratelimit_seconds": int,
-            "timeout": int,
-        }.items():
-            try:
-                setattr(self, attribute, conversion(getattr(self, attribute)))
-            except ValueError:
-                raise ValueError(
-                    "An incorrect config type was given for option {}. The "
-                    "expected type is {}, but the given value is {}.".format(
-                        attribute,
-                        conversion.__name__,
-                        getattr(self, attribute),
-                    )
-                )
+def get_praw_config(config: ConfigParser = None) -> ConfigParser:
+    if config is None:
+        config = ConfigParser()
+    config.read(get_potential_praw_ini_locations())
+    return config

--- a/praw/models/auth.py
+++ b/praw/models/auth.py
@@ -121,7 +121,7 @@ class Auth(PRAWBase):
 
         """
         authenticator = self._reddit._read_only_core._authorizer._authenticator
-        if authenticator.redirect_uri is self._reddit.config.CONFIG_NOT_SET:
+        if authenticator.redirect_uri is None:
             raise MissingRequiredAttributeException(
                 "redirect_uri must be provided"
             )

--- a/praw/models/reddit/collections.py
+++ b/praw/models/reddit/collections.py
@@ -246,9 +246,7 @@ class CollectionModeration(PRAWBase):
                     type(post)
                 )
             )
-        if post.startswith(
-            "{}_".format(self._reddit.config.kinds["submission"])
-        ):
+        if post.startswith("t3_"):
             return post
         try:
             return self._reddit.submission(url=post).fullname

--- a/praw/models/reddit/comment.py
+++ b/praw/models/reddit/comment.py
@@ -69,6 +69,7 @@ class Comment(InboxableMixin, UserContentMixin, FullnameMixin, RedditBase):
         "This comment does not appear to be in the comment tree"
     )
     STR_FIELD = "id"
+    _kind = "t1"
 
     @staticmethod
     def id_from_url(url: str) -> str:
@@ -84,15 +85,10 @@ class Comment(InboxableMixin, UserContentMixin, FullnameMixin, RedditBase):
         return parts[-1]
 
     @property
-    def _kind(self):
-        """Return the class's kind."""
-        return self._reddit.config.kinds["comment"]
-
-    @property
     def is_root(self) -> bool:
         """Return True when the comment is a top level comment."""
         parent_type = self.parent_id.split("_", 1)[0]
-        return parent_type == self._reddit.config.kinds["submission"]
+        return parent_type == "t3"
 
     @cachedproperty
     def mod(self) -> _CommentModeration:

--- a/praw/models/reddit/emoji.py
+++ b/praw/models/reddit/emoji.py
@@ -190,7 +190,7 @@ class SubredditEmoji:
         subreddit_keys = [
             key
             for key in response.keys()
-            if key.startswith(self._reddit.config.kinds["subreddit"])
+            if key.startswith("t5")
         ]
         assert len(subreddit_keys) == 1
         for emoji_name, emoji_data in response[subreddit_keys[0]].items():

--- a/praw/models/reddit/message.py
+++ b/praw/models/reddit/message.py
@@ -42,6 +42,7 @@ class Message(InboxableMixin, ReplyableMixin, FullnameMixin, RedditBase):
     """
 
     STR_FIELD = "id"
+    _kind = "t4"
 
     @classmethod
     def parse(cls, data: Dict[str, Any], reddit: Reddit):
@@ -72,11 +73,6 @@ class Message(InboxableMixin, ReplyableMixin, FullnameMixin, RedditBase):
             return SubredditMessage(reddit, _data=data)
 
         return cls(reddit, _data=data)
-
-    @property
-    def _kind(self):
-        """Return the class's kind."""
-        return self._reddit.config.kinds["message"]
 
     def __init__(self, reddit: Reddit, _data: Dict[str, Any]):
         """Construct an instance of the Message object."""

--- a/praw/models/reddit/modmail.py
+++ b/praw/models/reddit/modmail.py
@@ -71,13 +71,9 @@ class ModmailConversation(RedditBase):
     def _convert_user_summary(data, reddit):
         """Convert dictionaries of recent user history to PRAW objects."""
         parsers = {
-            "recentComments": reddit._objector.parsers[
-                reddit.config.kinds["comment"]
-            ],
+            "recentComments": reddit._objector.parsers["t1"],
             "recentConvos": ModmailConversation,
-            "recentPosts": reddit._objector.parsers[
-                reddit.config.kinds["submission"]
-            ],
+            "recentPosts": reddit._objector.parsers["t3"],
         }
         for kind, parser in parsers.items():
             objects = []

--- a/praw/models/reddit/redditor.py
+++ b/praw/models/reddit/redditor.py
@@ -83,6 +83,7 @@ class Redditor(
     """
 
     STR_FIELD = "name"
+    _kind = "t2"
 
     @classmethod
     def from_data(cls, reddit, data):
@@ -114,11 +115,6 @@ class Redditor(
 
         """
         return RedditorStream(self)
-
-    @property
-    def _kind(self):
-        """Return the class's kind."""
-        return self._reddit.config.kinds["redditor"]
 
     @property
     def _path(self):

--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -416,6 +416,7 @@ class Submission(
     """
 
     STR_FIELD = "id"
+    _kind = "t3"
 
     @staticmethod
     def id_from_url(url: str) -> str:
@@ -444,11 +445,6 @@ class Submission(
         if not submission_id.isalnum():
             raise InvalidURL(url)
         return submission_id
-
-    @property
-    def _kind(self):
-        """Return the class's kind."""
-        return self._reddit.config.kinds["submission"]
 
     @property
     def comments(self) -> CommentForest:
@@ -525,7 +521,7 @@ class Submission(
         https://www.reddit.com/r/announcements/comments/eorhm/reddit_30_less_typing/.
 
         """
-        return urljoin(self._reddit.config.short_url, self.id)
+        return urljoin(self._reddit.settings['short_url'], self.id)
 
     def __init__(
         self,

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -117,6 +117,7 @@ class Subreddit(
 
     STR_FIELD = "display_name"
     MESSAGE_PREFIX = "#"
+    _kind = "t5"
 
     @staticmethod
     def _create_or_update(
@@ -204,11 +205,6 @@ class Subreddit(
                 [str(subreddit)] + [str(x) for x in other_subreddits]
             )
         return str(subreddit)
-
-    @property
-    def _kind(self):
-        """Return the class's kind."""
-        return self._reddit.config.kinds["subreddit"]
 
     @cachedproperty
     def banned(self):
@@ -724,7 +720,7 @@ class Subreddit(
             path = redirect.path
         try:
             return self._submission_class(
-                self._reddit, url=urljoin(self._reddit.config.reddit_url, path)
+                self._reddit, url=urljoin(self._reddit.settings['reddit_url'], path)
             )
         except ClientException:
             return None
@@ -793,7 +789,7 @@ class Subreddit(
         except Redirect as redirect:
             path = redirect.path
         return self._submission_class(
-            self._reddit, url=urljoin(self._reddit.config.reddit_url, path)
+            self._reddit, url=urljoin(self._reddit.settings['reddit_url'], path)
         )
 
     def submit(
@@ -2682,7 +2678,7 @@ class ModeratorRelationship(SubredditRelationship):
            reddit.subreddit("subredditname").moderator.leave()
 
         """
-        self.remove(self.subreddit._reddit.config.username)
+        self.remove(self.subreddit._reddit.settings['username'])
 
     def remove_invite(self, redditor):
         """Remove the moderator invite for ``redditor``.

--- a/praw/objector.py
+++ b/praw/objector.py
@@ -82,22 +82,22 @@ class Objector:
             # Prevent clobbering base-36 id
             del data["id"]
             data["is_subreddit_mod"] = data.pop("is_mod")
-            parser = self.parsers[self._reddit.config.kinds["redditor"]]
+            parser = self.parsers["t2"]
         elif {"banStatus", "muteStatus", "recentComments"}.issubset(data):
             # Modmail user
             data = snake_case_keys(data)
             data["created_string"] = data.pop("created")
-            parser = self.parsers[self._reddit.config.kinds["redditor"]]
+            parser = self.parsers["t2"]
         elif {"displayName", "id", "type"}.issubset(data):
             # Modmail subreddit
             data = snake_case_keys(data)
-            parser = self.parsers[self._reddit.config.kinds[data["type"]]]
+            parser = self.parsers[data["type"]]
         elif {"date", "id", "name"}.issubset(data) or {
             "id",
             "name",
             "permissions",
         }.issubset(data):
-            parser = self.parsers[self._reddit.config.kinds["redditor"]]
+            parser = self.parsers["t2"]
         elif {"text", "url"}.issubset(data):
             if "color" in data or "linkUrl" in data:
                 parser = self.parsers["Button"]
@@ -114,12 +114,12 @@ class Objector:
             # discards flair information
             return self._reddit.redditor(data["name"])
         elif {"parent_id"}.issubset(data):
-            parser = self.parsers[self._reddit.config.kinds["comment"]]
+            parser = self.parsers["t1"]
         elif "collection_id" in data.keys():
             parser = self.parsers["Collection"]
         else:
             if "user" in data:
-                parser = self.parsers[self._reddit.config.kinds["redditor"]]
+                parser = self.parsers["t2"]
                 data["user"] = parser.parse(
                     {"name": data["user"]}, self._reddit
                 )
@@ -160,10 +160,8 @@ class Objector:
             if "url" in data["json"]["data"]:  # Subreddit.submit
                 # The URL is the URL to the submission, so it's removed.
                 del data["json"]["data"]["url"]
-                parser = self.parsers[self._reddit.config.kinds["submission"]]
-                if data["json"]["data"]["id"].startswith(
-                    self._reddit.config.kinds["submission"] + "_"
-                ):
+                parser = self.parsers["t3"]
+                if data["json"]["data"]["id"].startswith("t3_"):
                     # With polls, Reddit returns a fullname but calls it an
                     # "id". This fixes this by coercing the fullname into an
                     # id.

--- a/praw/praw.ini
+++ b/praw/praw.ini
@@ -2,24 +2,16 @@
 # A boolean to indicate whether or not to check for package updates.
 check_for_updates=True
 
-# Object to kind mappings
-comment_kind=t1
-message_kind=t4
-redditor_kind=t2
-submission_kind=t3
-subreddit_kind=t5
-trophy_kind=t6
-
-# The URL prefix for OAuth-related requests.
+# The URL prefix for resource requests.
 oauth_url=https://oauth.reddit.com
 
 # The amount of seconds to ratelimit
 ratelimit_seconds=5
 
-# The URL prefix for regular requests.
+# The URL prefix for Reddit.
 reddit_url=https://www.reddit.com
 
-# The URL prefix for short URLs.
+# The URL prefix for short Reddit URLs.
 short_url=https://redd.it
 
 # The timeout for requests to Reddit in number of seconds


### PR DESCRIPTION
Parts of the codebase are starting to get real messy, such as the praw.config module.

If we do away with the whole Config class and use the stuff from the configparser module directly I think we’ll have a more readable and more flexible system.

* `Reddit.config` has been replaced with `Reddit.settings`. The latter is dictionary that holds all the configuration values that PRAW uses. All instances of `reddit.config.my_setting` should be changed to `reddit.settings['my_setting']`.
* The ‘kind’ mappings have been removed. I.e., the `thing_kind=t0` lines have been removed from the package praw.ini.
* The `config_interpolation` parameter is replaced by `config`, which is a ConfigParser instance. Among other things, this lets you customise the locations of where praw.ini files are read.
* Basic interpolation is now the default.
* Remove the praw_site environment variable setting.
* Make praw.ini settings take higher precedence over environment variable settings.

These changes are obviously very backwards incompatible since the `Config` class is now completely gone. Lots of tests will need to change. I’ll start changing the docs and updating tests after these ideas get some approval.
