### PR TITLE
Use least-recently-used eviction policy for stream BoundedSet

### DIFF
--- a/praw/models/util.py
+++ b/praw/models/util.py
@@ -1,6 +1,7 @@
 """Provide helper classes used by other models."""
 import random
 import time
+from collections import OrderedDict
 from typing import Any, Callable, Generator, List, Optional, Set
 
 
@@ -13,19 +14,23 @@ class BoundedSet:
     def __init__(self, max_items: int):
         """Construct an instance of the BoundedSet."""
         self.max_items = max_items
-        self._fifo = []
-        self._set = set()
+        self._set = OrderedDict()
 
     def __contains__(self, item: Any) -> bool:
         """Test if the BoundedSet contains item."""
+        self._access(item)
         return item in self._set
+
+    def _access(self, item: Any):
+        if item in self._set:
+            self._set.move_to_end(item)
 
     def add(self, item: Any):
         """Add an item to the set discarding the oldest item if necessary."""
-        if len(self._set) == self.max_items:
-            self._set.remove(self._fifo.pop(0))
-        self._fifo.append(item)
-        self._set.add(item)
+        self._access(item)
+        self._set[item] = None
+        if len(self._set) > self.max_items:
+            self._set.popitem(last=False)
 
 
 class ExponentialCounter:

--- a/tests/unit/models/test_util.py
+++ b/tests/unit/models/test_util.py
@@ -1,6 +1,13 @@
 """Test praw.models.util."""
-from praw.models.util import ExponentialCounter, permissions_string
+from collections import namedtuple
+from unittest import mock
 
+from praw.models.util import (
+    ExponentialCounter,
+    permissions_string,
+    stream_generator,
+    BoundedSet,
+)
 from .. import UnitTest
 
 
@@ -38,7 +45,58 @@ class TestExponentialCounter(UnitTest):
             counter.reset()
 
 
-class TestUtil(UnitTest):
+class TestBoundedSet(UnitTest):
+    def test_contains(self):
+        bset = BoundedSet(max_items=10)
+        bset.add(1)
+        assert 1 in bset
+
+    def test_bound(self):
+        bset = BoundedSet(max_items=10)
+        [bset.add(i) for i in range(11)]
+        assert len(bset._set) == 10
+        assert 0 not in bset
+
+    def test_lru_add(self):
+        bset = BoundedSet(max_items=10)
+        [bset.add(i) for i in range(10)]
+        bset.add(0)
+        bset.add(10)
+        assert 0 in bset
+        assert 1 not in bset
+
+    def test_lru_contains(self):
+        bset = BoundedSet(max_items=10)
+        [bset.add(i) for i in range(10)]
+        assert 0 in bset
+        bset.add(10)
+        assert 0 in bset
+        assert 1 not in bset
+
+
+class TestStream(UnitTest):
+    @mock.patch("time.sleep", return_value=None)
+    def test_stream(self, _):
+        Thing = namedtuple("Thing", ["fullname"])
+        initial_things = [Thing(n) for n in reversed(range(100))]
+        counter = 99
+
+        def generate(limit, **kwargs):
+            nonlocal counter
+            counter += 1
+            if counter % 2 == 0:
+                return initial_things
+            return [Thing(counter)] + initial_things[:-1]
+
+        stream = stream_generator(generate)
+        seen = set()
+        for _ in range(400):
+            thing = next(stream)
+            assert thing not in seen
+            seen.add(thing)
+
+
+class TestPermissionsString(UnitTest):
     PERMISSIONS = {"a", "b", "c"}
 
     def test_permissions_string__all_explicit(self):


### PR DESCRIPTION
This PR changes the `BoundedSet` class used for streams to evict its least-recently-used element, rather than its oldest element.

The change includes a unit test where elements are duplicated in the stream. In this test, new items are added and removed from the head of the listing one one at a time. Even though the original items are seen at least every other fetch, the new items end up filling the cache and causing us to forget the old items.

I think I've seen behavior like this in production, though I don't have proof. In a slow-moving subreddit where a lot of submissions get removed, we've seen duplicates in the `submissions` stream. I think this scenario is basically similar to the test case, in that a high proportion of newly-seen items don't remain present in the listing.

It's presumably not possible to completely avoid duplicates when the cache is bounded and items can leave and re-enter the listing (e.g. because of removals). I'm not sure if there are real-world cases where the new behavior is worse.