### PR TITLE
Bugfix: Correct error message when we fail to fetch a comment

### DIFF
--- a/praw/models/reddit/comment.py
+++ b/praw/models/reddit/comment.py
@@ -205,9 +205,7 @@ class Comment(InboxableMixin, UserContentMixin, FullnameMixin, RedditBase):
 
         if not data["children"]:
             raise ClientException(
-                "No data returned for comment {}".format(
-                    self.__class__.__name__, self.fullname
-                )
+                "No data returned for comment {}".format(self.fullname)
             )
 
         comment_data = data["children"][0]["data"]


### PR DESCRIPTION
This mistake was caught by flake8: the `.format()` call wasn't using one of its arguments because it was mistakenly using the name of the class in place of the fullname of the relevant comment. Presumably this happened because the code was modified from previous code that changed the error message depending on the class.