### PR TITLE
Use the ABC class to declare an abstract class

### DIFF
--- a/praw/util/token_manager.py
+++ b/praw/util/token_manager.py
@@ -10,8 +10,10 @@ See ref:`using_refresh_tokens` for examples on how to leverage these classes.
 
 """
 
+from abc import ABC, abstractmethod
 
-class BaseTokenManager:
+
+class BaseTokenManager(ABC):
     """An abstract class for all token managers."""
 
     def __init__(self):
@@ -31,6 +33,7 @@ class BaseTokenManager:
             )
         self._reddit = value
 
+    @abstractmethod
     def post_refresh_callback(self, authorizer):
         """Handle callback that is invoked after a refresh token is used.
 
@@ -42,8 +45,8 @@ class BaseTokenManager:
         ``refresh_token``.
 
         """
-        raise NotImplementedError("``post_refresh_callback`` must be extended.")
 
+    @abstractmethod
     def pre_refresh_callback(self, authorizer):
         """Handle callback that is invoked before refreshing PRAW's authorization.
 
@@ -55,7 +58,6 @@ class BaseTokenManager:
         ``refresh_token``.
 
         """
-        raise NotImplementedError("``pre_refresh_callback`` must be extended.")
 
 
 class FileTokenManager(BaseTokenManager):

--- a/tests/unit/test_reddit.py
+++ b/tests/unit/test_reddit.py
@@ -16,6 +16,14 @@ from praw.util.token_manager import BaseTokenManager
 from . import UnitTest
 
 
+class DummyTokenManager(BaseTokenManager):
+    def post_refresh_callback(self, authorizer):
+        pass
+
+    def pre_refresh_callback(self, authorizer):
+        pass
+
+
 class TestReddit(UnitTest):
     REQUIRED_DUMMY_SETTINGS = {
         x: "dummy" for x in ["client_id", "client_secret", "user_agent"]
@@ -202,8 +210,8 @@ class TestReddit(UnitTest):
     def test_read_only__with_authenticated_core(self):
         with Reddit(
             password=None,
-            token_manager=BaseTokenManager(),
             username=None,
+            token_manager=DummyTokenManager(),
             **self.REQUIRED_DUMMY_SETTINGS,
         ) as reddit:
             assert not reddit.read_only
@@ -230,8 +238,8 @@ class TestReddit(UnitTest):
             client_id="dummy",
             client_secret=None,
             redirect_uri="dummy",
-            token_manager=BaseTokenManager(),
             user_agent="dummy",
+            token_manager=DummyTokenManager(),
         ) as reddit:
             assert not reddit.read_only
             reddit.read_only = True

--- a/tests/unit/util/test_token_manager.py
+++ b/tests/unit/util/test_token_manager.py
@@ -6,6 +6,7 @@ import pytest
 from praw.util.token_manager import BaseTokenManager, FileTokenManager
 
 from .. import UnitTest
+from ..test_reddit import DummyTokenManager
 
 
 class DummyAuthorizer:
@@ -14,25 +15,17 @@ class DummyAuthorizer:
 
 
 class TestBaseTokenManager(UnitTest):
-    def test_post_refresh_token_callback__raises_not_implemented(self):
-        manager = BaseTokenManager()
-        with pytest.raises(NotImplementedError) as excinfo:
-            manager.post_refresh_callback(None)
-        assert str(excinfo.value) == "``post_refresh_callback`` must be extended."
-
-    def test_pre_refresh_token_callback__raises_not_implemented(self):
-        manager = BaseTokenManager()
-        with pytest.raises(NotImplementedError) as excinfo:
-            manager.pre_refresh_callback(None)
-        assert str(excinfo.value) == "``pre_refresh_callback`` must be extended."
+    def test_init_base_fail(self):
+        with pytest.raises(TypeError):
+            BaseTokenManager()
 
     def test_reddit(self):
-        manager = BaseTokenManager()
+        manager = DummyTokenManager()
         manager.reddit = "dummy"
         assert manager.reddit == "dummy"
 
     def test_reddit__must_only_be_set_once(self):
-        manager = BaseTokenManager()
+        manager = DummyTokenManager()
         manager.reddit = "dummy"
         with pytest.raises(RuntimeError) as excinfo:
             manager.reddit = None


### PR DESCRIPTION
This allows IDEs and other tools to recognize that the class is abstract and throws the appropriate warnings.