### PR TITLE
Add newline to fix reST syntax

### DIFF
--- a/praw/models/reddit/comment.py
+++ b/praw/models/reddit/comment.py
@@ -114,6 +114,7 @@ class Comment(InboxableMixin, UserContentMixin, FullnameMixin, RedditBase):
         Sort order and reply limit can be set with the ``reply_sort`` and
         ``reply_limit`` attributes before replies are fetched, including any call to
         :meth:`.refresh`:
+
         .. code-block:: python
 
             comment.reply_sort = "new"


### PR DESCRIPTION
Just a small thing I noticed while reading the docs. The newline got deleted with 24bc2602d4034b3fb9302456261b7b2025cb426d and currently leads to badly rendered docs at https://praw.readthedocs.io/en/latest/code_overview/models/comment.html#praw.models.Comment.replies