### PR TITLE
docs: add body_html to doc strings..update AUTHORS.rst [#1495]

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -61,4 +61,5 @@ Source Contributors
 - George Schizas `@gschizas <https://github.com/gschizas>`_
 - Todd Roberts `@toddrob99 <https://github.com/toddrob99>`_
 - MaybeNetwork `@MaybeNetwork <https://github.com/MaybeNetwork>`_
+- Nick Kelly `@nickatnight <https://github.com/nickatnight>`_
 <!-- - Add "Name <email (optional)> and github profile link" above this line. -->

--- a/praw/models/reddit/comment.py
+++ b/praw/models/reddit/comment.py
@@ -35,7 +35,8 @@ class Comment(InboxableMixin, UserContentMixin, FullnameMixin, RedditBase):
     Attribute               Description
     ======================= ===================================================
     ``author``              Provides an instance of :class:`.Redditor`.
-    ``body``                The body of the comment.
+    ``body``                The body of the comment, as Markdown.
+    ``body_html``           The body of the comment, as HTML.
     ``created_utc``         Time the comment was created, represented in
                             `Unix Time`_.
     ``distinguished``       Whether or not the comment is distinguished.

--- a/praw/models/reddit/message.py
+++ b/praw/models/reddit/message.py
@@ -26,7 +26,8 @@ class Message(InboxableMixin, ReplyableMixin, FullnameMixin, RedditBase):
     Attribute               Description
     ======================= ===================================================
     ``author``              Provides an instance of :class:`.Redditor`.
-    ``body``                The body of the message.
+    ``body``                The body of the message, as Markdown.
+    ``body_html``           The body of the message, as HTML.
     ``created_utc``         Time the message was created, represented in
                             `Unix Time`_.
     ``dest``                Provides an instance of :class:`.Redditor`. The
@@ -113,7 +114,8 @@ class SubredditMessage(Message):
     Attribute               Description
     ======================= ===================================================
     ``author``              Provides an instance of :class:`.Redditor`.
-    ``body``                The body of the message.
+    ``body``                The body of the message, as Markdown.
+    ``body_html``           The body of the message, as HTML.
     ``created_utc``         Time the message was created, represented in
                             `Unix Time`_.
     ``dest``                Provides an instance of :class:`.Redditor`. The


### PR DESCRIPTION
Fixes #1495

## Feature Summary and Justification

This just adds `body_html` to the doc strings of `Comment`, `Message`, and `SubredditMessage`. The latest version of `praw` seems to have this attr available for `Comment`

## References
<img width="411" alt="Screen Shot 2020-07-01 at 9 58 41 PM" src="https://user-images.githubusercontent.com/8783431/86318155-1193ea00-bbe6-11ea-9e11-8bdc9f0b9874.png">

