### PR TITLE
Add changelog entry for #1547

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -20,8 +20,7 @@ Unreleased
 
 * Drop support for Python 3.5, which is end-of-life on 2020-09-13.
 * :class:`~.BoundedSet` will now utilize a Last-Recently-Used (LRU) storing mechanism,
-  which will change the order in which elements are removed from the set, but it should
-  not be noticeable.
+  which will change the order in which elements are removed from the set.
 
 **Deprecated**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,9 @@ Unreleased
 **Changed**
 
 * Drop support for Python 3.5, which is end-of-life on 2020-09-13.
+* :class:`~.BoundedSet` will now utilize a Last-Recently-Used (LRU) storing mechanism,
+  which will change the order in which elements are removed from the set, but it should
+  not be noticeable.
 
 **Deprecated**
 


### PR DESCRIPTION
This adds a changelog entry for the new storage mechanism because it may behave differently than it has been before the changes.