### PR TITLE
Rename parameter in Reddit.info.generator and actually use parameter instead of one from outer scope

### DIFF
--- a/praw/reddit.py
+++ b/praw/reddit.py
@@ -577,11 +577,11 @@ class Reddit:
 
             api_parameter_name = "id" if is_using_fullnames else "sr_name"
 
-            def generator(fullnames):
+            def generator(names):
                 if is_using_fullnames:
-                    iterable = iter(ids_or_names)
+                    iterable = iter(names)
                 else:
-                    iterable = iter([str(item) for item in ids_or_names])
+                    iterable = iter([str(item) for item in names])
                 while True:
                     chunk = list(islice(iterable, 100))
                     if not chunk:
@@ -590,7 +590,7 @@ class Reddit:
                     for result in self.get(API_PATH["info"], params=params):
                         yield result
 
-            return generator(fullnames)
+            return generator(ids_or_names)
 
         def generator(url):
             params = {"url": url}


### PR DESCRIPTION
## Feature Summary and Justification

This makes the generator in `Reddit.info` actually use the parameter being passed in instead of use a variable defined in the outer scope.