### PR TITLE
Broaden exception catch for async check

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Change Log
 Unreleased
 ----------
 
+**Fixed**
+
+* Asynchronous check will no longer fail in Python 3.6 multithreading edge cases.
+
 7.1.3 (2021/02/05)
 ------------------
 

--- a/praw/reddit.py
+++ b/praw/reddit.py
@@ -375,14 +375,14 @@ class Reddit:
             except NameError:
                 pass
             in_async = False
-            if sys.version_info >= (3, 7, 0):
-                try:
+            try:
+                if sys.version_info >= (3, 7, 0):
                     asyncio.get_running_loop()
                     in_async = True
-                except RuntimeError:
-                    pass
-            else:
-                in_async = asyncio.get_event_loop().is_running()
+                else:
+                    in_async = asyncio.get_event_loop().is_running()
+            except Exception:  # Quietly fail if any exception occurs during the check
+                pass
             if in_async:
                 logger.warning(
                     "It appears that you are using PRAW in an asynchronous"


### PR DESCRIPTION
Fixes #1663 
