### PR TITLE
Docs: update env print statements

### DIFF
--- a/docs/getting_started/configuration/prawini.rst
+++ b/docs/getting_started/configuration/prawini.rst
@@ -44,14 +44,14 @@ user defined ``praw.ini`` files in a few other locations:
       
       .. code-block:: powershell
       
-         Write-Output "$env:<variable>"
+         $Env:<variable>
          
       You can also view environment variables in Python:
       
       .. code-block:: python
       
          import os
-         print(os.environ.get("<variable>", ""))
+         print(os.getenv("<variable>", ""))
 
 Format of praw.ini
 ------------------


### PR DESCRIPTION
The extra syntax around the PowerShell example is unnecessary.  Users will have Python 3.5+ so `getenv` will be guaranteed to be there (and is shorter to write than `environ.get`).  The quotes are unnecessary in all the shell examples, but I didn't feel that strongly about it.
