### PR TITLE
Fix bug with leaving as a moderator when using token auth

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,9 @@ Unreleased
 
 * :meth:`~.Subreddits.gold` is superseded by :meth:`~.Subreddits.premium`.
 
+**Fixed**
+
+* An issue where leaving as a moderator fails if you are using token auth.
 
 7.1.0 (2020/06/22)
 ------------------

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -2636,7 +2636,9 @@ class ModeratorRelationship(SubredditRelationship):
            reddit.subreddit("subredditname").moderator.leave()
 
         """
-        self.remove(self.subreddit._reddit.config.username)
+        self.remove(
+            self.subreddit._reddit.config.username or self.subreddit._reddit.user.me()
+        )
 
     def remove_invite(self, redditor):
         """Remove the moderator invite for ``redditor``.


### PR DESCRIPTION
## Feature Summary and Justification

This fixes a bug when the user is using token auth and then tries to leave as a moderator from a subreddit.
