### PR TITLE
update docs for Submission.link_flair_template_id

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -22,7 +22,7 @@ Documentation Contributors
 - Kenneth Yang `@kennethy <https://github.com/kennethy>`_
 - Tarak Oueriache <Igosad@protonmail.com> `@igosad <https://github.com/igosad>`_
 - xCROv `@xCROv <https://github.com/xCROv>`_
-- taq  `@greentaquitos <https://github.com/greentaquitos>`_
+- taq `@greentaquitos <https://github.com/greentaquitos>`_
 
 <!-- - Add "Name <email (optional)> and github profile link" above this line. -->
 

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -22,6 +22,7 @@ Documentation Contributors
 - Kenneth Yang `@kennethy <https://github.com/kennethy>`_
 - Tarak Oueriache <Igosad@protonmail.com> `@igosad <https://github.com/igosad>`_
 - xCROv `@xCROv <https://github.com/xCROv>`_
+- taq  `@greentaquitos <https://github.com/greentaquitos>`_
 
 <!-- - Add "Name <email (optional)> and github profile link" above this line. -->
 

--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -367,7 +367,7 @@ class Submission(SubmissionListingMixin, UserContentMixin, FullnameMixin, Reddit
     ``is_original_content``    Whether or not the submission has been set as original
                                content.
     ``is_self``                Whether or not the submission is a selfpost (text-only).
-    ``link_flair_template_id`` The link flair's ID, or None if not flaired.
+    ``link_flair_template_id`` The link flair's ID.
     ``link_flair_text``        The link flair's text content, or None if not flaired.
     ``locked``                 Whether or not the submission has been locked.
     ``name``                   Fullname of the submission.


### PR DESCRIPTION
Closes #1700 

## Feature Summary and Justification

Docs reflect that link_flair_template_id attribute does not return None when a link flair isn't present
