### PR TITLE
Update Sphinx config

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from datetime import datetime
 
 # Do not touch these. They use the local PRAW over the global PRAW.
 sys.path.insert(0, ".")
@@ -7,14 +8,14 @@ sys.path.insert(1, "..")
 
 from praw import __version__
 
-copyright = "2020, Bryce Boe"
+copyright = datetime.today().strftime("%Y, Bryce Boe")
 exclude_patterns = ["_build"]
 extensions = ["sphinx.ext.autodoc", "sphinx.ext.intersphinx"]
 html_static_path = ["_static"]
 html_theme = "sphinx_rtd_theme"
 html_theme_options = {"collapse_navigation": True}
 htmlhelp_basename = "PRAW"
-intersphinx_mapping = {"python": ("https://docs.python.org/3.8", None)}
+intersphinx_mapping = {"python": ("https://docs.python.org", None)}
 master_doc = "index"
 nitpick_ignore = [
     ("py:class", "IO"),


### PR DESCRIPTION
This changes the following:
- Make copyright year dynamic to always return the current year
- Make intersphinx link to the latest Python docs