### PR TITLE
Fix pre-push script to work on Windows

### DIFF
--- a/pre_push.py
+++ b/pre_push.py
@@ -52,7 +52,7 @@ def run_static():
             path.join(current_directory, "tools", "check_documentation.py"),
         ]
     )
-    success &= do_process(["black ."], shell=True)
+    success &= do_process(["black", "."], shell=True)
     success &= do_process(["flake8", "--exclude=.eggs,build,docs"])
     success &= do_process(["pydocstyle", "praw"])
     # success &= do_process(["pylint", "--rcfile=.pylintrc", "praw"])

--- a/pre_push.py
+++ b/pre_push.py
@@ -52,7 +52,7 @@ def run_static():
             path.join(current_directory, "tools", "check_documentation.py"),
         ]
     )
-    success &= do_process(["black", "."], shell=True)
+    success &= do_process(["black", "."])
     success &= do_process(["flake8", "--exclude=.eggs,build,docs"])
     success &= do_process(["pydocstyle", "praw"])
     # success &= do_process(["pylint", "--rcfile=.pylintrc", "praw"])


### PR DESCRIPTION
## Feature Summary and Justification

Since Windows and all Unix-based OSes have different conventions on process initialization, check_call needs to always be a list, so that Python can accomondate each operating system. The changed line translates as "execute a file named `black ..exe`", not "execute a file named `black.exe` with a parameter of `.`", as it does on Unix. The fix just converts the list of arguments to an actual list of arguments.