### PR TITLE
Convert HTML comments to RST in AUTHORS.rst

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -24,7 +24,7 @@ Documentation Contributors
 - xCROv `@xCROv <https://github.com/xCROv>`_
 - taq `@greentaquitos <https://github.com/greentaquitos>`_
 
-<!-- - Add "Name <email (optional)> and github profile link" above this line. -->
+.. Add "Name <email (optional)> and github profile link" above this line.
 
 Logo Creator
 ============
@@ -73,4 +73,4 @@ Source Contributors
 - Yash Chhabria `@Cyatos <https://github.com/Cyatos>`_
 - Justin Krejcha <justin@justinkrejcha.com> `@jkrejcha <https://github.com/jkrejcha>`_
 
-<!-- - Add "Name <email (optional)> and github profile link" above this line. -->
+.. Add "Name <email (optional)> and github profile link" above this line.

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -23,8 +23,7 @@ Documentation Contributors
 - Tarak Oueriache <Igosad@protonmail.com> `@igosad <https://github.com/igosad>`_
 - xCROv `@xCROv <https://github.com/xCROv>`_
 - taq `@greentaquitos <https://github.com/greentaquitos>`_
-
-.. Add "Name <email (optional)> and github profile link" above this line.
+- Add "Name <email (optional)> and github profile link" above this line.
 
 Logo Creator
 ============
@@ -72,5 +71,4 @@ Source Contributors
 - Nick Kelly `@nickatnight <https://github.com/nickatnight>`_
 - Yash Chhabria `@Cyatos <https://github.com/Cyatos>`_
 - Justin Krejcha <justin@justinkrejcha.com> `@jkrejcha <https://github.com/jkrejcha>`_
-
-.. Add "Name <email (optional)> and github profile link" above this line.
+- Add "Name <email (optional)> and github profile link" above this line.


### PR DESCRIPTION
Doesn't change any functionality.

RST doesn't use HTML style (`<!-- COMMENT -->`) comments, but instead every block which isn't a valid markup construct is treated like a comment.
Surprised this wasn't fixed for 14 months. 👍