### PR TITLE
Change current documentation to adhere to code style

### DIFF
--- a/docs/code_overview/other.rst
+++ b/docs/code_overview/other.rst
@@ -101,6 +101,7 @@ instances of them bound to an attribute of one of the PRAW models.
    other/menulink
    other/modmail
    other/modmailmessage
+   other/objector
    other/preferences
    other/poll
    other/redditbase

--- a/docs/code_overview/other/objector.rst
+++ b/docs/code_overview/other/objector.rst
@@ -1,0 +1,5 @@
+Objector
+========
+
+.. autoclass:: praw.objector.Objector
+   :inherited-members:

--- a/praw/exceptions.py
+++ b/praw/exceptions.py
@@ -65,8 +65,10 @@ class APIException(PRAWException):
     """Old class preserved for alias purposes.
 
     .. deprecated:: 7.0
+
         Class :class:`.APIException` has been deprecated in favor of
         :class:`.RedditAPIException`. This class will be removed in PRAW 8.0.
+
     """
 
     @staticmethod
@@ -154,6 +156,7 @@ class APIException(PRAWException):
             or a list containing lists of unformed errors.
         :param optional_args: Takes the second and third arguments that
             :class:`.APIException` used to take.
+
         """
         if isinstance(items, str):
             items = [[items, *optional_args]]
@@ -186,7 +189,11 @@ class InvalidFlairTemplateID(ClientException):
     """Indicate exceptions where an invalid flair template id is given."""
 
     def __init__(self, template_id: str):
-        """Initialize the class."""
+        """Initialize the class.
+
+        :param template_id: The template id of the invalid flair.
+
+        """
         super().__init__(
             "The flair template id ``{template_id}`` is invalid. If you are "
             "trying to create a flair, please use the ``add`` method.".format(
@@ -199,7 +206,7 @@ class InvalidImplicitAuth(ClientException):
     """Indicate exceptions where an implicit auth type is used incorrectly."""
 
     def __init__(self):
-        """Instantize the class."""
+        """Instantiate the class."""
         super().__init__(
             "Implicit authorization can only be used with installed apps."
         )
@@ -214,6 +221,7 @@ class InvalidURL(ClientException):
         :param url: The invalid URL.
         :param message: The message to display. Must contain a format
             identifier (``{}`` or ``{0}``). (default: ``"Invalid URL: {}"``)
+
         """
         super().__init__(message.format(url))
 
@@ -230,6 +238,7 @@ class TooLargeMediaException(ClientException):
 
         :param maximum_size: The maximum_size size of the uploaded media.
         :param actual: The actual size of the uploaded media.
+
         """
         self.maximum_size = maximum_size
         self.actual = actual
@@ -249,6 +258,7 @@ class WebSocketException(ClientException):
 
         :param message: The exception message.
         :param exception: The exception thrown by the websocket library.
+
         """
         super().__init__(message)
         self.original_exception = exception

--- a/praw/models/reddit/rules.py
+++ b/praw/models/reddit/rules.py
@@ -285,7 +285,7 @@ class RuleModeration:
     """
 
     def __init__(self, rule: Rule):
-        """Instantize the RuleModeration class."""
+        """Instantiate the RuleModeration class."""
         self.rule = rule
 
     def delete(self):
@@ -376,7 +376,7 @@ class SubredditRulesModeration:
     """
 
     def __init__(self, subreddit_rules: SubredditRules):
-        """Instantize the SubredditRulesModeration class."""
+        """Instantiate the SubredditRulesModeration class."""
         self.subreddit_rules = subreddit_rules
 
     def add(

--- a/praw/objector.py
+++ b/praw/objector.py
@@ -23,8 +23,8 @@ class Objector:
         :param data: The dict to be converted.
         :returns: An instance of :class:`~.RedditAPIException`, or ``None`` if
             ``data`` doesn't fit this model.
-        :raises: An instance of :class:`.ClientException if there are no errors
-            present in the data.
+        :raises: An instance of :class:`.ClientException` if there are no
+            errors present in the data.
 
         """
         if isinstance(data, list):

--- a/praw/reddit.py
+++ b/praw/reddit.py
@@ -286,9 +286,9 @@ class Reddit:
         .. code-block:: python
 
            reddit.live.create("title", "description")
-           
+
         To fetch an existing live thread:
-        
+
         .. code-block:: python
 
             thread = reddit.live("ukaeu1ik4sw5")


### PR DESCRIPTION
Part of #1152 

# Current changes:

## exceptions.py

* Document parameters
* Adhere to documentation style

## objector.py

* Add better inline type hints
* Document more parameters/return values/raised exceptions
* Adhere to documentation standards

### objector.rst

The objector did not actually have any documentation until now. I have added it as an `Other` class.

## reddit.py

* Add better inline type hints
* Add code examples
* Document more parameters/return values/raised exceptions
* Adhere to documentation standards