### PR TITLE
reset yielded field to zero

### DIFF
--- a/praw/models/listing/generator.py
+++ b/praw/models/listing/generator.py
@@ -68,6 +68,7 @@ class ListingGenerator(PRAWBase, Iterator):
 
     def _next_batch(self):
         if self._exhausted:
+            self.yielded = 0
             raise StopIteration()
 
         self._listing = self._reddit.get(self.url, params=self.params)


### PR DESCRIPTION
This is to be able to rerun the generator.

Fixes #1593 

## Feature Summary and Justification

This feature provides the ability to rerun an itteration of a collection

