### PR TITLE
Add mention for Async PRAW

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,6 +88,14 @@ With the ``reddit`` instance you can then interact with Reddit:
 Please see PRAW's `documentation <https://praw.readthedocs.io/>`_ for
 more examples of what you can do with PRAW.
 
+Discord Bots and Asynchronous Environments
+------------------------------------------
+
+If you plan on using PRAW in an asynchronous environment, (e.g., discord.py, asyncio) it
+is strongly recommended to use `Async PRAW <https://asyncpraw.readthedocs.io/>`_. It is
+the official asynchronous version of PRAW and its usage is similar and has the same
+features as PRAW.
+
 PRAW Discussion and Support
 ---------------------------
 

--- a/docs/getting_started/multiple_instances.rst
+++ b/docs/getting_started/multiple_instances.rst
@@ -14,6 +14,14 @@ any additional configuration.
 If you are authorized on other users' behalf, each authorization should have its own
 rate limit, even when running from a single IP address.
 
+Discord Bots and Asynchronous Environments
+------------------------------------------
+
+If you plan on using PRAW in an asynchronous environment, (e.g., discord.py, asyncio) it
+is strongly recommended to use `Async PRAW <https://asyncpraw.readthedocs.io/>`_. It is
+the official asynchronous version of PRAW and its usage is similar and has the same
+features as PRAW.
+
 Multiple Programs
 -----------------
 


### PR DESCRIPTION
This adds a mention for Async PRAW as I am seeing more people using PRAW with discord bots which can cause unexpected bot crashes if PRAW blocks too long.