### PR TITLE
Fix _NotSet check in config.py

### DIFF
--- a/praw/config.py
+++ b/praw/config.py
@@ -33,7 +33,7 @@ class Config:
     @staticmethod
     def _config_boolean(item):
         if isinstance(item, _NotSet):
-            return false
+            return False
         if isinstance(item, bool):
             return item
         return item.lower() in {"1", "yes", "true", "on"}

--- a/praw/config.py
+++ b/praw/config.py
@@ -32,6 +32,8 @@ class Config:
 
     @staticmethod
     def _config_boolean(item):
+        if isinstance(item, _NotSet):
+            return false
         if isinstance(item, bool):
             return item
         return item.lower() in {"1", "yes", "true", "on"}


### PR DESCRIPTION
Fixes # (provide issue number if applicable)

## Feature Summary and Justification

This feature provides a fix for handling a _NotSet object properly in the _config_boolean() function. It appears the developer misunderstood how the __bool__ and __str__ built-in methods operate, which was causing the function to fall through the first isinstance() check and then throw an exception when trying to lower a non-string. This solution adds an additional isinstance check to return "false" if the item passed into the _config_boolean() function is a _NotSet object

## References

* 
*
