### PR TITLE
Fix documentation errors

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -55,7 +55,7 @@ to you, it likely is not to the person asking the question.
 ## Becoming a Team Member
 
 The PRAW team is always interested in expanding PRAW's active team member base
-with proven contributors. If you are interested please let us know, In general,
+with proven contributors. If you are interested, please let us know. In general,
 we would like to see you push a number of contributions before we add you on.
 
 

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -70,4 +70,5 @@ Source Contributors
 - Nick Kelly `@nickatnight <https://github.com/nickatnight>`_
 - Yash Chhabria `@Cyatos <https://github.com/Cyatos>`_
 - Justin Krejcha <justin@justinkrejcha.com> `@jkrejcha <https://github.com/jkrejcha>`_
+
 <!-- - Add "Name <email (optional)> and github profile link" above this line. -->

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -814,7 +814,7 @@ as described below:
   ``header_hover_text``, ``show_media`` and ``show_media_preview`` values.
 * Instances of :class:`.Comment` obtained through the inbox (including mentions) are now
   refreshable.
-* Searching ``/r/all`` should now work as intended for all users.
+* Searching ``r/all`` should now work as intended for all users.
 * Accessing an invalid attribute on an instance of :class:`.Message` will raise
   :py:class:`AttributeError` instead of :class:`.PRAWException`.
 
@@ -856,7 +856,7 @@ as described below:
 PRAW 4 introduces significant breaking changes. The numerous changes are not listed
 here, only the feature removals. Please read through :doc:`/getting_started/quick_start`
 to help with updating your code to PRAW 4. If you require additional help please ask on
-`/r/redditdev <https://www.reddit.com/r/redditdev>`_ or via Slack.
+`r/redditdev <https://www.reddit.com/r/redditdev>`_ or via Slack.
 
 **Added**
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -244,8 +244,8 @@ Unreleased
 
 **Expected Changes**
 
-* The behavior of func:`APIException` will no longer unicode-escape strings in the next
-  minor release
+* The behavior of ``APIException`` will no longer unicode-escape strings in the next
+  minor release.
 
 6.4.0 (2019/09/21)
 ------------------
@@ -273,9 +273,9 @@ Unreleased
 * Removed ``css_class`` parameter cannot be used with ``background_color``,
   ``text_color``, or ``mod_only`` constraint on methods:
 
-    * ``SubredditFlairTemplates.update()``
-    * ``SubredditRedditorFlairTemplates.add()``
-    * ``SubredditLinkFlairTemplates.add()``
+  * ``SubredditFlairTemplates.update()``
+  * ``SubredditRedditorFlairTemplates.add()``
+  * ``SubredditLinkFlairTemplates.add()``
 
 **Removed**
 
@@ -394,7 +394,7 @@ Unreleased
 
 **Fixed**
 
-* Widgets of unknown types are parsed as ``Widget`` s rather than raising an exception
+* Widgets of unknown types are parsed as ``Widget``\ s rather than raising an exception.
 
 6.0.0 (2018/07/24)
 ------------------
@@ -679,7 +679,7 @@ as described below:
 
 * Uploading an image resulting in too large of a request (>500 KB) now raises
   ``prawcore.TooLarge`` instead of an ``AssertionError``.
-* Uploading an invalid image raises func:`APIException`.
+* Uploading an invalid image raises ``APIException``.
 * :class:`.Redditor` instances obtained via :attr:`.moderator` (e.g.,
   ``reddit.subreddit("subreddit").moderator()``) will contain attributes with the
   relationship metadata (e.g., ``mod_permissions``).
@@ -816,7 +816,7 @@ as described below:
   refreshable.
 * Searching ``/r/all`` should now work as intended for all users.
 * Accessing an invalid attribute on an instance of :class:`.Message` will raise
-  :py:class:`.AttributeError` instead of :class:`.PRAWException`.
+  :py:class:`AttributeError` instead of :class:`.PRAWException`.
 
 4.0.0 (2016/11/29)
 ------------------

--- a/README.rst
+++ b/README.rst
@@ -165,7 +165,7 @@ License
 PRAW's source (v4.0.0+) is provided under the `Simplified BSD License
 <https://github.com/praw-dev/praw/blob/0860c11a9309c80621c267af7caeb6a993933744/LICENSE.txt>`_.
 
-* Copyright (c), 2016, Bryce Boe
+* Copyright ©, 2016, Bryce Boe
 
 Earlier versions of PRAW were released under `GPLv3
 <https://github.com/praw-dev/praw/blob/0c88697fdc26e75f87b68e2feb11e101e90ce215/COPYING>`_.

--- a/docs/examples/lmgtfy_bot.py
+++ b/docs/examples/lmgtfy_bot.py
@@ -3,7 +3,7 @@ from urllib.parse import quote_plus
 import praw
 
 QUESTIONS = ["what is", "who is", "what are"]
-REPLY_TEMPLATE = "[Let me google that for you](http://lmgtfy.com/?q={})"
+REPLY_TEMPLATE = "[Let me google that for you](https://lmgtfy.com/?q={})"
 
 
 def main():

--- a/docs/examples/obtain_refresh_token.py
+++ b/docs/examples/obtain_refresh_token.py
@@ -41,8 +41,8 @@ def send_message(client, message):
 def main():
     """Provide the program's entry point when directly executed."""
     print(
-        "Go here while logged into the account you want to create a token for: "
-        "https://www.reddit.com/prefs/apps/"
+        "Go here while logged into the account you want to create a token for:"
+        " https://www.reddit.com/prefs/apps/"
     )
     print(
         "Click the create an app button. Put something in the name field and select the"

--- a/docs/getting_started/authentication.rst
+++ b/docs/getting_started/authentication.rst
@@ -189,7 +189,7 @@ redirect. For the implicit flow call :meth:`.url` like so:
 
 .. code-block:: python
 
-    print(reddit.auth.url(["identity"], "...", implicit=True)
+    print(reddit.auth.url(["identity"], "...", implicit=True))
 
 Then use :meth:`.implicit` to provide the authorization to the :class:`.Reddit`
 instance.

--- a/docs/getting_started/configuration.rst
+++ b/docs/getting_started/configuration.rst
@@ -55,8 +55,8 @@ certificate without an exception from Requests, first export the certificate as 
 
 .. code-block:: python
 
-   import praw
-   from requests import Session
+    import praw
+    from requests import Session
 
 
     session = Session()

--- a/docs/getting_started/faq.rst
+++ b/docs/getting_started/faq.rst
@@ -38,7 +38,7 @@ Q: Help, I keep on getting redirected to ``/r/subreddit/login/``!
 
 Q2: I keep on getting this exception:
 
-.. code-block:: none
+.. code-block:: text
 
     prawcore.exceptions.Redirect: Redirect to /r/subreddit/login/ (You may be trying to perform a non-read-only action via a read-only instance.)
 

--- a/docs/getting_started/quick_start.rst
+++ b/docs/getting_started/quick_start.rst
@@ -79,11 +79,11 @@ information). For example:
 
     import praw
 
-     reddit = praw.Reddit(
-         client_id="my client id",
-         client_secret="my client secret",
-         user_agent="my user agent"
-     )
+    reddit = praw.Reddit(
+        client_id="my client id",
+        client_secret="my client secret",
+        user_agent="my user agent"
+    )
 
 Just like that, you now have a read-only  :class:`.Reddit` instance.
 

--- a/docs/package_info/glossary.rst
+++ b/docs/package_info/glossary.rst
@@ -20,30 +20,30 @@ Glossary
 
   Here is a list of the six different types of objects returned from reddit:
 
-   .. _fullname_t1:
+  .. _fullname_t1:
 
-   - ``t1`` These object represent :class:`.Comment`\ s.
+  - ``t1`` These object represent :class:`.Comment`\ s.
 
-   .. _fullname_t2:
+  .. _fullname_t2:
 
-   - ``t2`` These object represent :class:`.Redditor`\ s.
+  - ``t2`` These object represent :class:`.Redditor`\ s.
 
-   .. _fullname_t3:
+  .. _fullname_t3:
 
-   - ``t3`` These object represent :class:`.Submission`\ s.
+  - ``t3`` These object represent :class:`.Submission`\ s.
 
-   .. _fullname_t4:
+  .. _fullname_t4:
 
-   - ``t4`` These object represent :class:`.Message`\ s.
+  - ``t4`` These object represent :class:`.Message`\ s.
 
-   .. _fullname_t5:
+  .. _fullname_t5:
 
-   - ``t5`` These object represent :class:`.Subreddit`\ s.
+  - ``t5`` These object represent :class:`.Subreddit`\ s.
 
-   .. _fullname_t6:
+  .. _fullname_t6:
 
-   - ``t6`` These object represent ``Award``\ s, such as ``Reddit Gold`` or
-     ``Reddit Silver``.
+  - ``t6`` These object represent ``Award``\ s, such as ``Reddit Gold`` or
+    ``Reddit Silver``.
 
 .. _gild:
 

--- a/docs/tutorials/reply_bot.rst
+++ b/docs/tutorials/reply_bot.rst
@@ -87,6 +87,7 @@ indefinitely iterate over new submissions to a subreddit add:
     subreddit = reddit.subreddit("AskReddit")
     for submission in subreddit.stream.submissions():
         # do something with submission
+        ...
 
 Replace ``AskReddit`` with the name of another subreddit if you want to iterate through
 its new submissions. Additionally multiple subreddits can be specified by joining them
@@ -114,7 +115,7 @@ First we filter out titles that contain more than ten words:
 .. code-block:: python
 
    if len(submission.title.split()) > 10:
-           return
+       return
 
 We then check to see if the submission's title contains any of the desired phrases:
 

--- a/docs/tutorials/reply_bot.rst
+++ b/docs/tutorials/reply_bot.rst
@@ -11,7 +11,7 @@ As a result, it is little surprise that a majority of bots on Reddit are powered
 PRAW.
 
 This tutorial will show you how to build a bot that monitors a particular subreddit,
-`/r/AskReddit <https://www.reddit.com/r/AskReddit/>`_, for new submissions containing
+`r/AskReddit <https://www.reddit.com/r/AskReddit/>`_, for new submissions containing
 simple questions and replies with an appropriate link to lmgtfy_ (Let Me Google That For
 You).
 
@@ -76,8 +76,8 @@ that registered the application are required.
     <https://github.com/reddit/reddit/wiki/oauth2-app-types>`_.
 
 
-Step 2: Monitoring New Submissions to /r/AskReddit
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Step 2: Monitoring New Submissions to r/AskReddit
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 PRAW provides a convenient way to obtain new submissions to a given subreddit. To
 indefinitely iterate over new submissions to a subreddit add:
@@ -97,7 +97,7 @@ specified using the special name ``all``.
 Step 3: Analyzing the Submission Titles
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Now that we have a stream of new submissions to /r/AskReddit, it is time to see if their
+Now that we have a stream of new submissions to r/AskReddit, it is time to see if their
 titles contain a simple question. We naïvely define a simple question as:
 
 1. It must contain no more than ten words.

--- a/praw/config.py
+++ b/praw/config.py
@@ -60,7 +60,11 @@ class Config:
 
     @property
     def short_url(self) -> str:
-        """Return the short url or raise a ClientException when not set."""
+        """Return the short url.
+
+        :raises: :class:`.ClientException` if it is not set.
+
+        """
         if self._short_url is self.CONFIG_NOT_SET:
             raise ClientException("No short domain specified.")
         return self._short_url

--- a/praw/config.py
+++ b/praw/config.py
@@ -156,5 +156,7 @@ class Config:
                 setattr(self, attribute, conversion(getattr(self, attribute)))
             except ValueError:
                 raise ValueError(
-                    f"An incorrect config type was given for option {attribute}. The expected type is {conversion.__name__}, but the given value is {getattr(self, attribute)}."
+                    f"An incorrect config type was given for option {attribute}. The"
+                    f" expected type is {conversion.__name__}, but the given value is"
+                    f" {getattr(self, attribute)}."
                 )

--- a/praw/exceptions.py
+++ b/praw/exceptions.py
@@ -27,7 +27,7 @@ class RedditErrorItem:
         return error_str
 
     def __init__(self, error_type: str, message: str, field: Optional[str] = None):
-        """Instantiate an error item.
+        """Initialize an error item.
 
         :param error_type: The error type set on Reddit's end.
         :param message: The associated message for the error.
@@ -185,7 +185,7 @@ class InvalidImplicitAuth(ClientException):
     """Indicate exceptions where an implicit auth type is used incorrectly."""
 
     def __init__(self):
-        """Instantize the class."""
+        """Initialize the class."""
         super().__init__("Implicit authorization can only be used with installed apps.")
 
 
@@ -264,7 +264,7 @@ class MediaPostFailed(WebSocketException):
     """Indicate exceptions where media uploads failed.."""
 
     def __init__(self):
-        """Instantiate MediaPostFailed."""
+        """Initialize MediaPostFailed."""
         super().__init__(
             "The attempted media upload action has failed. Possible causes include the corruption of media files. Check that the media file can be opened on your local machine.",
             None,

--- a/praw/exceptions.py
+++ b/praw/exceptions.py
@@ -50,7 +50,10 @@ class RedditErrorItem:
 
     def __repr__(self):
         """Return repr(self)."""
-        return f"{self.__class__.__name__}(error_type={self.error_type!r}, message={self.message!r}, field={self.field!r})"
+        return (
+            f"{self.__class__.__name__}(error_type={self.error_type!r},"
+            f" message={self.message!r}, field={self.field!r})"
+        )
 
     def __str__(self):
         """Get the message returned from str(self)."""
@@ -125,7 +128,10 @@ class APIException(PRAWException):
 
     def _get_old_attr(self, attrname):
         warn(
-            f"Accessing attribute ``{attrname}`` through APIException is deprecated. This behavior will be removed in PRAW 8.0. Check out https://praw.readthedocs.io/en/latest/package_info/praw7_migration.html to learn how to migrate your code.",
+            f"Accessing attribute ``{attrname}`` through APIException is deprecated."
+            " This behavior will be removed in PRAW 8.0. Check out"
+            " https://praw.readthedocs.io/en/latest/package_info/praw7_migration.html"
+            " to learn how to migrate your code.",
             category=DeprecationWarning,
             stacklevel=3,
         )
@@ -177,7 +183,8 @@ class InvalidFlairTemplateID(ClientException):
     def __init__(self, template_id: str):
         """Initialize the class."""
         super().__init__(
-            f"The flair template id ``{template_id}`` is invalid. If you are trying to create a flair, please use the ``add`` method."
+            f"The flair template id ``{template_id}`` is invalid. If you are trying to"
+            " create a flair, please use the ``add`` method."
         )
 
 
@@ -220,7 +227,8 @@ class TooLargeMediaException(ClientException):
         self.maximum_size = maximum_size
         self.actual = actual
         super().__init__(
-            f"The media that you uploaded was too large (maximum size is {maximum_size} bytes, uploaded {actual} bytes)"
+            f"The media that you uploaded was too large (maximum size is {maximum_size}"
+            f" bytes, uploaded {actual} bytes)"
         )
 
 
@@ -231,7 +239,9 @@ class WebSocketException(ClientException):
     def original_exception(self) -> Exception:
         """Access the original_exception attribute (now deprecated)."""
         warn(
-            "Accessing the attribute original_exception is deprecated. Please rewrite your code in such a way that this attribute does not need to be used. It will be removed in PRAW 8.0.",
+            "Accessing the attribute original_exception is deprecated. Please rewrite"
+            " your code in such a way that this attribute does not need to be used. It"
+            " will be removed in PRAW 8.0.",
             category=DeprecationWarning,
             stacklevel=2,
         )
@@ -266,6 +276,8 @@ class MediaPostFailed(WebSocketException):
     def __init__(self):
         """Initialize MediaPostFailed."""
         super().__init__(
-            "The attempted media upload action has failed. Possible causes include the corruption of media files. Check that the media file can be opened on your local machine.",
+            "The attempted media upload action has failed. Possible causes include the"
+            " corruption of media files. Check that the media file can be opened on"
+            " your local machine.",
             None,
         )

--- a/praw/models/comment_forest.py
+++ b/praw/models/comment_forest.py
@@ -82,8 +82,8 @@ class CommentForest:
             self._comments.append(comment)
         else:
             assert comment.parent_id in self._submission._comments_by_id, (
-                "PRAW Error occurred. Please file a bug report and include "
-                "the code that caused the error."
+                "PRAW Error occurred. Please file a bug report and include the code"
+                " that caused the error."
             )
             parent = self._submission._comments_by_id[comment.parent_id]
             parent.replies._comments.append(comment)

--- a/praw/models/listing/generator.py
+++ b/praw/models/listing/generator.py
@@ -17,7 +17,7 @@ class ListingGenerator(PRAWBase, Iterator):
         This class should not be directly utilized. Instead you will find a number of
         methods that return instances of the class:
 
-        http://praw.readthedocs.io/en/latest/search.html?q=ListingGenerator
+        https://praw.readthedocs.io/en/latest/search.html?q=ListingGenerator
 
     """
 

--- a/praw/models/listing/mixins/base.py
+++ b/praw/models/listing/mixins/base.py
@@ -27,9 +27,8 @@ class BaseListingMixin(PRAWBase):
 
         """
         if time_filter not in BaseListingMixin.VALID_TIME_FILTERS:
-            raise ValueError(
-                f"time_filter must be one of: {', '.join(BaseListingMixin.VALID_TIME_FILTERS)}"
-            )
+            valid_time_filters = ", ".join(BaseListingMixin.VALID_TIME_FILTERS)
+            raise ValueError(f"time_filter must be one of: {valid_time_filters}")
 
     def controversial(
         self,

--- a/praw/models/listing/mixins/base.py
+++ b/praw/models/listing/mixins/base.py
@@ -21,7 +21,11 @@ class BaseListingMixin(PRAWBase):
 
     @staticmethod
     def _validate_time_filter(time_filter):
-        """Raise :py:class:`.ValueError` if ``time_filter`` is not valid."""
+        """Validate ``time_filter``.
+
+        :raises: :py:class:`ValueError` if ``time_filter`` is not valid.
+
+        """
         if time_filter not in BaseListingMixin.VALID_TIME_FILTERS:
             raise ValueError(
                 f"time_filter must be one of: {', '.join(BaseListingMixin.VALID_TIME_FILTERS)}"

--- a/praw/models/listing/mixins/redditor.py
+++ b/praw/models/listing/mixins/redditor.py
@@ -65,10 +65,13 @@ class RedditorListingMixin(BaseListingMixin, GildedListingMixin):
     ) -> Iterator[Any]:
         """Return a :class:`.ListingGenerator` for items the user has downvoted.
 
-        May raise ``prawcore.Forbidden`` after issuing the request if the user is not
-        authorized to access the list. Note that because this function returns a
-        :class:`.ListingGenerator` the exception may not occur until sometime after this
-        function has returned.
+        :raises: ``prawcore.Forbidden`` if the user is not authorized to access the
+            list.
+
+            .. note::
+
+                Since this function returns a :class:`.ListingGenerator` the exception
+                may not occur until sometime after this function has returned.
 
         Additional keyword arguments are passed in the initialization of
         :class:`.ListingGenerator`.
@@ -90,10 +93,13 @@ class RedditorListingMixin(BaseListingMixin, GildedListingMixin):
     ) -> Iterator[Any]:
         """Return a :class:`.ListingGenerator` for items the user has gilded.
 
-        May raise ``prawcore.Forbidden`` after issuing the request if the user is not
-        authorized to access the list. Note that because this function returns a
-        :class:`.ListingGenerator` the exception may not occur until sometime after this
-        function has returned.
+        :raises: ``prawcore.Forbidden`` if the user is not authorized to access the
+            list.
+
+            .. note::
+
+                Since this function returns a :class:`.ListingGenerator` the exception
+                may not occur until sometime after this function has returned.
 
         Additional keyword arguments are passed in the initialization of
         :class:`.ListingGenerator`.
@@ -115,10 +121,13 @@ class RedditorListingMixin(BaseListingMixin, GildedListingMixin):
     ) -> Iterator[Any]:
         """Return a :class:`.ListingGenerator` for items the user has hidden.
 
-        May raise ``prawcore.Forbidden`` after issuing the request if the user is not
-        authorized to access the list. Note that because this function returns a
-        :class:`.ListingGenerator` the exception may not occur until sometime after this
-        function has returned.
+        :raises: ``prawcore.Forbidden`` if the user is not authorized to access the
+            list.
+
+            .. note::
+
+                Since this function returns a :class:`.ListingGenerator` the exception
+                may not occur until sometime after this function has returned.
 
         Additional keyword arguments are passed in the initialization of
         :class:`.ListingGenerator`.
@@ -140,10 +149,13 @@ class RedditorListingMixin(BaseListingMixin, GildedListingMixin):
     ) -> Iterator[Any]:
         """Return a :class:`.ListingGenerator` for items the user has saved.
 
-        May raise ``prawcore.Forbidden`` after issuing the request if the user is not
-        authorized to access the list. Note that because this function returns a
-        :class:`.ListingGenerator` the exception may not occur until sometime after this
-        function has returned.
+        :raises: ``prawcore.Forbidden`` if the user is not authorized to access the
+            list.
+
+            .. note::
+
+                Since this function returns a :class:`.ListingGenerator` the exception
+                may not occur until sometime after this function has returned.
 
         Additional keyword arguments are passed in the initialization of
         :class:`.ListingGenerator`.
@@ -165,10 +177,13 @@ class RedditorListingMixin(BaseListingMixin, GildedListingMixin):
     ) -> Iterator[Any]:
         """Return a :class:`.ListingGenerator` for items the user has upvoted.
 
-        May raise ``prawcore.Forbidden`` after issuing the request if the user is not
-        authorized to access the list. Note that because this function returns a
-        :class:`.ListingGenerator` the exception may not occur until sometime after this
-        function has returned.
+        :raises: ``prawcore.Forbidden`` if the user is not authorized to access the
+            list.
+
+            .. note::
+
+                Since this function returns a :class:`.ListingGenerator` the exception
+                may not occur until sometime after this function has returned.
 
         Additional keyword arguments are passed in the initialization of
         :class:`.ListingGenerator`.

--- a/praw/models/reddit/collections.py
+++ b/praw/models/reddit/collections.py
@@ -179,7 +179,8 @@ class Collection(RedditBase):
             # causes Reddit to return something that looks like an error
             # but with no content.
             raise ClientException(
-                f"Error during fetch. Check collection ID {self.collection_id!r} is correct."
+                f"Error during fetch. Check collection ID {self.collection_id!r} is"
+                " correct."
             )
 
         other = type(self)(self._reddit, _data=data)

--- a/praw/models/reddit/emoji.py
+++ b/praw/models/reddit/emoji.py
@@ -200,7 +200,9 @@ class SubredditEmoji:
         :param post_flair_allowed: (boolean) When provided, indicate whether the emoji
             may appear in post flair. (Default: ``None``)
         :param user_flair_allowed: (boolean) When provided, indicate whether the emoji
-            may appear in user flair. (Default: ``None``) :returns: The Emoji added.
+            may appear in user flair. (Default: ``None``)
+
+        :returns: The Emoji added.
 
         To add ``test`` to the subreddit ``praw_test`` try:
 

--- a/praw/models/reddit/live.py
+++ b/praw/models/reddit/live.py
@@ -773,11 +773,11 @@ class LiveUpdateContribution:
 
         Usage:
 
-         .. code-block:: python
+        .. code-block:: python
 
-             thread = reddit.live("ydwwxneu7vsa")
-             update = thread["6854605a-efec-11e6-b0c7-0eafac4ff094"]
-             update.contrib.remove()
+            thread = reddit.live("ydwwxneu7vsa")
+            update = thread["6854605a-efec-11e6-b0c7-0eafac4ff094"]
+            update.contrib.remove()
 
         """
         url = API_PATH["live_remove_update"].format(id=self.update.thread.id)

--- a/praw/models/reddit/live.py
+++ b/praw/models/reddit/live.py
@@ -794,9 +794,12 @@ class LiveUpdateContribution:
             update.contrib.strike()
 
         To check whether the update is stricken or not, use ``update.stricken``
-        attribute. But note that accessing lazy attributes on updates
-        (includes ``update.stricken``) may raises ``AttributeError``.
-        See :class:`.LiveUpdate` for details.
+        attribute.
+
+        .. note::
+
+            Accessing lazy attributes on updates (includes ``update.stricken``) may
+            raise :py:class:`AttributeError`. See :class:`.LiveUpdate` for details.
 
         """
         url = API_PATH["live_strike"].format(id=self.update.thread.id)

--- a/praw/models/reddit/mixins/messageable.py
+++ b/praw/models/reddit/mixins/messageable.py
@@ -22,8 +22,12 @@ class MessageableMixin:
         :param message: The message content.
         :param from_subreddit: A :class:`~.Subreddit` instance or string to send the
             message from. When provided, messages are sent from the subreddit rather
-            than from the authenticated user. Note that the authenticated user must be
-            a moderator of the subreddit and have the ``mail`` moderator permission.
+            than from the authenticated user.
+
+            .. note::
+
+                The authenticated user must be a moderator of the subreddit and have the
+                ``mail`` moderator permission.
 
         For example, to send a private message to ``u/spez``, try:
 

--- a/praw/models/reddit/mixins/reportable.py
+++ b/praw/models/reddit/mixins/reportable.py
@@ -10,7 +10,7 @@ class ReportableMixin:
 
         :param reason: The reason for reporting.
 
-        :raises :class:`.RedditAPIException` if ``reason`` is longer than 100
+        :raises: :class:`.RedditAPIException` if ``reason`` is longer than 100
             characters.
 
         Example usage:

--- a/praw/models/reddit/poll.py
+++ b/praw/models/reddit/poll.py
@@ -108,7 +108,7 @@ class PollData(PRAWBase):
         :param option_id: The ID of a poll option, as a ``str``.
         :returns: The specified :class:`.PollOption`.
 
-        Raises ``KeyError`` if no option exists with the specified ID.
+        :raises: :py:class:`KeyError` if no option exists with the specified ID.
 
         """
         for option in self.options:

--- a/praw/models/reddit/rules.py
+++ b/praw/models/reddit/rules.py
@@ -168,12 +168,10 @@ class SubredditRules:
 
         """
         warn(
-            "Calling SubredditRules to get a list of rules is deprecated. "
-            "Remove the parentheses to use the iterator. View the "
-            "PRAW documentation on how to change the code in order to use the "
-            "iterator (https://praw.readthedocs.io/en/latest/code_overview"
-            "/other/subredditrules.html#praw.models.reddit.rules."
-            "SubredditRules.__call__).",
+            "Calling SubredditRules to get a list of rules is deprecated. Remove the"
+            " parentheses to use the iterator. View the PRAW documentation on how to"
+            " change the code in order to use the iterator"
+            " (https://praw.readthedocs.io/en/latest/code_overview/other/subredditrules.html#praw.models.reddit.rules.SubredditRules.__call__).",
             category=DeprecationWarning,
             stacklevel=2,
         )

--- a/praw/models/reddit/rules.py
+++ b/praw/models/reddit/rules.py
@@ -170,7 +170,7 @@ class SubredditRules:
         warn(
             "Calling SubredditRules to get a list of rules is deprecated. "
             "Remove the parentheses to use the iterator. View the "
-            "PRAW documentation on how to change the code in order to use the"
+            "PRAW documentation on how to change the code in order to use the "
             "iterator (https://praw.readthedocs.io/en/latest/code_overview"
             "/other/subredditrules.html#praw.models.reddit.rules."
             "SubredditRules.__call__).",

--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -509,7 +509,7 @@ class Submission(SubmissionListingMixin, UserContentMixin, FullnameMixin, Reddit
     def shortlink(self) -> str:
         """Return a shortlink to the submission.
 
-        For example http://redd.it/eorhm is a shortlink for
+        For example https://redd.it/eorhm is a shortlink for
         https://www.reddit.com/r/announcements/comments/eorhm/reddit_30_less_typing/.
 
         """

--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -104,11 +104,12 @@ class SubmissionModeration(ThingModerationMixin):
             True).
 
         Contest mode have the following effects:
-          * The comment thread will default to being sorted randomly.
-          * Replies to top-level comments will be hidden behind "[show replies]" buttons.
-          * Scores will be hidden from non-moderators.
-          * Scores accessed through the API (mobile apps, bots) will be obscured to "1"
-            for non-moderators.
+
+        * The comment thread will default to being sorted randomly.
+        * Replies to top-level comments will be hidden behind "[show replies]" buttons.
+        * Scores will be hidden from non-moderators.
+        * Scores accessed through the API (mobile apps, bots) will be obscured to "1"
+          for non-moderators.
 
         Example usage:
 
@@ -476,7 +477,7 @@ class Submission(SubmissionListingMixin, UserContentMixin, FullnameMixin, Reddit
         """Provide an instance of :class:`.SubmissionFlair`.
 
         This attribute is used to work with flair as a regular user of the subreddit the
-         submission belongs to. Moderators can directly use meth:`.flair`.
+        submission belongs to. Moderators can directly use :meth:`.flair`.
 
         For example, to select an arbitrary editable flair text (assuming there is one)
         and set a custom value try:

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -844,7 +844,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
         discussion_type=None,
         inline_media=None,
     ):  # noqa: D301
-        """Add a submission to the subreddit.
+        r"""Add a submission to the subreddit.
 
         :param title: The title of the submission.
         :param selftext: The Markdown formatted content for a ``text`` submission. Use
@@ -894,8 +894,8 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
 
         .. note::
 
-            Inserted media will have a padding of `\n\n` automatically added. This due
-            to the weirdness with Reddit's API. Using the example above the result
+            Inserted media will have a padding of ``\\n\\n`` automatically added. This due
+            to the weirdness with Reddit's API. Using the example above, the result
             selftext body will look like so:
 
             .. code-block::

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -482,8 +482,8 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
 
             subreddit = reddit.subreddit("SUBREDDIT")
             stylesheet = subreddit.stylesheet()
-            stylesheet += ".test{color:blue}"
-            subreddit.stylesheet.update(stylesheet)
+            stylesheet.stylesheet += ".test{color:blue}"
+            subreddit.stylesheet.update(stylesheet.stylesheet)
 
         """
         return SubredditStylesheet(self)

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -62,10 +62,12 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
         for submission in reddit.subreddit("redditdev+learnpython").top("all"):
             print(submission)
 
-    Subreddits can be filtered from combined listings as follows. Note that these
-    filters are ignored by certain methods, including
-    :attr:`~praw.models.Subreddit.comments`, :meth:`~praw.models.Subreddit.gilded`, and
-    :meth:`.SubredditStream.comments`.
+    Subreddits can be filtered from combined listings as follows.
+
+    .. note::
+
+        These filters are ignored by certain methods, including :attr:`.comments`,
+        :meth:`.gilded`, and :meth:`.SubredditStream.comments`.
 
     .. code-block:: python
 

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -619,8 +619,8 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
             BlockingIOError,
         ) as ws_exception:
             raise WebSocketException(
-                "Websocket error. Check your media file. "
-                "Your post may still have been created.",
+                "Websocket error. Check your media file. Your post may still have been"
+                " created.",
                 ws_exception,
             )
         if ws_update.get("type") == "failed":
@@ -662,7 +662,8 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
             and mime_type.partition("/")[0] != expected_mime_prefix
         ):
             raise ClientException(
-                f"Expected a mimetype starting with {expected_mime_prefix!r} but got mimetype {mime_type!r} (from file extension {file_extension!r})."
+                f"Expected a mimetype starting with {expected_mime_prefix!r} but got"
+                f" mimetype {mime_type!r} (from file extension {file_extension!r})."
             )
         img_data = {"filepath": file_name, "mimetype": mime_type}
 
@@ -1660,8 +1661,8 @@ class SubredditFlair:
         """
         if css_class and flair_template_id is not None:
             raise TypeError(
-                "Parameter `css_class` cannot be used in "
-                "conjunction with `flair_template_id`."
+                "Parameter `css_class` cannot be used in conjunction with"
+                " `flair_template_id`."
             )
         data = {"name": str(redditor), "text": text}
         if flair_template_id is not None:

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -811,7 +811,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
         :param number: Specify which sticky to return. 1 appears at the top (default:
             1).
 
-        Raises ``prawcore.NotFound`` if the sticky does not exist.
+        :raises: ``prawcore.NotFound`` if the sticky does not exist.
 
         For example, to get the stickied post on the subreddit ``r/test``:
 
@@ -994,8 +994,8 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
             (default: False).
         :returns: A :class:`.Submission` object for the newly created submission.
 
-        If ``image_path`` in ``images`` refers to a file that is not an image, PRAW will
-        raise a :class:`.ClientException`.
+        :raises: :class:`.ClientException` if ``image_path`` in ``images`` refers to a
+            file that is not an image.
 
         For example to submit an image gallery to ``r/reddit_api_test`` do:
 
@@ -1109,8 +1109,8 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
         :returns: A :class:`.Submission` object for the newly created submission,
             unless ``without_websockets`` is ``True``.
 
-        If ``image_path`` refers to a file that is not an image, PRAW will raise a
-        :class:`.ClientException`.
+        :raises: :class:`.ClientException` if ``image_path`` refers to a file that is
+            not an image.
 
         .. note::
 
@@ -1292,8 +1292,8 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
         :returns: A :class:`.Submission` object for the newly created submission, unless
             ``without_websockets`` is ``True``.
 
-        If ``video_path`` refers to a file that is not a video, PRAW will
-        raise a :class:`.ClientException`.
+        :raises: :class:`.ClientException` if ``video_path`` refers to a file that is
+            not a video.
 
         .. note::
 
@@ -1381,9 +1381,9 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
     def traffic(self):
         """Return a dictionary of the subreddit's traffic statistics.
 
-        Raises ``prawcore.NotFound`` when the traffic stats aren't available to the
-        authenticated user, that is, they are not public and the authenticated user is
-        not a moderator of the subreddit.
+        :raises: ``prawcore.NotFound`` when the traffic stats aren't available to the
+            authenticated user, that is, they are not public and the authenticated user
+            is not a moderator of the subreddit.
 
         The traffic method returns a dict with three keys. The keys are ``day``,
         ``hour`` and ``month``. Each key contains a list of lists with 3 or 4 values.
@@ -1486,7 +1486,7 @@ class SubredditFilters:
 
             reddit.subreddit("all-redditdev-learnpython")
 
-        Raises ``prawcore.NotFound`` when calling on a non-special subreddit.
+        :raises: ``prawcore.NotFound`` when calling on a non-special subreddit.
 
         """
         url = API_PATH["subreddit_filter"].format(
@@ -1501,7 +1501,7 @@ class SubredditFilters:
 
         :param subreddit: The subreddit to remove from the filter list.
 
-        Raises ``prawcore.NotFound`` when calling on a non-special subreddit.
+        :raises: ``prawcore.NotFound`` when calling on a non-special subreddit.
 
         """
         url = API_PATH["subreddit_filter"].format(
@@ -3428,12 +3428,12 @@ class SubredditStylesheet:
         :returns: A dictionary containing a link to the uploaded image under the key
             ``img_src``.
 
-        Raises ``prawcore.TooLarge`` if the overall request body is too large.
+        :raises: ``prawcore.TooLarge`` if the overall request body is too large.
 
-        Raises :class:`.RedditAPIException` if there are other issues with the uploaded
-        image. Unfortunately the exception info might not be very specific, so try
-        through the website with the same image to see what the problem actually might
-        be.
+        :raises: :class:`.RedditAPIException` if there are other issues with the
+            uploaded image. Unfortunately the exception info might not be very specific,
+            so try through the website with the same image to see what the problem
+            actually might be.
 
         For example:
 
@@ -3449,12 +3449,12 @@ class SubredditStylesheet:
 
         :param image_path: A path to a jpeg or png image.
 
-        Raises ``prawcore.TooLarge`` if the overall request body is too large.
+        :raises: ``prawcore.TooLarge`` if the overall request body is too large.
 
-        Raises :class:`.RedditAPIException` if there are other issues with the
-        uploaded image. Unfortunately the exception info might not be very
-        specific, so try through the website with the same image to see what
-        the problem actually might be.
+        :raises: :class:`.RedditAPIException` if there are other issues with the
+            uploaded image. Unfortunately the exception info might not be very specific,
+            so try through the website with the same image to see what the problem
+            actually might be.
 
         For example:
 
@@ -3473,12 +3473,12 @@ class SubredditStylesheet:
         :param image_path: A path to a jpeg or png image.
         :param align: Either ``left``, ``centered``, or ``right``. (default: ``left``).
 
-        Raises ``prawcore.TooLarge`` if the overall request body is too large.
+        :raises: ``prawcore.TooLarge`` if the overall request body is too large.
 
-        Raises :class:`.RedditAPIException` if there are other issues with the uploaded
-        image. Unfortunately the exception info might not be very specific, so try
-        through the website with the same image to see what the problem actually might
-        be.
+        :raises: :class:`.RedditAPIException` if there are other issues with the
+            uploaded image. Unfortunately the exception info might not be very specific,
+            so try through the website with the same image to see what the problem
+            actually might be.
 
         For example:
 
@@ -3510,12 +3510,12 @@ class SubredditStylesheet:
 
         Fails if the Subreddit does not have an additional image defined
 
-        Raises ``prawcore.TooLarge`` if the overall request body is too large.
+        :raises: ``prawcore.TooLarge`` if the overall request body is too large.
 
-        Raises :class:`.RedditAPIException` if there are other issues with the uploaded
-        image. Unfortunately the exception info might not be very specific, so try
-        through the website with the same image to see what the problem actually might
-        be.
+        :raises: :class:`.RedditAPIException` if there are other issues with the
+            uploaded image. Unfortunately the exception info might not be very specific,
+            so try through the website with the same image to see what the problem
+            actually might be.
 
         For example:
 
@@ -3536,12 +3536,12 @@ class SubredditStylesheet:
         :returns: A dictionary containing a link to the uploaded image under the key
             ``img_src``.
 
-        Raises ``prawcore.TooLarge`` if the overall request body is too large.
+        :raises: ``prawcore.TooLarge`` if the overall request body is too large.
 
-        Raises :class:`.RedditAPIException` if there are other issues with the uploaded
-        image. Unfortunately the exception info might not be very specific, so try
-        through the website with the same image to see what the problem actually might
-        be.
+        :raises: :class:`.RedditAPIException` if there are other issues with the
+            uploaded image. Unfortunately the exception info might not be very specific,
+            so try through the website with the same image to see what the problem
+            actually might be.
 
         For example:
 
@@ -3559,12 +3559,12 @@ class SubredditStylesheet:
         :returns: A dictionary containing a link to the uploaded image under the key
             ``img_src``.
 
-        Raises ``prawcore.TooLarge`` if the overall request body is too large.
+        :raises: ``prawcore.TooLarge`` if the overall request body is too large.
 
-        Raises :class:`.RedditAPIException` if there are other issues with the uploaded
-        image. Unfortunately the exception info might not be very specific, so try
-        through the website with the same image to see what the problem actually might
-        be.
+        :raises: :class:`.RedditAPIException` if there are other issues with the
+            uploaded image. Unfortunately the exception info might not be very specific,
+            so try through the website with the same image to see what the problem
+            actually might be.
 
         For example:
 
@@ -3582,12 +3582,12 @@ class SubredditStylesheet:
         :returns: A dictionary containing a link to the uploaded image under the key
             ``img_src``.
 
-        Raises ``prawcore.TooLarge`` if the overall request body is too large.
+        :raises: ``prawcore.TooLarge`` if the overall request body is too large.
 
-        Raises :class:`.RedditAPIException` if there are other issues with the uploaded
-        image. Unfortunately the exception info might not be very specific, so try
-        through the website with the same image to see what the problem actually might
-        be.
+        :raises: :class:`.RedditAPIException` if there are other issues with the
+            uploaded image. Unfortunately the exception info might not be very specific,
+            so try through the website with the same image to see what the problem
+            actually might be.
 
         For example:
 

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -1902,7 +1902,7 @@ class SubredditRedditorFlairTemplates(SubredditFlairTemplates):
         """Add a Redditor flair template to the associated subreddit.
 
         :param text: The flair template's text (required).
-        :param css_class: The flair template's css_class ((default: "")).
+        :param css_class: The flair template's css_class (default: "").
         :param text_editable: (boolean) Indicate if the flair text can be modified for
             each Redditor that sets it (default: False).
         :param background_color: The flair template's new background color, as a hex

--- a/praw/models/reddit/widgets.py
+++ b/praw/models/reddit/widgets.py
@@ -446,7 +446,7 @@ class SubredditWidgetsModeration:
             Each button is either a text button or an image button. A text button looks
             like this:
 
-            .. code-block:: none
+            .. code-block:: text
 
                 {
                     "kind": "text",
@@ -460,7 +460,7 @@ class SubredditWidgetsModeration:
 
             An image button looks like this:
 
-            .. code-block:: none
+            .. code-block:: text
 
                 {
                     "kind": "image",
@@ -476,7 +476,7 @@ class SubredditWidgetsModeration:
             to be included (it is optional). If it is included, it can be one of two
             types: text or image. A text ``hoverState`` looks like this:
 
-            .. code-block:: none
+            .. code-block:: text
 
                 {
                     "kind": "text",
@@ -488,7 +488,7 @@ class SubredditWidgetsModeration:
 
             An image ``hoverState`` looks like this:
 
-            .. code-block:: none
+            .. code-block:: text
 
                {
                    "kind": "image",
@@ -806,7 +806,7 @@ class SubredditWidgetsModeration:
         :param data: A ``list`` of ``dict``\ s describing menu contents, as specified in
             `Reddit docs`_. As of this writing, the format is:
 
-            .. code-block:: none
+            .. code-block:: text
 
                 [
                     {

--- a/praw/models/reddit/widgets.py
+++ b/praw/models/reddit/widgets.py
@@ -228,7 +228,7 @@ class SubredditWidgets(PRAWBase):
         widgets.progressive_images = True
         for widget in widgets.sidebar:
             # do something
-            pass
+            ...
 
     Access a subreddit's widgets with the following attributes:
 

--- a/praw/models/reddit/widgets.py
+++ b/praw/models/reddit/widgets.py
@@ -1002,8 +1002,8 @@ class Widget(PRAWBase):
         .. note::
 
             Using any of the methods of :class:`.WidgetModeration` will likely make the
-            data in the :class:`.SubredditWidgets` that this widget belongs to,
-            outdated. To remedy this, call :meth:`~.SubredditWidgets.refresh`.
+            data in the :class:`.SubredditWidgets` that this widget belongs to outdated.
+            To remedy this, call :meth:`~.SubredditWidgets.refresh`.
 
         """
         return WidgetModeration(self, self.subreddit, self._reddit)

--- a/praw/models/reddit/wikipage.py
+++ b/praw/models/reddit/wikipage.py
@@ -88,7 +88,7 @@ class WikiPageModeration:
         :param other_settings: Additional keyword arguments to pass.
         :returns: The updated WikiPage settings.
 
-        To set the wikipage ``praw_test`` in ``/r/test`` to mod only and disable it from
+        To set the wikipage ``praw_test`` in ``r/test`` to mod only and disable it from
         showing in the page list, try:
 
         .. code-block:: python
@@ -232,7 +232,7 @@ class WikiPage(RedditBase):
     def revision(self, revision: str):
         """Return a specific version of this page by revision ID.
 
-        To view revision ``[ID]`` of ``"praw_test"`` in ``/r/test``:
+        To view revision ``[ID]`` of ``"praw_test"`` in ``r/test``:
 
         .. code-block:: python
 
@@ -249,7 +249,7 @@ class WikiPage(RedditBase):
         Additional keyword arguments are passed in the initialization of
         :class:`.ListingGenerator`.
 
-        To view the wiki revisions for ``"praw_test"`` in ``/r/test`` try:
+        To view the wiki revisions for ``"praw_test"`` in ``r/test`` try:
 
         .. code-block:: python
 

--- a/praw/models/reddit/wikipage.py
+++ b/praw/models/reddit/wikipage.py
@@ -179,7 +179,10 @@ class WikiPage(RedditBase):
 
     def __repr__(self) -> str:
         """Return an object initialization representation of the instance."""
-        return f"{self.__class__.__name__}(subreddit={self.subreddit!r}, name={self.name!r})"
+        return (
+            f"{self.__class__.__name__}(subreddit={self.subreddit!r},"
+            f" name={self.name!r})"
+        )
 
     def __str__(self) -> str:
         """Return a string representation of the instance."""

--- a/praw/models/util.py
+++ b/praw/models/util.py
@@ -39,8 +39,11 @@ class ExponentialCounter:
     def __init__(self, max_counter: int):
         """Initialize an instance of ExponentialCounter.
 
-        :param max_counter: The maximum base value. Note that the computed value may be
-            3.125% higher due to jitter.
+        :param max_counter: The maximum base value.
+
+            .. note::
+
+                The computed value may be 3.125% higher due to jitter.
 
         """
         self._base = 1

--- a/praw/reddit.py
+++ b/praw/reddit.py
@@ -230,8 +230,11 @@ class Reddit:
         self.auth = models.Auth(self, None)
         """An instance of :class:`.Auth`.
 
-        Provides the interface for interacting with installed and web applications. See
-        :ref:`auth_url`
+        Provides the interface for interacting with installed and web applications. 
+        
+        .. seealso::
+             
+             :ref:`auth_url`
 
         """
 

--- a/praw/reddit.py
+++ b/praw/reddit.py
@@ -95,8 +95,7 @@ class Reddit:
             self._core = self._read_only_core
         elif self._authorized_core is None:
             raise ClientException(
-                "read_only cannot be unset as only the "
-                "ReadOnlyAuthorizer is available."
+                "read_only cannot be unset as only the ReadOnlyAuthorizer is available."
             )
         else:
             self._core = self._authorized_core
@@ -114,7 +113,9 @@ class Reddit:
         value = self._validate_on_submit
         if value is False:
             warn(
-                "Reddit will check for validation on all posts around May-June 2020. It is recommended to check for validation by setting reddit.validate_on_submit to True.",
+                "Reddit will check for validation on all posts around May-June 2020. It"
+                " is recommended to check for validation by setting"
+                " reddit.validate_on_submit to True.",
                 category=DeprecationWarning,
                 stacklevel=3,
             )
@@ -207,12 +208,22 @@ class Reddit:
                 config_section, config_interpolation, **config_settings
             )
         except configparser.NoSectionError as exc:
-            help_message = "You provided the name of a praw.ini configuration which does not exist.\n\nFor help with creating a Reddit instance, visit\nhttps://praw.readthedocs.io/en/latest/code_overview/reddit_instance.html\n\nFor help on configuring PRAW, visit\nhttps://praw.readthedocs.io/en/latest/getting_started/configuration.html"
+            help_message = (
+                "You provided the name of a praw.ini configuration which does not"
+                " exist.\n\nFor help with creating a Reddit instance,"
+                " visit\nhttps://praw.readthedocs.io/en/latest/code_overview/reddit_instance.html\n\nFor"
+                " help on configuring PRAW,"
+                " visit\nhttps://praw.readthedocs.io/en/latest/getting_started/configuration.html"
+            )
             if site_name is not None:
                 exc.message += f"\n{help_message}"
             raise
 
-        required_message = "Required configuration setting {!r} missing. \nThis setting can be provided in a praw.ini file, as a keyword argument to the `Reddit` class constructor, or as an environment variable."
+        required_message = (
+            "Required configuration setting {!r} missing. \nThis setting can be"
+            " provided in a praw.ini file, as a keyword argument to the `Reddit` class"
+            " constructor, or as an environment variable."
+        )
         for attribute in ("client_id", "user_agent"):
             if getattr(self.config, attribute) in (self.config.CONFIG_NOT_SET, None):
                 raise MissingRequiredAttributeException(
@@ -220,7 +231,9 @@ class Reddit:
                 )
         if self.config.client_secret is self.config.CONFIG_NOT_SET:
             raise MissingRequiredAttributeException(
-                f"{required_message.format('client_secret')}\nFor installed applications this value must be set to None via a keyword argument to the `Reddit` class constructor."
+                f"{required_message.format('client_secret')}\nFor installed"
+                " applications this value must be set to None via a keyword argument"
+                " to the `Reddit` class constructor."
             )
 
         self._check_for_update()

--- a/praw/reddit.py
+++ b/praw/reddit.py
@@ -330,7 +330,7 @@ class Reddit:
 
             reddit.subreddit("redditdev")
 
-        Note that multiple subreddits can be combined and filtered views of r/all can
+        Multiple subreddits can be combined and filtered views of r/all can
         also be used just like a subreddit:
 
         .. code-block:: python

--- a/praw/reddit.py
+++ b/praw/reddit.py
@@ -243,10 +243,10 @@ class Reddit:
         self.auth = models.Auth(self, None)
         """An instance of :class:`.Auth`.
 
-        Provides the interface for interacting with installed and web applications. 
-        
+        Provides the interface for interacting with installed and web applications.
+
         .. seealso::
-             
+
              :ref:`auth_url`
 
         """

--- a/praw/util/cache.py
+++ b/praw/util/cache.py
@@ -13,7 +13,7 @@ class cachedproperty:
     This is useful for implementing lazy-loaded properties.
 
     The cache can be invalidated via `delattr()`, or by modifying `__dict__` directly.
-    directly. It will be repopulated on next access.
+    It will be repopulated on next access.
 
     .. versionadded:: 6.3.0
 

--- a/pre_push.py
+++ b/pre_push.py
@@ -118,8 +118,7 @@ def main():
         "--all",
         action="store_true",
         default=False,
-        help="Run all of the tests (static and unit). "
-        "Overrides the unstatic argument.",
+        help="Run all of the tests (static and unit). Overrides the unstatic argument.",
     )
     args = parser.parse_args()
     success = True

--- a/setup.py
+++ b/setup.py
@@ -55,9 +55,8 @@ setup(
         "Topic :: Utilities",
     ],
     description=(
-        "PRAW, an acronym for `Python Reddit API Wrapper`, is a "
-        "python package that allows for simple access to "
-        "reddit's API."
+        "PRAW, an acronym for `Python Reddit API Wrapper`, is a python package that"
+        " allows for simple access to reddit's API."
     ),
     extras_require=extras,
     install_requires=[

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -62,8 +62,8 @@ os.environ["praw_check_for_updates"] = "False"
 placeholders = {
     x: env_default(x)
     for x in (
-        "auth_code client_id client_secret password redirect_uri "
-        "test_subreddit user_agent username refresh_token"
+        "auth_code client_id client_secret password redirect_uri test_subreddit"
+        " user_agent username refresh_token"
     ).split()
 }
 

--- a/tests/integration/models/reddit/test_live.py
+++ b/tests/integration/models/reddit/test_live.py
@@ -18,7 +18,7 @@ class TestLiveUpdate(IntegrationTest):
         with self.use_cassette():
             assert isinstance(update.author, Redditor)
             assert update.author == "umbrae"
-            assert update.name == ("LiveUpdate_7827987a-c998-11e4-a0b9-22000b6a88d2")
+            assert update.name == "LiveUpdate_7827987a-c998-11e4-a0b9-22000b6a88d2"
             assert update.body.startswith("Small change")
 
 

--- a/tests/integration/models/reddit/test_subreddit.py
+++ b/tests/integration/models/reddit/test_subreddit.py
@@ -85,8 +85,7 @@ class WebsocketMockException:
             return dumps(
                 {
                     "payload": {
-                        "redirect": "https://reddit.com/r/<TEST_SUBREDDIT>/"
-                        "comments/abcdef/test_title/"
+                        "redirect": "https://reddit.com/r/<TEST_SUBREDDIT>/comments/abcdef/test_title/"
                     }
                 }
             )
@@ -500,13 +499,11 @@ class TestSubreddit(IntegrationTest):
             '<?xml version="1.0" encoding="UTF-8"?>'
             "<Error>"
             "<Code>EntityTooLarge</Code>"
-            "<Message>Your proposed upload exceeds the maximum "
-            "allowed size</Message>"
+            "<Message>Your proposed upload exceeds the maximum allowed size</Message>"
             "<ProposedSize>20971528</ProposedSize>"
             "<MaxSizeAllowed>20971520</MaxSizeAllowed>"
             "<RequestId>23F056D6990D87E0</RequestId>"
-            "<HostId>iYEVOuRfbLiKwMgHt2ewqQRIm0NWL79uiC2rPLj9P0PwW55"
-            "4MhjY2/O8d9JdKTf1iwzLjwWMnGQ=</HostId>"
+            "<HostId>iYEVOuRfbLiKwMgHt2ewqQRIm0NWL79uiC2rPLj9P0PwW554MhjY2/O8d9JdKTf1iwzLjwWMnGQ=</HostId>"
             "</Error>"
         )
         _post = reddit._core._requestor._http.post

--- a/tests/integration/models/reddit/test_widgets.py
+++ b/tests/integration/models/reddit/test_widgets.py
@@ -226,8 +226,8 @@ class TestCalendar(IntegrationTest):
             assert isinstance(widget, Calendar)
             assert widget.shortName == "Upcoming Events"
             assert (
-                widget.googleCalendarId == "ccahu0rstno2jrvioq4ccffn78@"
-                "group.calendar.google.com"
+                widget.googleCalendarId
+                == "ccahu0rstno2jrvioq4ccffn78@group.calendar.google.com"
             )
             assert widget.configuration == config
             assert widget.styles == styles
@@ -237,8 +237,8 @@ class TestCalendar(IntegrationTest):
             assert isinstance(widget, Calendar)
             assert widget.shortName == "Past Events :("
             assert (
-                widget.googleCalendarId == "ccahu0rstno2jrvioq4ccffn78@"
-                "group.calendar.google.com"
+                widget.googleCalendarId
+                == "ccahu0rstno2jrvioq4ccffn78@group.calendar.google.com"
             )
             assert widget.configuration == config
             assert widget.styles == styles

--- a/tests/unit/models/reddit/test_emoji.py
+++ b/tests/unit/models/reddit/test_emoji.py
@@ -56,7 +56,7 @@ class TestEmoji(UnitTest):
 
     def test_repr(self):
         emoji = Emoji(self.reddit, subreddit=Subreddit(self.reddit, "a"), name="x")
-        assert repr(emoji) == ("Emoji(name='x')")
+        assert repr(emoji) == "Emoji(name='x')"
 
     def test_str(self):
         emoji = Emoji(self.reddit, subreddit=Subreddit(self.reddit, "a"), name="x")

--- a/tests/unit/models/reddit/test_more.py
+++ b/tests/unit/models/reddit/test_more.py
@@ -16,10 +16,10 @@ class TestComment(UnitTest):
         more = MoreComments(
             self.reddit, {"children": ["a", "b", "c", "d", "e"], "count": 5}
         )
-        assert repr(more) == ("<MoreComments count=5, children=['a', 'b', 'c', '...']>")
+        assert repr(more) == "<MoreComments count=5, children=['a', 'b', 'c', '...']>"
 
         more = MoreComments(self.reddit, {"children": ["a", "b", "c", "d"], "count": 4})
-        assert repr(more) == ("<MoreComments count=4, children=['a', 'b', 'c', 'd']>")
+        assert repr(more) == "<MoreComments count=4, children=['a', 'b', 'c', 'd']>"
 
     def test_equality(self):
         more = MoreComments(self.reddit, {"children": ["a", "b", "c", "d"], "count": 4})

--- a/tests/unit/models/reddit/test_subreddit.py
+++ b/tests/unit/models/reddit/test_subreddit.py
@@ -192,7 +192,7 @@ class TestSubredditModmailConversationsStream(UnitTest):
         submodstream.modmail_conversations()
         assert submodstream.subreddit == "all"
 
-    def test_conversation_stream_capilization(self):
+    def test_conversation_stream_capitalization(self):
         submodstream = self.reddit.subreddit("Mod").mod.stream
         submodstream.modmail_conversations()
         assert submodstream.subreddit == "all"

--- a/tests/unit/test_deprecations.py
+++ b/tests/unit/test_deprecations.py
@@ -34,7 +34,7 @@ class TestDeprecation(UnitTest):
             excinfo.value.args[0]
             == "Calling SubredditRules to get a list of rules is deprecated. "
             "Remove the parentheses to use the iterator. View the "
-            "PRAW documentation on how to change the code in order to use the"
+            "PRAW documentation on how to change the code in order to use the "
             "iterator (https://praw.readthedocs.io/en/latest/code_overview"
             "/other/subredditrules.html#praw.models.reddit.rules."
             "SubredditRules.__call__)."

--- a/tests/unit/test_deprecations.py
+++ b/tests/unit/test_deprecations.py
@@ -32,12 +32,7 @@ class TestDeprecation(UnitTest):
             self.reddit.subreddit("test").rules()
         assert (
             excinfo.value.args[0]
-            == "Calling SubredditRules to get a list of rules is deprecated. "
-            "Remove the parentheses to use the iterator. View the "
-            "PRAW documentation on how to change the code in order to use the "
-            "iterator (https://praw.readthedocs.io/en/latest/code_overview"
-            "/other/subredditrules.html#praw.models.reddit.rules."
-            "SubredditRules.__call__)."
+            == "Calling SubredditRules to get a list of rules is deprecated. Remove the parentheses to use the iterator. View the PRAW documentation on how to change the code in order to use the iterator (https://praw.readthedocs.io/en/latest/code_overview/other/subredditrules.html#praw.models.reddit.rules.SubredditRules.__call__)."
         )
 
     def test_web_socket_exception_attribute(self):
@@ -46,9 +41,7 @@ class TestDeprecation(UnitTest):
             _ = exc.original_exception
         assert (
             excinfo.value.args[0]
-            == "Accessing the attribute original_exception is deprecated."
-            " Please rewrite your code in such a way that this attribute does "
-            "not need to be used. It will be removed in PRAW 8.0."
+            == "Accessing the attribute original_exception is deprecated. Please rewrite your code in such a way that this attribute does not need to be used. It will be removed in PRAW 8.0."
         )
 
     def test_gold_method(self):

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -48,8 +48,8 @@ class TestRedditErrorItem:
     def test_repr(self):
         error = RedditErrorItem("BAD_SOMETHING", "invalid something", "some_field")
         assert (
-            repr(error) == "RedditErrorItem(error_type='BAD_SOMETHING', message="
-            "'invalid something', field='some_field')"
+            repr(error)
+            == "RedditErrorItem(error_type='BAD_SOMETHING', message='invalid something', field='some_field')"
         )
 
 
@@ -100,8 +100,7 @@ class TestDuplicateReplaceException:
     def test_message(self):
         assert (
             str(DuplicateReplaceException())
-            == "A duplicate comment has been detected. Are you attempting to "
-            "call ``replace_more_comments`` more than once?"
+            == "A duplicate comment has been detected. Are you attempting to call ``replace_more_comments`` more than once?"
         )
 
 
@@ -112,8 +111,7 @@ class TestInvalidFlairTemplateID:
     def test_str(self):
         assert (
             str(InvalidFlairTemplateID("123"))
-            == "The flair template id ``123`` is invalid. If you are "
-            "trying to create a flair, please use the ``add`` method."
+            == "The flair template id ``123`` is invalid. If you are trying to create a flair, please use the ``add`` method."
         )
 
 
@@ -186,7 +184,5 @@ class TestMediaPostFailed:
     def test_message(self):
         assert (
             str(MediaPostFailed())
-            == "The attempted media upload action has failed. Possible causes"
-            " include the corruption of media files. Check that the media "
-            "file can be opened on your local machine."
+            == "The attempted media upload action has failed. Possible causes include the corruption of media files. Check that the media file can be opened on your local machine."
         )

--- a/tests/unit/test_reddit.py
+++ b/tests/unit/test_reddit.py
@@ -39,11 +39,9 @@ class TestReddit(UnitTest):
         loop.run_until_complete(self.check_async(reddit))
         log_record = caplog.records[0]
         assert log_record.levelname == "WARNING"
-        assert log_record.message == (
-            "It appears that you are using PRAW in an asynchronous environment.\nIt is"
-            " strongly recommended to use Async PRAW: https://asyncpraw.readthedocs.io."
-            "\nSee https://praw.readthedocs.io/en/latest/getting_started/multiple_instances.html#discord-bots-and-asynchronous-environments"
-            " for more info.\n"
+        assert (
+            log_record.message
+            == "It appears that you are using PRAW in an asynchronous environment.\nIt is strongly recommended to use Async PRAW: https://asyncpraw.readthedocs.io.\nSee https://praw.readthedocs.io/en/latest/getting_started/multiple_instances.html#discord-bots-and-asynchronous-environments for more info.\n"
         )
 
     def test_check_for_async__disabled(self, caplog):
@@ -93,15 +91,13 @@ class TestReddit(UnitTest):
             Reddit(timeout="test", **self.REQUIRED_DUMMY_SETTINGS)
         assert (
             excinfo.value.args[0]
-            == "An incorrect config type was given for option timeout. The "
-            "expected type is int, but the given value is test."
+            == "An incorrect config type was given for option timeout. The expected type is int, but the given value is test."
         )
         with pytest.raises(ValueError) as excinfo:
             Reddit(ratelimit_seconds="test", **self.REQUIRED_DUMMY_SETTINGS)
         assert (
-            excinfo.value.args[0] == "An incorrect config type was given for option "
-            "ratelimit_seconds. The expected type is int, but the given value "
-            "is test."
+            excinfo.value.args[0]
+            == "An incorrect config type was given for option ratelimit_seconds. The expected type is int, but the given value is test."
         )
 
     def test_info__not_list(self):

--- a/tools/check_docstring.py
+++ b/tools/check_docstring.py
@@ -40,7 +40,9 @@ class Visitor(docutils.nodes.NodeVisitor):
             needsReformatted = formatted != f"{node.rawsource}\n"
             if needsReformatted:
                 print(
-                    f"{current_file}:{current.lineno} Object: {current.name} at line {current.lineno}:\n{node.rawsource}\n\nNeeds reformatted to:\n\n{formatted}"
+                    f"{current_file}:{current.lineno} Object: {current.name} at line"
+                    f" {current.lineno}:\n{node.rawsource}\n\nNeeds reformatted"
+                    f" to:\n\n{formatted}"
                 )
                 failed = True
 

--- a/tools/check_documentation.py
+++ b/tools/check_documentation.py
@@ -56,7 +56,8 @@ class DocumentationChecker:
                 continue
             if not cls.HAS_ATTRIBUTE_TABLE.search(subclass.__doc__):
                 print(
-                    f"Subclass {subclass.__module__}.{subclass.__name__} is missing a table of common attributes."
+                    f"Subclass {subclass.__module__}.{subclass.__name__} is missing a"
+                    " table of common attributes."
                 )
                 success = False
             for method_name in dir(subclass):
@@ -71,11 +72,15 @@ class DocumentationChecker:
                     if cls.HAS_CODE_BLOCK.search(method.__doc__):
                         if cls.CODE_BLOCK_IMPROPER_INDENT.search(method.__doc__):
                             print(
-                                f"Code block for method {subclass.__module__}.{subclass.__name__}.{method.__name__} is improperly indented."
+                                "Code block for method"
+                                f" {subclass.__module__}.{subclass.__name__}.{method.__name__}"
+                                " is improperly indented."
                             )
                     else:
                         print(
-                            f"Method {subclass.__module__}.{subclass.__name__}.{method.__name__} is missing code examples."
+                            "Method"
+                            f" {subclass.__module__}.{subclass.__name__}.{method.__name__}"
+                            " is missing code examples."
                         )
                         success = False
         return success

--- a/tools/generate_award_table.py
+++ b/tools/generate_award_table.py
@@ -134,8 +134,10 @@ def main():
         action="store",
         choices=["a", "g", "s", "m"],
         default="g",
-        help="One of ``a`` for all, ``g`` for global, ``s`` for subreddit, or ``m`` "
-        "for moderator. Determines the types of awards to give. (default: g)",
+        help=(
+            "One of ``a`` for all, ``g`` for global, ``s`` for subreddit, or ``m`` for"
+            " moderator. Determines the types of awards to give. (default: g)"
+        ),
     )
     parser.add_argument(
         "-f",
@@ -150,8 +152,10 @@ def main():
         "--client_id",
         action="store",
         default=None,
-        help="Used to fetch the awards. Must be a 1st party client id. Note: If this "
-        "is passed [thing] and [subreddit] must be provided.",
+        help=(
+            "Used to fetch the awards. Must be a 1st party client id. Note: If this is"
+            " passed [thing] and [subreddit] must be provided."
+        ),
     )
     parser.add_argument(
         "-r",
@@ -165,25 +169,31 @@ def main():
         "--thing",
         action="store",
         default=None,
-        help="A submission or comment fullname. Must be used in conjunction with "
-        "[client_id].",
+        help=(
+            "A submission or comment fullname. Must be used in conjunction with"
+            " [client_id]."
+        ),
     )
     parser.add_argument(
         "-l",
         "--load_file",
         action="store",
         default=None,
-        help="Load award json from file. This is useful if you grab the JSON response "
-        "from a browser request. Can not be used with [client_id]. If not provided "
-        "[client_id] and [thing] is required.",
+        help=(
+            "Load award json from file. This is useful if you grab the JSON response"
+            " from a browser request. Can not be used with [client_id]. If not provided"
+            " [client_id] and [thing] is required."
+        ),
     )
     parser.add_argument(
         "-o",
         "--out_file",
         action="store",
         default=None,
-        help="File to write the formatted. If not provided output will be written to "
-        "STDOUT.",
+        help=(
+            "File to write the formatted. If not provided output will be written to"
+            " STDOUT."
+        ),
     )
     args = parser.parse_args()
     award_type = args.type
@@ -217,9 +227,8 @@ def main():
     if output_format == "j":
         if load_file:
             print(
-                "Uh...there's nothing to do if "
-                "you want output the loaded JSON "
-                "from 'load_file' as JSON"
+                "Uh...there's nothing to do if you want output the loaded JSON from"
+                " 'load_file' as JSON"
             )
             return
         final_content = dumps(award_json, ident=4)
@@ -241,7 +250,7 @@ def main():
             disable_numparse=True,
         )
         final_content = (
-            f"This is a list of known global awards (as of "
+            "This is a list of known global awards (as of "
             f"{datetime.today().strftime('%m/%d/%Y')})\n\n{table}"
         )
     if out_file is None:

--- a/tools/static_word_checks.py
+++ b/tools/static_word_checks.py
@@ -8,7 +8,7 @@ class StaticChecker:
     """Run simple checks on the entire document or specific lines."""
 
     def __init__(self, replace: bool):
-        """Instantiates the class.
+        """Initializes the class.
 
         :param replace: Whether or not to make replacements.
         """

--- a/tools/static_word_checks.py
+++ b/tools/static_word_checks.py
@@ -27,8 +27,8 @@ class StaticChecker:
         """Checks the code for ``.. code::`` statements.
 
         :param filename: The name of the file to check & replace.
-        :param content: The content of the file
-        :returns: A boolean with the status of the check
+        :param content: The content of the file.
+        :returns: A boolean with the status of the check.
         """
         if ".. code::" in content:
             new_content = content.replace(".. code::", ".. code-block::")
@@ -48,8 +48,8 @@ class StaticChecker:
         """Checks a file for double-slash statements (``/r/`` and ``/u/``).
 
         :param filename: The name of the file to check & replace.
-        :param content: The content of the file
-        :returns: A boolean with the status of the check
+        :param content: The content of the file.
+        :returns: A boolean with the status of the check.
 
         """
         if os.path.join("praw", "const.py") in filename:  # fails due to bytes blocks
@@ -77,9 +77,9 @@ class StaticChecker:
         """Checks a line for ``NoReturn`` statements.
 
         :param filename: The name of the file to check & replace.
-        :param line_number: The line number
-        :param content: The content of the line
-        :returns: A boolean with the status of the check
+        :param line_number: The line number.
+        :param content: The content of the line.
+        :returns: A boolean with the status of the check.
 
         """
         if "noreturn" in content.lower():

--- a/tools/static_word_checks.py
+++ b/tools/static_word_checks.py
@@ -31,10 +31,10 @@ class StaticChecker:
         :returns: A boolean with the status of the check
         """
         if ".. code::" in content:
-            newcontent = content.replace(".. code::", ".. code-block::")
+            new_content = content.replace(".. code::", ".. code-block::")
             if self.replace:
                 with open(filename, "w") as fp:
-                    fp.write(newcontent)
+                    fp.write(new_content)
                 print(f"{filename}: Replaced all ``code::`` to ``code-block::``")
                 return True
             print(
@@ -53,14 +53,14 @@ class StaticChecker:
         """
         if os.path.join("praw", "const.py") in filename:  # fails due to bytes blocks
             return True
-        newcontent = re.sub(r"(^|\s)/(u|r)/", r"\1\2/", content)
+        new_content = re.sub(r"(^|\s)/(u|r)/", r"\1\2/", content)
         # will only replace if the character behind a /r/ is a  whitespace character or
         # the start of a line
-        if content == newcontent:
+        if content == new_content:
             return True
         if self.replace:
             with open(filename, "w") as fp:
-                fp.write(newcontent)
+                fp.write(new_content)
             print(
                 f"{filename}: Replaced all instances of ``/r/`` and/or ``/u/`` to ``r/`` and/or ``u/``."
             )

--- a/tools/static_word_checks.py
+++ b/tools/static_word_checks.py
@@ -38,7 +38,8 @@ class StaticChecker:
                 print(f"{filename}: Replaced all ``code::`` to ``code-block::``")
                 return True
             print(
-                f"{filename}; This file uses the `code::` syntax, please change the syntax to ``code-block::``."
+                f"{filename}; This file uses the `code::` syntax, please change the"
+                " syntax to ``code-block::``."
             )
             return False
         return True
@@ -62,11 +63,13 @@ class StaticChecker:
             with open(filename, "w") as fp:
                 fp.write(new_content)
             print(
-                f"{filename}: Replaced all instances of ``/r/`` and/or ``/u/`` to ``r/`` and/or ``u/``."
+                f"{filename}: Replaced all instances of ``/r/`` and/or ``/u/`` to"
+                " ``r/`` and/or ``u/``."
             )
             return True
         print(
-            f"{filename}: This file contains instances of ``/r/`` and/or ``/u/``. Please change them to ``r/`` and/or ``u/``."
+            f"{filename}: This file contains instances of ``/r/`` and/or ``/u/``."
+            " Please change them to ``r/`` and/or ``u/``."
         )
         return False
 
@@ -81,7 +84,8 @@ class StaticChecker:
         """
         if "noreturn" in content.lower():
             print(
-                f"{filename}: Line {line_number} has phrase ``noreturn``, please edit and remove this."
+                f"{filename}: Line {line_number} has phrase ``noreturn``, please edit"
+                " and remove this."
             )
             return False
         return True
@@ -134,16 +138,20 @@ class StaticChecker:
 def main():
     """The main function."""
     parser = argparse.ArgumentParser(
-        description="Run static line checks and optionally replace values that"
-        " should not be used."
+        description=(
+            "Run static line checks and optionally replace values that"
+            " should not be used."
+        )
     )
     parser.add_argument(
         "-r",
         "--replace",
         action="store_true",
         default=False,
-        help="If it is possible, tries to reformat values. Not all checks "
-        "can reformat values, and those will have to be edited manually.",
+        help=(
+            "If it is possible, tries to reformat values. Not all checks can reformat"
+            " values, and those will have to be edited manually."
+        ),
     )
     args = parser.parse_args()
     check = StaticChecker(args.replace)

--- a/tools/static_word_checks.py
+++ b/tools/static_word_checks.py
@@ -101,12 +101,12 @@ class StaticChecker:
 
         * Full file checks:
 
-           * :meth:`.check_for_code_statement`
-           * :meth:`.check_for_double_syntax`
+          * :meth:`.check_for_code_statement`
+          * :meth:`.check_for_double_syntax`
 
         * Line checks
 
-           * :meth:`.check_for_noreturn`
+          * :meth:`.check_for_noreturn`
         """
         status = True
         directory = os.path.abspath(os.path.join(__file__, "..", "..", "praw"))


### PR DESCRIPTION
Fixes #1633

## Feature Summary and Justification

This fixes the following documentation errors (each item is a separate commit):

- Fix python code-block syntax errors
- Fix rst errors
- Replace http with https where applicable
- Replace /r/ with r/
- Change Raise(s) to use the :raises: directive where applicable
- Change Instantiate to Initialize
- Replace (c) with © in readme
- Clean up code
- Format long strings with black's `--experimental-string-processing` flag
- Change instances of "Note that" to use note directive
- Fix typos in docs

## References

- #1599