### PR TITLE
Make Redditor.moderated utilized all data returned from the API

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -4,6 +4,10 @@ Change Log
 Unreleased
 ----------
 
+**Changed**
+
+- :meth:`.Redditor.moderated` will now objectify all data returned from the API.
+
 7.2.0 (2021/02/24)
 ------------------
 

--- a/docs/code_overview/other.rst
+++ b/docs/code_overview/other.rst
@@ -105,6 +105,7 @@ them bound to an attribute of one of the PRAW models.
     other/inlinevideo
     other/menulink
     other/mod_action
+    other/moderatedlist
     other/modmail
     other/modmailmessage
     other/preferences

--- a/docs/code_overview/other/moderatedlist.rst
+++ b/docs/code_overview/other/moderatedlist.rst
@@ -1,0 +1,5 @@
+ModeratedList
+=============
+
+.. autoclass:: praw.models.ModeratedList
+    :inherited-members:

--- a/praw/models/__init__.py
+++ b/praw/models/__init__.py
@@ -3,6 +3,7 @@ from .auth import Auth
 from .front import Front
 from .helpers import LiveHelper, MultiredditHelper, SubredditHelper
 from .inbox import Inbox
+from .list.moderated import ModeratedList
 from .list.redditor import RedditorList
 from .list.trophy import TrophyList
 from .listing.domain import DomainListing

--- a/praw/models/list/moderated.py
+++ b/praw/models/list/moderated.py
@@ -1,0 +1,8 @@
+"""Provide the ModeratedList class."""
+from .base import BaseList
+
+
+class ModeratedList(BaseList):
+    """A list of Moderated Subreddits. Works just like a regular list."""
+
+    CHILD_ATTRIBUTE = "data"

--- a/praw/models/reddit/redditor.py
+++ b/praw/models/reddit/redditor.py
@@ -260,12 +260,7 @@ class Redditor(MessageableMixin, RedditorListingMixin, FullnameMixin, RedditBase
                 print(subreddit.title)
 
         """
-        modded_data = self._reddit.get(API_PATH["moderated"].format(user=self))
-        if "data" not in modded_data:
-            return []
-        else:
-            subreddits = [self._reddit.subreddit(x["sr"]) for x in modded_data["data"]]
-            return subreddits
+        return self._reddit.get(API_PATH["moderated"].format(user=self)) or []
 
     def multireddits(self) -> List["praw.models.Multireddit"]:
         """Return a list of the redditor's public multireddits.

--- a/praw/objector.py
+++ b/praw/objector.py
@@ -131,6 +131,9 @@ class Objector:
         elif "username" in data.keys():
             data["name"] = data.pop("username")
             parser = self.parsers[self._reddit.config.kinds["redditor"]]
+        elif {"mod_permissions", "name", "sr", "subscribers"}.issubset(data):
+            data["display_name"] = data["sr"]
+            parser = self.parsers[self._reddit.config.kinds["subreddit"]]
         else:
             if "user" in data:
                 parser = self.parsers[self._reddit.config.kinds["redditor"]]
@@ -166,7 +169,10 @@ class Objector:
             return parser.parse(data, self._reddit)
         if {"kind", "data"}.issubset(data) and data["kind"] in self.parsers:
             parser = self.parsers[data["kind"]]
-            return parser.parse(data["data"], self._reddit)
+            if data["kind"] == "ModeratedList":
+                return parser.parse(data, self._reddit)
+            else:
+                return parser.parse(data["data"], self._reddit)
         if "json" in data and "data" in data["json"]:
             if "websocket_url" in data["json"]["data"]:
                 return data

--- a/praw/reddit.py
+++ b/praw/reddit.py
@@ -457,6 +457,7 @@ class Reddit:
             "LiveUpdate": models.LiveUpdate,
             "LiveUpdateEvent": models.LiveThread,
             "MenuLink": models.MenuLink,
+            "ModeratedList": models.ModeratedList,
             "ModmailAction": models.ModmailAction,
             "ModmailConversation": models.ModmailConversation,
             "ModmailMessage": models.ModmailMessage,


### PR DESCRIPTION
## Feature Summary and Justification

This makes the `Redditor.moderated()` method actually utilize all the data that is returned from the API.

 Currently, this method just uses the `sr` key to initialize a lazy subreddit instance from what is returned:

```json
{
    "banner_img": "",
    "community_icon": "",
    "display_name": "pics",
    "title": "Reddit Pics",
    "over_18": false,
    "icon_size": [
        256,
        256
    ],
    "primary_color": "#ffffff",
    "icon_img": "https://b.thumbs.redditmedia.com/VZX_KQLnI1DPhlEZ07bIcLzwR1Win808RIt7zm49VIQ.png",
    "display_name_prefixed": "r/pics",
    "sr_display_name_prefixed": "r/pics",
    "subscribers": 26892797,
    "whitelist_status": "all_ads",
    "subreddit_type": "public",
    "key_color": "#222222",
    "name": "t5_2qh0u",
    "created": 1201249869.0,
    "url": "/r/pics/",
    "sr": "pics",
    "created_utc": 1201221069.0,
    "banner_size": null,
    "mod_permissions": [],
    "user_can_crosspost": true,
    "user_is_subscriber": true
}
```