### PR TITLE
Sort all imports with isort

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,18 +27,20 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[lint]
-    - name: Run flynt
-      run: flynt -vdf -tc -ll 1000 .
-    - name: Run black
-      run: black --check --verbose .
-    - name: Run flake8
-      run: flake8 --exclude docs --statistics
     - name: Check other phrase usages
       run: python ./tools/static_word_checks.py
     - name: Check documentation
       run: python ./tools/check_documentation.py
     - name: Check docstrings
       run: python ./tools/check_docstring.py
+    - name: Run black
+      run: black --check --verbose .
+    - name: Run flake8
+      run: flake8 --exclude docs --statistics
+    - name: Run flynt
+      run: flynt -vdf -tc -ll 1000 .
+    - name: Run isort
+      run: isort -cv .
     - name: Run pydocstyle
       run: pydocstyle praw
     - name: Run sphinx
@@ -68,16 +70,18 @@ jobs:
         pip install .[lint]
     - name: Check other phrase usages
       run: python ./tools/static_word_checks.py
-    - name: Run flynt
-      run: flynt -vdf -tc -ll 1000 .
-    - name: Run black
-      run: black --check --verbose .
-    - name: Run flake8
-      run: flake8 --exclude docs --statistics
     - name: Check documentation
       run: python ./tools/check_documentation.py
     - name: Check docstrings
       run: python ./tools/check_docstring.py
+    - name: Run black
+      run: black --check --verbose .
+    - name: Run flake8
+      run: flake8 --exclude docs --statistics
+    - name: Run flynt
+      run: flynt -vdf -tc -ll 1000 .
+    - name: Run isort
+      run: isort -cv .
     - name: Run pydocstyle
       run: pydocstyle praw
     - name: Run sphinx

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,6 @@ sys.path.insert(1, "..")
 
 from praw import __version__
 
-
 copyright = "2020, Bryce Boe"
 exclude_patterns = ["_build"]
 extensions = ["sphinx.ext.autodoc", "sphinx.ext.intersphinx"]

--- a/praw/models/auth.py
+++ b/praw/models/auth.py
@@ -1,12 +1,7 @@
 """Provide the Auth class."""
 from typing import Dict, List, Optional, Set, Union
 
-from prawcore import (
-    Authorizer,
-    ImplicitAuthorizer,
-    UntrustedAuthenticator,
-    session,
-)
+from prawcore import Authorizer, ImplicitAuthorizer, UntrustedAuthenticator, session
 
 from ..exceptions import InvalidImplicitAuth, MissingRequiredAttributeException
 from .base import PRAWBase

--- a/praw/models/reddit/comment.py
+++ b/praw/models/reddit/comment.py
@@ -1,6 +1,10 @@
 """Provide the Comment class."""
 from typing import TYPE_CHECKING, Any, Dict, Optional, Union
 
+from ...const import API_PATH
+from ...exceptions import ClientException, InvalidURL
+from ...util.cache import cachedproperty
+from ..comment_forest import CommentForest
 from .base import RedditBase
 from .mixins import (
     FullnameMixin,
@@ -9,10 +13,6 @@ from .mixins import (
     UserContentMixin,
 )
 from .redditor import Redditor
-from ..comment_forest import CommentForest
-from ...const import API_PATH
-from ...exceptions import ClientException, InvalidURL
-from ...util.cache import cachedproperty
 
 if TYPE_CHECKING:  # pragma: no cover
     from ... import Reddit

--- a/praw/models/subreddits.py
+++ b/praw/models/subreddits.py
@@ -1,7 +1,7 @@
 """Provide the Subreddits class."""
 from typing import Dict, Iterator, List, Optional, Union
-
 from warnings import warn
+
 from ..const import API_PATH
 from . import Subreddit
 from .base import PRAWBase

--- a/pre_push.py
+++ b/pre_push.py
@@ -41,6 +41,7 @@ def run_static():
 
     """
     success = True
+    # Formatters
     success &= do_process(
         [
             sys.executable,
@@ -48,6 +49,11 @@ def run_static():
             "--replace",
         ]
     )
+    success &= do_process(["flynt", "-q", "-tc", "-ll", "1000", "."])
+    # needs to be first because flynt is not black compliant
+    success &= do_process(["black", "."])
+    success &= do_process(["isort", "."])
+    # Linters
     success &= do_process(
         [
             sys.executable,
@@ -60,8 +66,6 @@ def run_static():
             path.join(current_directory, "tools", "check_docstring.py"),
         ]
     )
-    success &= do_process(["flynt", "-q", "-tc", "-ll", "1000", "."])
-    success &= do_process(["black", "."])
     success &= do_process(["flake8", "--exclude=.eggs,build,docs,.venv"])
     success &= do_process(["pydocstyle", "praw"])
     # success &= do_process(["pylint", "--rcfile=.pylintrc", "praw"])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
 [tool.black]
 exclude = '/(\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|_build|buck-out|build|dist)/'
 line-length = 88
+
+[tool.isort]
+profile = "black"

--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,11 @@ extras = {
     "lint": [
         "black",
         "flake8",
+        "flynt",
+        "isort",
         "pydocstyle",
         "sphinx<3.0",
         "sphinx_rtd_theme",
-        "flynt",
     ],
     "readthedocs": ["sphinx<3.0"],
     "test": [

--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -4,9 +4,9 @@ import logging
 
 import pytest
 import requests
+from betamax import Betamax
 
 from praw import Reddit
-from betamax import Betamax
 
 
 class IntegrationTest:

--- a/tests/integration/models/reddit/test_live.py
+++ b/tests/integration/models/reddit/test_live.py
@@ -5,13 +5,7 @@ import pytest
 
 from praw.const import API_PATH
 from praw.exceptions import RedditAPIException
-from praw.models import (
-    LiveThread,
-    LiveUpdate,
-    Redditor,
-    RedditorList,
-    Submission,
-)
+from praw.models import LiveThread, LiveUpdate, Redditor, RedditorList, Submission
 
 from ... import IntegrationTest
 

--- a/tests/integration/models/reddit/test_subreddit.py
+++ b/tests/integration/models/reddit/test_subreddit.py
@@ -8,13 +8,7 @@ from unittest import mock
 import pytest
 import requests
 import websocket
-from prawcore import (
-    BadRequest,
-    Forbidden,
-    NotFound,
-    RequestException,
-    TooLarge,
-)
+from prawcore import BadRequest, Forbidden, NotFound, RequestException, TooLarge
 
 from praw.const import PNG_HEADER
 from praw.exceptions import (

--- a/tests/unit/models/reddit/test_collections.py
+++ b/tests/unit/models/reddit/test_collections.py
@@ -3,6 +3,7 @@ import pytest
 
 from praw.models import Collection
 from praw.models.reddit.collections import SubredditCollections
+
 from ... import UnitTest
 
 

--- a/tests/unit/models/reddit/test_inline_media.py
+++ b/tests/unit/models/reddit/test_inline_media.py
@@ -1,6 +1,6 @@
 import pickle
 
-from praw.models import InlineMedia, InlineGif, InlineImage, InlineVideo
+from praw.models import InlineGif, InlineImage, InlineMedia, InlineVideo
 
 from ... import UnitTest
 

--- a/tests/unit/models/reddit/test_rules.py
+++ b/tests/unit/models/reddit/test_rules.py
@@ -1,6 +1,7 @@
 import pytest
 
 from praw.models import Rule
+
 from ... import UnitTest
 
 

--- a/tests/unit/models/reddit/test_subreddit.py
+++ b/tests/unit/models/reddit/test_subreddit.py
@@ -1,7 +1,8 @@
 import json
 import pickle
-import pytest
 from unittest import mock
+
+import pytest
 
 from praw.exceptions import MediaPostFailed
 from praw.models import InlineGif, InlineImage, InlineVideo, Subreddit, WikiPage

--- a/tests/unit/models/test_util.py
+++ b/tests/unit/models/test_util.py
@@ -3,11 +3,12 @@ from collections import namedtuple
 from unittest import mock
 
 from praw.models.util import (
+    BoundedSet,
     ExponentialCounter,
     permissions_string,
     stream_generator,
-    BoundedSet,
 )
+
 from .. import UnitTest
 
 

--- a/tools/check_docstring.py
+++ b/tools/check_docstring.py
@@ -1,14 +1,13 @@
 import ast
 import os
 import re
-from ast import ClassDef, get_docstring, FunctionDef
+from ast import ClassDef, FunctionDef, get_docstring
 from os.path import basename
 
 import black
 import docutils.nodes
 import docutils.parsers.rst
 import docutils.utils
-
 
 mode = black.Mode(
     target_versions={black.TargetVersion.PY36},


### PR DESCRIPTION
## Feature Summary and Justification

This sorts all imports as recommended in the [contributing](https://github.com/praw-dev/praw/blob/c74a5e81a93fe49f5957adc82bc7db9a649196d8/.github/CONTRIBUTING.md#import-statement-order) guidelines. It also adds a step to `pre_push.py` and GitHub Actions for enforcement.

## References

- #1599
