### PR TITLE
Tag release on merge and then publish to pypi

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,7 +1,7 @@
 jobs:
   prepare_release:
-    runs-on: ubuntu-latest
     name: Prepare Release v${{ github.event.inputs.version }}
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
       with:
@@ -18,11 +18,16 @@ jobs:
         git config --global committer.email noreply@github.com
         git config --global committer.name GitHub
     - name: Set desired version
-      run: echo "version=$(tools/set_version.py ${{ github.event.inputs.version }})" >> $GITHUB_ENV
+      run: |
+        tools/set_version.py ${{ github.event.inputs.version }} > tmp_version
+        echo "version=$(cat tmp_version)" >> $GITHUB_ENV
     - name: Commit desired version
       run: git commit -am "Bump to v${{ env.version }}"
     - name: Set development version
-      run: echo "dev_version=$(tools/set_version.py Unreleased)" >> $GITHUB_ENV
+      run: |
+        tools/set_version.py Unreleased > tmp_version
+        echo "dev_version=$(cat tmp_version)" >> $GITHUB_ENV
+        rm tmp_version
     - name: Commit development version
       run: git commit -am "Set development version v${{ env.dev_version }}"
     - name: Create Pull Request

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,24 @@
+jobs:
+  release:
+    name: Build and release
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.x'
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+    - env:
+        TWINE_USERNAME: __token__
+        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+      name: Build and release
+      run: |
+        python setup.py sdist bdist_wheel
+        twine upload dist/*
+name: Upload Python Package
+on:
+  release:
+    types: [created]

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -1,0 +1,42 @@
+jobs:
+  release_tag:
+    if: "startsWith(github.event.head_commit.message, 'Merge pull request #') && contains(github.event.head_commit.message, ' from praw-dev/prepare_release_v')"
+    name: Tag Release
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 3
+        ssh-key: ${{ secrets.SSH_DEPLOY_KEY }}
+    - uses: actions/setup-python@v2
+      with:
+        python-version: 3.x
+    - name: Install dependencies
+      run: pip install packaging
+    - name: Extract Version
+      run: |
+        git checkout HEAD^2^
+        echo "commit=$(git rev-parse HEAD)" >> $GITHUB_ENV
+        git log --format=%B -n 1 | ./tools/bump_version.py > tmp_version
+        echo "version=$(cat tmp_version)" >> $GITHUB_ENV
+        cat tmp_version | python -c 'import sys; from packaging import version; print(int(version.Version(sys.stdin.readline()).is_prerelease))' > tmp_is_prerelease
+        echo "is_prerelease=$(cat tmp_is_prerelease)" >> $GITHUB_ENV
+    - env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      name: Create GitHub Release
+      uses: actions/create-release@v1
+      with:
+        body: |
+          [Changelog](https://praw.readthedocs.io/en/v${{ env.version }}/package_info/change_log.html#id1)
+        commitish: ${{ env.commit }}
+        draft: true
+        prerelease: ${{ env.is_prerelease == '1' }}
+        release_name: v${{ env.version }}
+        tag_name: v${{ env.version }}
+name: Tag Release
+on:
+  push:
+    branches:
+      - master
+      - release_test
+

--- a/tools/bump_version.py
+++ b/tools/bump_version.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+import sys
+
+COMMIT_PREFIX = "Bump to v"
+
+
+def main():
+    line = sys.stdin.readline()
+    if not line.startswith(COMMIT_PREFIX):
+        sys.stderr.write(
+            f"Commit message does not begin with `{COMMIT_PREFIX}`.\nMessage:\n\n{line}"
+        )
+        return 1
+    print(line[len(COMMIT_PREFIX) : -1])
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Only pull requests created through the prepare_release action will be tagged on merge.