### PR TITLE
Cleanup doc

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -120,7 +120,7 @@ Unreleased
 
 * :meth:`.SubredditFlair.update` will not error out when the flair text 
   contains quote marks.
-  
+
 **Removed**
 
 * Converting :class:`.APIException` to string will no longer escape unicode

--- a/docs/code_overview/exceptions.rst
+++ b/docs/code_overview/exceptions.rst
@@ -2,9 +2,8 @@ Exceptions in PRAW
 ==================
 
 In addition to exceptions under the ``praw.exceptions`` namespace shown below,
-exceptions might be raised that inherit from
-``prawcore.PrawcoreException``. Please see the following resource for
-information on those exceptions:
+exceptions might be raised that inherit from ``prawcore.PrawcoreException``.
+Please see the following resource for information on those exceptions:
 https://github.com/praw-dev/prawcore/blob/master/prawcore/exceptions.py
 
 praw.exceptions

--- a/docs/examples/obtain_refresh_token.py
+++ b/docs/examples/obtain_refresh_token.py
@@ -53,15 +53,14 @@ def main():
         "click create app"
     )
     client_id = input(
-        "Enter the client ID, it's the line just under "
-        "Personal use script at the top: "
+        "Enter the client ID, it's the line just under Personal use script "
+        "at the top: "
     )
     client_secret = input(
-        "Enter the client secret, it's the line next " "to secret: "
+        "Enter the client secret, it's the line next to secret: "
     )
     commaScopes = input(
-        "Now enter a comma separated list of scopes, or "
-        "all for all tokens: "
+        "Now enter a comma separated list of scopes, or all for all tokens: "
     )
 
     if commaScopes.lower() == "all":

--- a/docs/examples/obtain_refresh_token.py
+++ b/docs/examples/obtain_refresh_token.py
@@ -41,16 +41,13 @@ def send_message(client, message):
 def main():
     """Provide the program's entry point when directly executed."""
     print(
-        "Go here while logged into the account you want to create a "
-        "token for: https://www.reddit.com/prefs/apps/"
-    )
-    print(
-        "Click the create an app button. Put something in the name "
-        "field and select the script radio button."
-    )
-    print(
-        "Put http://localhost:8080 in the redirect uri field and "
-        "click create app"
+        "Go here while logged into the account you want to create a token "
+        "for: https://www.reddit.com/prefs/apps/",
+        "Click the create an app button. Put something in the name field and "
+        "select the script radio button.",
+        "Put http://localhost:8080 in the redirect uri field and click "
+        "create app.",
+        sep="\n",
     )
     client_id = input(
         "Enter the client ID, it's the line just under Personal use script "

--- a/docs/getting_started/authentication.rst
+++ b/docs/getting_started/authentication.rst
@@ -122,7 +122,7 @@ A **code flow** application is useful for two primary purposes:
 * You have an application and want to be able to access Reddit from your users'
   accounts.
 * You have a personal-use script application and you either want to
-   
+
    * limit the access one of your PRAW-based programs has to Reddit
    * avoid the hassle of 2FA (described above)
    * not pass your username and password to PRAW (and thus not keep it in memory)

--- a/docs/getting_started/authentication.rst
+++ b/docs/getting_started/authentication.rst
@@ -14,7 +14,8 @@ Before you can use any one of these with PRAW, you must first `register
 <https://www.reddit.com/prefs/apps/>`_ an application of the appropriate type
 on Reddit.
 
-If your app does not require a user context, it is :ref:`read-only <read_only_application>`.
+If your app does not require a user context, it is :ref:`read-only
+<read_only_application>`.
 
 PRAW supports the flows that each of these applications can use. The
 following table defines which tables can use which flows:
@@ -64,11 +65,13 @@ is as simple as:
 
 .. code-block:: python
 
-   reddit = praw.Reddit(client_id="SI8pN3DSbt0zor",
-                        client_secret="xaxkj7HNh8kwg8e5t4m6KvSrbTI",
-                        password="1guiwevlfo00esyy",
-                        user_agent="testscript by /u/fakebot3",
-                        username="fakebot3")
+   reddit = praw.Reddit(
+       client_id="SI8pN3DSbt0zor",
+       client_secret="xaxkj7HNh8kwg8e5t4m6KvSrbTI",
+       password="1guiwevlfo00esyy",
+       user_agent="testscript by /u/fakebot3",
+       username="fakebot3",
+   )
 
 To verify that you are authenticated as the correct user run:
 
@@ -78,13 +81,10 @@ To verify that you are authenticated as the correct user run:
 
 The output should contain the same name as you entered for ``username``.
 
-.. note:: If the following exception is raised, double-check your credentials,
-          and ensure that that the username and password you are using are for
-          the same user with which the application is associated:
-
-          .. code::
-
-             OAuthException: invalid_grant error processing request
+.. note:: If the exception ``OAuthException: invalid_grant error processing
+   request`` is raised, double-check your credentials, and ensure that that
+   the username and password you are using are for the same user with which
+   the application is associated.
 
 .. _2FA:
 
@@ -95,11 +95,13 @@ A 2FA token can be used by joining it to the password with a colon:
 
 .. code-block:: python
 
-   reddit = praw.Reddit(client_id="SI8pN3DSbt0zor",
-                        client_secret="xaxkj7HNh8kwg8e5t4m6KvSrbTI",
-                        password='1guiwevlfo00esyy:955413',
-                        user_agent="testscript by /u/fakebot3",
-                        username="fakebot3")
+   reddit = praw.Reddit(
+       client_id="SI8pN3DSbt0zor",
+       client_secret="xaxkj7HNh8kwg8e5t4m6KvSrbTI",
+       password="1guiwevlfo00esyy:955413",
+       user_agent="testscript by /u/fakebot3",
+       username="fakebot3",
+   )
 
 However, for such an app there is little benefit to using 2FA. The token
 must be refreshed after one hour; therefore, the 2FA secret would have to be
@@ -146,10 +148,12 @@ URL. You can do that as follows:
 
 .. code-block:: python
 
-   reddit = praw.Reddit(client_id="SI8pN3DSbt0zor",
-                        client_secret="xaxkj7HNh8kwg8e5t4m6KvSrbTI",
-                        redirect_uri="http://localhost:8080",
-                        user_agent="testscript by /u/fakebot3")
+   reddit = praw.Reddit(
+       client_id="SI8pN3DSbt0zor",
+       client_secret="xaxkj7HNh8kwg8e5t4m6KvSrbTI",
+       redirect_uri="http://localhost:8080",
+       user_agent="testscript by /u/fakebot3",
+   )
    print(reddit.auth.url(["identity"], "...", "permanent"))
 
 The above will output an authorization URL for a permanent token that has only
@@ -164,8 +168,8 @@ token via:
 
 .. code-block:: python
 
-    print(reddit.auth.authorize(code))
-    print(reddit.user.me())
+   print(reddit.auth.authorize(code))
+   print(reddit.user.me())
 
 The first line of output is the ``refresh_token``. You can save this for later
 use (see :ref:`using_refresh_token`).
@@ -230,9 +234,10 @@ The following flows are the **read-only mode** flows for Reddit applications
 Application-Only (Client Credentials)
 +++++++++++++++++++++++++++++++++++++
 
-This is the default flow for **read-only mode** in script and web applications.
-The idea behind this is that Reddit *can* trust these applications as coming from
-a given developer, however the application requires no logged-in user context.
+This is the default flow for **read-only mode** in script and web
+applications. The idea behind this is that Reddit *can* trust these
+applications as coming from a given developer, however the application
+requires no logged-in user context.
 
 An installed application *cannot* use this flow, because Reddit requires a
 ``client_secret`` to be given it this flow is being used. In other words,
@@ -243,19 +248,19 @@ installed applications are not considered confidential clients.
 Application-Only (Installed Client)
 +++++++++++++++++++++++++++++++++++
 
-This is the default flow for **read-only mode** in installed applications.
-The idea behind this is that Reddit *might not be able* to trust these
+This is the default flow for **read-only mode** in installed applications. The
+idea behind this is that Reddit *might not be able* to trust these
 applications as coming from a given developer. This would be able to happen if
-someone other than the developer can potentially replicate the client information
-and then pretend to be the application, such as in installed applications where
-the end user could retrieve the ``client_id``.
+someone other than the developer can potentially replicate the client
+information and then pretend to be the application, such as in installed
+applications where the end user could retrieve the ``client_id``.
 
-.. note:: No benefit is really gained from this in script or web apps.
- The one exception is for when a script or web app has multiple end users, this
- will allow you to give Reddit the information needed in order to distinguish
- different users of your app from each other (as the supplied device id *should*
- be a unique string per both device (in the case of a web app, server) and user
- (in the case of a web app, browser session).
+.. note:: No benefit is really gained from this in script or web apps. The one
+   exception is for when a script or web app has multiple end users, this will
+   allow you to give Reddit the information needed in order to distinguish
+   different users of your app from each other (as the supplied device id
+   *should* be a unique string per both device (in the case of a web app,
+   server) and user (in the case of a web app, browser session).
 
 .. _using_refresh_token:
 
@@ -267,14 +272,16 @@ of :class:`.Reddit` like so:
 
 .. code-block:: python
 
-   reddit = praw.Reddit(client_id="SI8pN3DSbt0zor",
-                        client_secret="xaxkj7HNh8kwg8e5t4m6KvSrbTI",
-                        refresh_token="WeheY7PwgeCZj4S3QgUcLhKE5S2s4eAYdxM",
-                        user_agent="testscript by u/fakebot3")
+   reddit = praw.Reddit(
+       client_id="SI8pN3DSbt0zor",
+       client_secret="xaxkj7HNh8kwg8e5t4m6KvSrbTI",
+       refresh_token="WeheY7PwgeCZj4S3QgUcLhKE5S2s4eAYdxM",
+       user_agent="testscript by u/fakebot3",
+   )
    print(reddit.auth.scopes())
 
 The output from the above code displays which scopes are available on the
 :class:`.Reddit` instance.
 
 .. note:: Observe that ``redirect_uri`` does not need to be provided in such
-          cases. It is only needed when :meth:`.url` is used.
+   cases. It is only needed when :meth:`.url` is used.

--- a/docs/getting_started/configuration/options.rst
+++ b/docs/getting_started/configuration/options.rst
@@ -115,7 +115,7 @@ in PRAW.
                     representing the amount of seconds to sleep.
 
                     .. note:: PRAW sleeps for the ratelimit plus either 1/10th
-                        of the ratelimit or 1 second, whichever is smallest.
+                       of the ratelimit or 1 second, whichever is smallest.
 
 :timeout: Controls the amount of time PRAW will wait for a request from Reddit
           to complete before throwing an exception. By default, PRAW waits
@@ -137,6 +137,5 @@ from an instance of :class:`.Reddit` you can execute:
 
    reddit.config.custom["app_debugging"]
 
-.. note:: Custom PRAW configuration environment variables are not
-          supported. You can directly access environment variables via
-          ``os.getenv``.
+.. note:: Custom PRAW configuration environment variables are not supported.
+   You can directly access environment variables via ``os.getenv``.

--- a/docs/getting_started/configuration/prawini.rst
+++ b/docs/getting_started/configuration/prawini.rst
@@ -22,34 +22,34 @@ user defined ``praw.ini`` files in a few other locations:
 
    3. In the directory specified by the ``APPDATA`` environment variable
       (Windows).
-      
+
    .. note:: To check the values of the environment variables, you can
       open up a terminal (Terminal/Terminal.app/Command Prompt/Powershell)
       and echo the variables (replacing <variable> with the name of the
       variable):
-      
+
       **MacOS/Linux**: 
-      
+
       .. code-block:: bash
-      
+
          echo "$<variable>"
-         
+
       **Windows Command Prompt**
-      
+
       .. code-block:: bat
-      
+
          echo "%<variable>%"
-         
+
       **Powershell**
-      
+
       .. code-block:: powershell
-      
+
          Write-Output "$env:<variable>"
-         
+
       You can also view environment variables in Python:
-      
+
       .. code-block:: python
-      
+
          import os
          print(os.environ.get("<variable>", ""))
 

--- a/docs/getting_started/configuration/prawini.rst
+++ b/docs/getting_started/configuration/prawini.rst
@@ -25,7 +25,7 @@ user defined ``praw.ini`` files in a few other locations:
       
    .. note:: To check the values of the environment variables, you can
       open up a terminal (Terminal/Terminal.app/Command Prompt/Powershell)
-      and echo the variables (replacing <variable> with the name of the 
+      and echo the variables (replacing <variable> with the name of the
       variable):
       
       **MacOS/Linux**: 
@@ -66,10 +66,9 @@ Reddit. The contents of the package's ``praw.ini`` file are:
 .. literalinclude:: ../../../praw/praw.ini
    :language: ini
 
-.. warning:: Avoid modifying the package's ``praw.ini`` file. Prefer instead to
-             override its values in your own ``praw.ini`` file. You can even
-             override settings of the ``DEFAULT`` site in user defined
-             ``praw.ini`` files.
+.. warning:: Avoid modifying the package's ``praw.ini`` file. Prefer instead
+   to override its values in your own ``praw.ini`` file. You can even override
+   settings of the ``DEFAULT`` site in user defined ``praw.ini`` files.
 
 Defining Additional Sites
 -------------------------
@@ -115,7 +114,7 @@ example, to use the settings defined for ``bot2`` as shown above, initialize
    reddit = praw.Reddit("bot2", user_agent="bot2 user agent")
 
 .. note:: In the above example you can obviate passing ``user_agent`` if you
-          add the setting ``user_agent=...`` in the ``[bot2]`` site definition.
+   add the setting ``user_agent=...`` in the ``[bot2]`` site definition.
 
 A site can also be selected via a ``praw_site`` environment variable. This
 approach has precedence over the ``site_name`` parameter described above.
@@ -153,6 +152,6 @@ See `Interpolation of values
 <https://docs.python.org/3/library/configparser.html#interpolation-of-values>`_
 for details.
 
-.. warning:: The ConfigParser instance is cached internally at the class level,
-             it is shared across all instances of :class:`.Reddit` and once set
-             it's not overridden by future invocations.
+.. warning:: The ConfigParser instance is cached internally at the class
+   level, it is shared across all instances of :class:`.Reddit` and once set
+   it's not overridden by future invocations.

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -8,10 +8,10 @@ PRAW supports Python 3.5+. The recommended way to install PRAW is via ``pip``.
    pip install praw
 
 .. note:: Depending on your system, you may need to use ``pip3`` to install
-          packages for Python 3.
+   packages for Python 3.
 
 .. warning:: Avoid using ``sudo`` to install packages. Do you `really` trust
-             this package?
+   this package?
 
 For instructions on installing Python and pip see "The Hitchhiker's Guide to
 Python" `Installation Guides

--- a/docs/getting_started/logging.rst
+++ b/docs/getting_started/logging.rst
@@ -27,7 +27,7 @@ similar to the following:
    Data: None
    Params: {'raw_json': 1}
    Response: 200 (876 bytes)
-   
+
 Furthermore, any API ratelimits from POST actions that are handled will produce
 a log entry with a message similar to the following message:
 

--- a/docs/getting_started/multiple_instances.rst
+++ b/docs/getting_started/multiple_instances.rst
@@ -5,9 +5,9 @@ PRAW, as of version 4, performs rate limiting dynamically based on the HTTP
 response headers from Reddit. As a result you can safely run a handful of PRAW
 instances without any additional configuration.
 
-.. note:: Running more than a dozen or so instances of PRAW concurrently
-          may occasionally result in exceeding Reddit's rate limits as each
-          instance can only guess how many other instances are running.
+.. note:: Running more than a dozen or so instances of PRAW concurrently may
+   occasionally result in exceeding Reddit's rate limits as each instance can
+   only guess how many other instances are running.
 
 If you are authorized on other users' behalf, each authorization should have
 its own rate limit, even when running from a single IP address.
@@ -17,8 +17,8 @@ Multiple Programs
 
 The recommended way to run multiple instances of PRAW is to simply write
 separate independent Python programs. With this approach one program can
-monitor a comment stream and reply as needed, and another program can monitor a
-submission stream, for example.
+monitor a comment stream and reply as needed, and another program can monitor
+a submission stream, for example.
 
 If these programs need to share data consider using a third-party system such
 as a database or queuing system.
@@ -35,11 +35,10 @@ of reasons in its own code and each instance depends on an instance of
 
 In theory, having a unique :class:`.Reddit` instance for each thread, and
 making sure that the instances are used in their respective threads only, will
-work. :class:`multiprocessing.Process` has been confirmed to work with PRAW, so
-that is a viable choice as well. However, there are various errors with
-:class:`multiprocessing.pool.Pool`, thus it is not supported by PRAW. Please use
-``multiprocessing.pool.ThreadPool`` as an alternative to a process
-pool.
+work. :class:`multiprocessing.Process` has been confirmed to work with PRAW,
+so that is a viable choice as well. However, there are various errors with
+:class:`multiprocessing.pool.Pool`, thus it is not supported by PRAW. Please
+use ``multiprocessing.pool.ThreadPool`` as an alternative to a process pool.
 
 Please see `this discussion
 <https://www.reddit.com/r/redditdev/comments/5uwxke/praw4_is_praw4_thread_safe/>`_

--- a/docs/getting_started/quick_start.rst
+++ b/docs/getting_started/quick_start.rst
@@ -53,12 +53,12 @@ Common Tasks
 Obtain a :class:`.Reddit` Instance
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. warning:: For the sake of brevity, the following examples pass authentication
-             information via arguments to :py:func:`praw.Reddit`. If you do
-             this, you need to be careful not to reveal this information to the
-             outside world if you share your code. It is recommended to use a
-             :ref:`praw.ini file <praw.ini>` in order to keep your
-             authentication information separate from your code.
+.. warning:: For the sake of brevity, the following examples pass
+   authentication information via arguments to :py:func:`praw.Reddit`. If you
+   do this, you need to be careful not to reveal this information to the
+   outside world if you share your code. It is recommended to use a
+   :ref:`praw.ini file <praw.ini>` in order to keep your authentication
+   information separate from your code.
 
 You need an instance of the :class:`.Reddit` class to do *anything* with
 PRAW. There are two distinct states a :class:`.Reddit` instance can be in:
@@ -111,10 +111,9 @@ If you want to do more than retrieve public information from Reddit, then you
 need an authorized :class:`.Reddit` instance.
 
 .. note:: In the above example we are limiting the results to 10. Without the
-          ``limit`` parameter PRAW should yield as many results as it can with
-          a single request. For most endpoints this results in 100 items per
-          request. If you want to retrieve as many as possible pass in
-          ``limit=None``.
+   ``limit`` parameter PRAW should yield as many results as it can with a
+   single request. For most endpoints this results in 100 items per request.
+   If you want to retrieve as many as possible pass in ``limit=None``.
 
 .. _authorized:
 
@@ -153,8 +152,8 @@ switch back to read-only mode whenever you want:
    reddit.read_only = True
 
 .. note:: If you are uncomfortable hard-coding your credentials into your
-          program, there are some options available to you. Please see:
-          :ref:`configuration`.
+   program, there are some options available to you. Please see:
+   :ref:`configuration`.
 
 Obtain a :class:`.Subreddit`
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -201,9 +200,9 @@ submissions based on the ``hot`` sort for a given subreddit try:
        print(submission.url)    # Output: the URL the submission points to
                                 # or the submission's URL if it's a self post
 
-.. note:: The act of calling a method that returns a :class:`.ListingGenerator`
-          does not result in any network requests until you begin to iterate
-          through the :class:`.ListingGenerator`.
+.. note:: The act of calling a method that returns a
+   :class:`.ListingGenerator` does not result in any network requests until
+   you begin to iterate through the :class:`.ListingGenerator`.
 
 You can create :class:`.Submission` instances in other ways too:
 
@@ -255,24 +254,24 @@ want to iterate over *all* comments as a flattened list you can call the
    all_comments = submission.comments.list()
 
 .. note:: The comment sort order can be changed by updating the value of
-          ``comment_sort`` on the :class:`.Submission` instance prior to
-          accessing ``comments`` (see: `/api/set_suggested_sort
-          <https://www.reddit.com/dev/api#POST_api_set_suggested_sort>`_ for
-          possible values). For example to have comments sorted by ``new`` try
-          something like:
+   ``comment_sort`` on the :class:`.Submission` instance prior to accessing
+   ``comments`` (see: `/api/set_suggested_sort
+   <https://www.reddit.com/dev/api#POST_api_set_suggested_sort>`_ for possible
+   values). For example to have comments sorted by ``new`` try something like:
 
-          .. code-block:: python
+    .. code-block:: python
 
-             # assume you have a Reddit instance bound to variable `reddit`
-             submission = reddit.submission(id="39zje0")
-             submission.comment_sort = "new"
-             top_level_comments = list(submission.comments)
+       # assume you have a Reddit instance bound to variable `reddit`
+       submission = reddit.submission(id="39zje0")
+       submission.comment_sort = "new"
+       top_level_comments = list(submission.comments)
 
-As you may be aware there will periodically be :class:`.MoreComments` instances
-scattered throughout the forest. Replace those :class:`.MoreComments` instances
-at any time by calling :meth:`.replace_more` on a :class:`.CommentForest`
-instance. Calling :meth:`.replace_more` access ``comments``, and so must be done
-after ``comment_sort`` is updated. See :ref:`extracting_comments` for an example.
+As you may be aware there will periodically be :class:`.MoreComments`
+instances scattered throughout the forest. Replace those
+:class:`.MoreComments` instances at any time by calling :meth:`.replace_more`
+on a :class:`.CommentForest` instance. Calling :meth:`.replace_more` access
+``comments``, and so must be done after ``comment_sort`` is updated. See
+:ref:`extracting_comments` for an example.
 
 .. _determine-available-attributes-of-an-object:
 

--- a/docs/package_info/contributing.rst
+++ b/docs/package_info/contributing.rst
@@ -14,9 +14,9 @@ checks. The following are PRAW-specific guidelines in addition to those PEP's.
 
 .. note:: In order to install the dependencies needed to run the script, you can
    install the ``[dev]`` package of praw, like so:
-   
+
    .. code-block:: bash
-   
+
       pip install praw[dev]
 
 Code

--- a/docs/tutorials/comments.rst
+++ b/docs/tutorials/comments.rst
@@ -45,7 +45,7 @@ or with the submission's ID which comes after ``comments/`` in the URL:
    submission = reddit.submission(id="3g1jfi")
 
 With a submission object we can then interact with its :class:`.CommentForest`
-through the submission's :attr:`~praw.models.Submission.comments` attribute. A
+through the submission's :attr:`~.praw.models.Submission.comments` attribute. A
 :class:`.CommentForest` is a list of top-level comments each of which contains
 a :class:`.CommentForest` of replies.
 
@@ -75,10 +75,10 @@ thread" links encountered on the website. While we could ignore
 The ``replace_more`` method
 ---------------------------
 
-In the previous snippet, we used ``isinstance`` to check whether the item
-in the comment list was a :class:`.MoreComments` so that we could ignore it.
-But there is a better way: the :class:`.CommentForest` object has a method
-called :meth:`.replace_more`, which replaces or removes :class:`.MoreComments`
+In the previous snippet, we used ``isinstance`` to check whether the item in
+the comment list was a :class:`.MoreComments` so that we could ignore it. But
+there is a better way: the :class:`.CommentForest` object has a method called
+:meth:`.replace_more`, which replaces or removes :class:`.MoreComments`
 objects from the forest.
 
 Each replacement requires one network request, and its response may yield
@@ -148,8 +148,8 @@ order as the code above. Thus the above can be rewritten as:
    for comment in submission.comments.list():
        print(comment.body)
 
-You can now properly extract and parse all (or most) of the comments
-belonging to a single submission. Combine this with :ref:`submission iteration
+You can now properly extract and parse all (or most) of the comments belonging
+to a single submission. Combine this with :ref:`submission iteration
 <submission-iteration>` and you can build some really cool stuff.
 
 Finally, note that the value of ``submission.num_comments`` may not match up

--- a/docs/tutorials/refresh_token.rst
+++ b/docs/tutorials/refresh_token.rst
@@ -5,8 +5,8 @@ Obtaining a Refresh Token
 
 The following program can be used to obtain a refresh token with the desired
 scopes. Such a token can be used in conjunction with the ``refresh_token``
-keyword argument using in initializing an instance of :class:`~praw.Reddit`.
-A list of all possible scopes can be found in the `reddit API docs
+keyword argument using in initializing an instance of :class:`~praw.Reddit`. A
+list of all possible scopes can be found in the `reddit API docs
 <https://www.reddit.com/dev/api/oauth>`_
 
 .. literalinclude:: ../examples/obtain_refresh_token.py

--- a/docs/tutorials/reply_bot.rst
+++ b/docs/tutorials/reply_bot.rst
@@ -12,8 +12,8 @@ are powered by PRAW.
 
 This tutorial will show you how to build a bot that monitors a particular
 subreddit, `/r/AskReddit <https://www.reddit.com/r/AskReddit/>`_, for new
-submissions containing simple questions and replies with an appropriate link to
-lmgtfy_ (Let Me Google That For You).
+submissions containing simple questions and replies with an appropriate link
+to lmgtfy_ (Let Me Google That For You).
 
 There are three key components we will address to perform this task:
 
@@ -38,8 +38,7 @@ Two examples of such questions are:
 2. "How many feet are in a yard?"
 
 Once we identify these questions, the LMGTFY Bot will reply to the submission
-with an appropriate lmgtfy_ link. For the example
-questions those links are:
+with an appropriate lmgtfy_ link. For the example questions those links are:
 
 1. https://lmgtfy.com/?q=What+is+the+capital+of+Canada%3F
 
@@ -148,10 +147,10 @@ representation so that a question like "What is the capital of Canada?" is
 transformed into the link
 ``https://lmgtfy.com/?q=What+is+the+capital+of+Canada%3F)``.
 
-There are a number of ways we could accomplish this task. For starters we could
-write a function to replace spaces with pluses, ``+``, and question marks with
-``%3F``. However, there is even an easier way; using an existing built-in
-function to do so.
+There are a number of ways we could accomplish this task. For starters we
+could write a function to replace spaces with pluses, ``+``, and question
+marks with ``%3F``. However, there is even an easier way; using an existing
+built-in function to do so.
 
 Add the following code where the "do something with a matched submission"
 comment is located:
@@ -211,9 +210,9 @@ Observe that we added some comments and a ``print`` call. The ``print``
 addition informs us every time we are about to reply to a submission, which is
 useful to ensure the script is running.
 
-Next, it is a good practice to not have any top-level executable code in
-case you want to turn your Python script into a Python module, i.e., import it
-from another Python script or module. A common way to do that is to move the
+Next, it is a good practice to not have any top-level executable code in case
+you want to turn your Python script into a Python module, i.e., import it from
+another Python script or module. A common way to do that is to move the
 top-level code to a ``main`` function:
 
 .. include:: ../examples/lmgtfy_bot.py

--- a/tools/static_word_checks.py
+++ b/tools/static_word_checks.py
@@ -27,8 +27,8 @@ class StaticChecker:
         """Checks the code for ``.. code::`` statements.
 
         :param filename: The name of the file to check & replace.
-        :param content: The content of the file
-        :returns: A boolean with the status of the check
+        :param content: The content of the file.
+        :returns: A boolean with the status of the check.
         """
         if ".. code::" in content:
             newcontent = content.replace(".. code::", ".. code-block::")
@@ -51,8 +51,8 @@ class StaticChecker:
         """Checks a file for double-slash statements (``/r/`` and ``/u/``).
 
         :param filename: The name of the file to check & replace.
-        :param content: The content of the file
-        :returns: A boolean with the status of the check
+        :param content: The content of the file.
+        :returns: A boolean with the status of the check.
         """
         if (
             os.path.join("praw", "const.py")  # fails due to bytes blocks


### PR DESCRIPTION
This cleanup uses three standards:

1. The black standard to reformat Python code
2. The directive standard to indent 3 spaces
3. The width standard to try and fit all words into 79 characters/line