### PR TITLE
Generate objects for dictionary parameters

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,7 @@ Unreleased
 * Added :class:`.CalendarConfiguration` to represent the configuration of a
   :class:`.Calendar` widget.
 * Added :class:`.Hover` to represent the hover state of a :class:`.Button`.
+* Added :class:`.Styles` to represent widget styling information.
 
 **Changed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,7 @@ Unreleased
   DELETE requests.
 * Added :class:`.CalendarConfiguration` to represent the configuration of a
   :class:`.Calendar` widget.
+* Added :class:`.Hover` to represent the hover state of a :class:`.Button`.
 
 **Changed**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ Unreleased
   on poll submissions.
 * Add method :meth:`~.Reddit.delete` to :class:`.Reddit` class to support HTTP
   DELETE requests.
+* Added :class:`.CalendarConfiguration` to represent the configuration of a
+  :class:`.Calendar` widget.
 
 **Changed**
 

--- a/docs/code_overview/other.rst
+++ b/docs/code_overview/other.rst
@@ -88,6 +88,7 @@ instances of them bound to an attribute of one of the PRAW models.
 
    other/auth
    other/button
+   other/calendarconfiguration
    other/commentforest
    other/commenthelper
    other/config

--- a/docs/code_overview/other.rst
+++ b/docs/code_overview/other.rst
@@ -94,6 +94,7 @@ instances of them bound to an attribute of one of the PRAW models.
    other/config
    other/domainlisting
    other/emoji
+   other/hover
    other/listinggenerator
    other/image
    other/imagedata

--- a/docs/code_overview/other.rst
+++ b/docs/code_overview/other.rst
@@ -107,6 +107,7 @@ instances of them bound to an attribute of one of the PRAW models.
    other/redditorlist
    other/removalreason
    other/rule
+   other/styles
    other/sublisting
    other/submenu
    other/subredditemoji

--- a/docs/code_overview/other/calendarconfiguration.rst
+++ b/docs/code_overview/other/calendarconfiguration.rst
@@ -1,0 +1,4 @@
+CalendarConfiguration
+=====================
+.. autoclass:: praw.models.CalendarConfiguration
+   :inherited-members:

--- a/docs/code_overview/other/hover.rst
+++ b/docs/code_overview/other/hover.rst
@@ -1,0 +1,4 @@
+Hover
+=====
+.. autoclass:: praw.models.Hover
+   :inherited-members:

--- a/docs/code_overview/other/styles.rst
+++ b/docs/code_overview/other/styles.rst
@@ -1,0 +1,4 @@
+Styles
+======
+.. autoclass:: praw.models.Styles
+   :inherited-members:

--- a/praw/models/__init__.py
+++ b/praw/models/__init__.py
@@ -41,6 +41,7 @@ from .reddit.widgets import (
     ModeratorsWidget,
     PostFlairWidget,
     RulesWidget,
+    Styles,
     Submenu,
     SubredditWidgets,
     SubredditWidgetsModeration,

--- a/praw/models/__init__.py
+++ b/praw/models/__init__.py
@@ -31,6 +31,7 @@ from .reddit.widgets import (
     CalendarConfiguration,
     CommunityList,
     CustomWidget,
+    Hover,
     IDCard,
     Image,
     ImageData,

--- a/praw/models/__init__.py
+++ b/praw/models/__init__.py
@@ -28,6 +28,7 @@ from .reddit.widgets import (
     Button,
     ButtonWidget,
     Calendar,
+    CalendarConfiguration,
     CommunityList,
     CustomWidget,
     IDCard,

--- a/praw/models/reddit/widgets.py
+++ b/praw/models/reddit/widgets.py
@@ -66,6 +66,33 @@ class CalendarConfiguration(PRAWBase):
     """
 
 
+class Hover(PRAWBase):
+    """Class to represent the hover data for a :class:`.ButtonWidget`.
+
+    These values will take effect when the button is hovered over (the user
+    moves their cursor so it's on top of the button).
+
+    **Typical Attributes**
+
+    This table describes attributes that typically belong to objects of this
+    class. Since attributes are dynamically provided (see
+    :ref:`determine-available-attributes-of-an-object`), there is not a
+    guarantee that these attributes will always be present, nor is this list
+    comprehensive in any way.
+
+    ======================= ===================================================
+    Attribute               Description
+    ======================= ===================================================
+    ``color``               The hex color used to outline the button.
+    ``fillColor``           The hex color for the background of the button.
+    ``textColor``           The hex color for the text of the button.
+    ``height``              Image height. Only present on image buttons.
+    ``kind``                Either ``text`` or ``image``.
+    ``text``                The text displayed on the button.
+    ``url``                 * If the button is a text button, a link that can
+                              be visited by clicking the button.
+                            * If the button is an image button, the URL of a
+                              Reddit-hosted image.
     ``width``               Image width. Only present on image buttons.
     ======================= ===================================================
     """

--- a/praw/models/reddit/widgets.py
+++ b/praw/models/reddit/widgets.py
@@ -24,6 +24,7 @@ class Button(PRAWBase):
     Attribute               Description
     ======================= ===================================================
     ``color``               The hex color used to outline the button.
+    ``fillColor``           The hex color for the background of the button.
     ``height``              Image height. Only present on image buttons.
     ``hoverState``          A ``dict`` describing the state of the button when
                             hovered over. Optional.
@@ -31,8 +32,14 @@ class Button(PRAWBase):
     ``linkUrl``             A link that can be visited by clicking the button.
                             Only present on image buttons.
     ``text``                The text displayed on the button.
-    ``url``                 If the button is a text button, a link that can be
-                            visited by clicking the button.
+    ``textColor``           The hex color for the text of the button.
+    ``url``                 * If the button is a text button, a link that can
+                              be visited by clicking the button.
+                            * If the button is an image button, the URL of a
+                              Reddit-hosted image.
+    ``width``               Image width. Only present on image buttons.
+    ======================= ===================================================
+    """
 
                             If the button is an image button, the URL of a
                             Reddit-hosted image.

--- a/praw/models/reddit/widgets.py
+++ b/praw/models/reddit/widgets.py
@@ -41,8 +41,31 @@ class Button(PRAWBase):
     ======================= ===================================================
     """
 
-                            If the button is an image button, the URL of a
-                            Reddit-hosted image.
+
+class CalendarConfiguration(PRAWBase):
+    """Class to represent the configuration of a :class:`.Calendar`.
+
+    **Typical Attributes**
+
+    This table describes attributes that typically belong to objects of this
+    class. Since attributes are dynamically provided (see
+    :ref:`determine-available-attributes-of-an-object`), there is not a
+    guarantee that these attributes will always be present, nor is this list
+    necessarily complete.
+
+    ======================= ===================================================
+    Attribute               Description
+    ======================= ===================================================
+    ``numEvents``           The number of events to display on the calendar.
+    ``showDate``            Whether or not to show the dates of events.
+    ``showDescription``     Whether or not to show the descriptions of events.
+    ``showLocation``        Whether or not to show the locations of events.
+    ``showTime``            Whether or not to show the times of events.
+    ``showTitle``           Whether or not to show the titles of events.
+    ======================= ===================================================
+    """
+
+
     ``width``               Image width. Only present on image buttons.
     ======================= ===================================================
     """

--- a/praw/models/reddit/widgets.py
+++ b/praw/models/reddit/widgets.py
@@ -162,6 +162,28 @@ class MenuLink(PRAWBase):
     """
 
 
+class Styles(PRAWBase):
+    """Class to represent the style information of a widget.
+
+    **Typical Attributes**
+
+    This table describes attributes that typically belong to objects of this
+    class. Since attributes are dynamically provided (see
+    :ref:`determine-available-attributes-of-an-object`), there is not a
+    guarantee that these attributes will always be present, nor is this list
+    comprehensive in any way.
+
+    ======================= ===================================================
+    Attribute               Description
+    ======================= ===================================================
+    ``backgroundColor``     The background color of a widget, given as a
+                            hexadecimal (``0x######``).
+    ``headerColor``         The header color of a widget, given as a
+                            hexadecimal (``0x######``).
+    ======================= ===================================================
+    """
+
+
 class Submenu(BaseList):
     r"""Class to represent a submenu of links inside a menu.
 


### PR DESCRIPTION
Fixes # (provide issue number if applicable)

Linked to #1435 

## Feature Summary and Justification

This feature provides objects for any dictionaries that are provided as parameters.

Each commit contains a link to where the common attributes for that class were found.

## References

* Updates to Button class: https://github.com/praw-dev/praw/pull/1506/commits/fbde0e4342f9adb4d391e6654049f775db0e7afa
* CalendarConfiguration: https://github.com/praw-dev/praw/pull/1506/commits/68742ef3f70483447a15536afd88c61c5c4a0dcc
* Hover: https://github.com/praw-dev/praw/pull/1506/commits/60d77286806b0b3f1e1288d794e922951c5b190c
* Styles: https://github.com/praw-dev/praw/pull/1506/commits/2e39d72213192ce85d3f8562fa043fb3bc70c081
