### PR TITLE
Tag release only makes a draft release

### DIFF
--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -21,4 +21,4 @@ jobs:
 name: Upload Python Package
 on:
   release:
-    types: [created, published]
+    types: [published]

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -29,7 +29,7 @@ jobs:
         body: |
           [Changelog](https://praw.readthedocs.io/en/v${{ env.version }}/package_info/change_log.html#id1)
         commitish: ${{ env.commit }}
-        draft: false
+        draft: true
         prerelease: ${{ env.is_prerelease == '1' }}
         release_name: v${{ env.version }}
         tag_name: v${{ env.version }}


### PR DESCRIPTION
Using a draft is necessary because one github action will not result in
automatically triggering a separate action. Thus we create a draft, because the
manual publishing of the draft will cause the publish to pypi action to
trigger.