### PR TITLE
Fix CommentForest.list() method signature

### DIFF
--- a/praw/models/comment_forest.py
+++ b/praw/models/comment_forest.py
@@ -93,7 +93,7 @@ class CommentForest:
         for comment in comments:
             comment.submission = self._submission
 
-    def list(self) -> Union["Comment", "MoreComments"]:
+    def list(self) -> List[Union["Comment", "MoreComments"]]:
         """Return a flattened list of all Comments.
 
         This list may contain :class:`.MoreComments` instances if :meth:`.replace_more`


### PR DESCRIPTION
## Feature Summary and Justification

This PR provides a very minor change to a method's return signature. When I was using `CommentForest.list()`, the signature suggested that it would just return one of `Comment` or `MoreComments`, while its description did correctly say that there was a list being returned.
