### PR TITLE
Fix GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,14 +122,18 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[test]
-        pip install https://github.com/bboe/coveralls-python/archive/github_actions.zip
+        pip install https://github.com/bboe/coveralls-python/archive/master.zip
     - name: Test with pytest
       run: coverage run --source praw --module pytest
     - env:
         COVERALLS_PARALLEL: true
         COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       name: Submit to coveralls
-      run: coveralls
+      run: |
+        if [ "$GITHUB_REPOSITORY" = 'praw-dev/praw' \
+          -a "$GITHUB_EVENT_NAME" = 'push' ]; then
+            coveralls
+        fi
     - name: Check coverage
       run: coverage report -m --fail-under=100
     strategy:


### PR DESCRIPTION
First, use the proper ZIP to install coveralls. The previous one was 404-ing.

Second, perform a crude shell-based check to only run the coveralls upload stage if the repository is praw-dev/praw and that `GITHUB_EVENT_NAME` is `push`. This might mess with the way that pull requests report coverage increase/decrease, which could be an issue.

This has the effect of not reporting coverage unless the repository is praw-dev/praw. I'm not sure if this was the previous behavior.