### PR TITLE
Add another changelog entry for #1547

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -36,6 +36,8 @@ Unreleased
 
 * An issue where leaving as a moderator fails if you are using token auth.
 * An issue where an incorrect error was being raised due to invalid submission urls.
+* Some cases where streams yield the same item multiple times. This cannot be
+  prevented in every case.
 
 7.1.0 (2020/06/22)
 ------------------


### PR DESCRIPTION
The new entry, under "Fixes," describes the change to stream behavior.

There is already an entry under "Changes" describing the addition to `BoundedSet`, but users are more likely to care about the change to streams.