### PR TITLE
pin update_checker version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     extras_require=extras,
     install_requires=[
         "prawcore >=1.3.0, <2.0",
-        "update_checker >=0.17",
+        "update_checker==0.17",
         "websocket-client >=0.54.0",
     ],
     keywords="reddit api wrapper",

--- a/setup.py
+++ b/setup.py
@@ -53,7 +53,7 @@ setup(
     extras_require=extras,
     install_requires=[
         "prawcore >=1.3.0, <2.0",
-        "update_checker==0.17",
+        "update_checker ==0.17",
         "websocket-client >=0.54.0",
     ],
     keywords="reddit api wrapper",


### PR DESCRIPTION
.18 release breaks python3.5 and earlier versions

.18 commit message release notes: https://github.com/bboe/update_checker/commit/bb0e0081528069d1d57c192db0cf8211b25ff630

Example of failure: https://travis-ci.org/github/Almenon/AREPL-backend/jobs/715008376