### PR TITLE
Add check to see if PRAW is being ran in an asynchronous environment

### DIFF
--- a/docs/getting_started/multiple_instances.rst
+++ b/docs/getting_started/multiple_instances.rst
@@ -22,6 +22,18 @@ is strongly recommended to use `Async PRAW <https://asyncpraw.readthedocs.io/>`_
 the official asynchronous version of PRAW and its usage is similar and has the same
 features as PRAW.
 
+.. note::
+
+    By default, PRAW will check to see if it is in an asynchronous environment at the
+    initialization of :class:`.Reddit` and every time a network request is made. To
+    disable this check you can do:
+
+    .. code-block:: python
+
+        import praw
+
+        reddit = praw.Reddit(..., check_for_async=False)
+
 Multiple Programs
 -----------------
 

--- a/praw/config.py
+++ b/praw/config.py
@@ -107,6 +107,9 @@ class Config:
 
     def _initialize_attributes(self):
         self._short_url = self._fetch_default("short_url") or self.CONFIG_NOT_SET
+        self.check_for_async = self._config_boolean(
+            self._fetch_default("check_for_async", True)
+        )
         self.check_for_updates = self._config_boolean(
             self._fetch_or_not_set("check_for_updates")
         )


### PR DESCRIPTION
## Feature Summary and Justification

This adds a check to see if PRAW is being ran in an asynchronous environment (more specifically, if there is a running asyncio event loop) and advise users to use Async PRAW if there is one running.

This adds a check that is ran on the initialization of `praw.Reddit` and every time `Reddit.request()` is called. It can be suppressed by passing `check_for_async=False` anywhere config options are accepted.