### PR TITLE
Fix bug where Reddit.request could not handle certain Bad Requests

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -16,6 +16,8 @@ Unreleased
   passed `content` and `reason` parameters that produced a request with a body greater
   than 500 KiB, even when the parameters did not exceed their respective permitted
   maximum lengths.
+- Fixed bug where :meth:`.Reddit.request` could not handle instances of ``BadRequest``\s
+  when the JSON data contained only the keys "reason" and "message".
 
 **Deprecated**
 

--- a/praw/exceptions.py
+++ b/praw/exceptions.py
@@ -21,7 +21,7 @@ class RedditErrorItem:
     @property
     def error_message(self) -> str:
         """Get the completed error message string."""
-        error_str = f"{self.error_type}"
+        error_str = self.error_type
         if self.message:
             error_str += f": {self.message!r}"
         if self.field:

--- a/praw/exceptions.py
+++ b/praw/exceptions.py
@@ -22,7 +22,7 @@ class RedditErrorItem:
     def error_message(self) -> str:
         """Get the completed error message string."""
         if not self.message:
-            error_str = f"{self.error_type}"
+            error_str = f"{self.error_type!r}"
         else:
             error_str = f"{self.error_type}: {self.message!r}"
         if self.field:

--- a/praw/exceptions.py
+++ b/praw/exceptions.py
@@ -21,10 +21,9 @@ class RedditErrorItem:
     @property
     def error_message(self) -> str:
         """Get the completed error message string."""
-        if not self.message:
-            error_str = f"{self.error_type!r}"
-        else:
-            error_str = f"{self.error_type}: {self.message!r}"
+        error_str = f"{self.error_type}"
+        if self.message:
+            error_str += f": {self.message!r}"
         if self.field:
             error_str += f" on field {self.field!r}"
         return error_str

--- a/praw/exceptions.py
+++ b/praw/exceptions.py
@@ -21,12 +21,20 @@ class RedditErrorItem:
     @property
     def error_message(self) -> str:
         """Get the completed error message string."""
-        error_str = f"{self.error_type}: {self.message!r}"
+        if not self.message:
+            error_str = f"{self.error_type}"
+        else:
+            error_str = f"{self.error_type}: {self.message!r}"
         if self.field:
             error_str += f" on field {self.field!r}"
         return error_str
 
-    def __init__(self, error_type: str, message: str, field: Optional[str] = None):
+    def __init__(
+        self,
+        error_type: str,
+        message: Optional[str] = None,
+        field: Optional[str] = None,
+    ):
         """Initialize an error item.
 
         :param error_type: The error type set on Reddit's end.
@@ -78,7 +86,7 @@ class APIException(PRAWException):
             if isinstance(exception, RedditErrorItem)
             else RedditErrorItem(
                 exception[0],
-                exception[1],
+                exception[1] if bool(exception[1]) else "",
                 exception[2] if bool(exception[2]) else "",
             )
             for exception in exceptions

--- a/praw/reddit.py
+++ b/praw/reddit.py
@@ -867,15 +867,12 @@ class Reddit:
                 ) from exception
             if set(data) == {"error", "message"}:
                 raise
+            explanation = data["explanation"] if "explanation" in data else None
             if "fields" in data:
                 assert len(data["fields"]) == 1
                 field = data["fields"][0]
             else:
                 field = None
-            if "explanation" in data:
-                explanation = data["explanation"]
-            else:
-                explanation = None
             raise RedditAPIException(
                 [data["reason"], explanation, field]
             ) from exception

--- a/praw/reddit.py
+++ b/praw/reddit.py
@@ -872,8 +872,12 @@ class Reddit:
                 field = data["fields"][0]
             else:
                 field = None
+            if "explanation" in data:
+                explanation = data["explanation"]
+            else:
+                explanation = None
             raise RedditAPIException(
-                [data["reason"], data["explanation"], field]
+                [data["reason"], explanation, field]
             ) from exception
 
     def submission(  # pylint: disable=invalid-name,redefined-builtin

--- a/praw/reddit.py
+++ b/praw/reddit.py
@@ -867,7 +867,7 @@ class Reddit:
                 ) from exception
             if set(data) == {"error", "message"}:
                 raise
-            explanation = data["explanation"] if "explanation" in data else None
+            explanation = data.get("explanation")
             if "fields" in data:
                 assert len(data["fields"]) == 1
                 field = data["fields"][0]

--- a/tests/integration/cassettes/TestWikiPage.test_content_md__invalid_name.json
+++ b/tests/integration/cassettes/TestWikiPage.test_content_md__invalid_name.json
@@ -1,0 +1,194 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2021-05-08T23:19:03",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=client_credentials"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "29"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/7.2.1.dev0 prawcore/2.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "109"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sat, 08 May 2021 23:19:03 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "edgebucket=ncikXmq8AzUewLx52y; Domain=reddit.com; Max-Age=63071999; Path=/;  secure"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-reddit-loid": [
+            "0000000000c0pra3g1.2.1620515943640.t2"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2021-05-08T23:19:03",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "edgebucket=ncikXmq8AzUewLx52y"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/7.2.1.dev0 prawcore/2.0.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/r/reddit.com/wiki/%5CA?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"reason\": \"INVALID_PAGE_NAME\", \"message\": \"Bad Request\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "57"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sat, 08 May 2021 23:19:03 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "loid=0000000000c0pra3g1.2.1620515943640.Z0FBQUFBQmdseHhuLWNxaGx2YVQtbkxJd3BVbE5BaC0teVlCQTVtdUVhV1ZzX3B3NHlKZjB0SnBuRVZUVDBIR0N5u05ocUJ3U3hxWVZjNVFFbkk1T0dHLWk2U2txSXRMY0VLVnNYdzByVHN2bjItaFUwU2NRYVBaUi1ENVZLWjNzZ1N3UmVtZGM0czM; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Mon, 08-May-2023 23:19:03 GMT; secure; SameSite=None; Secure",
+            "session_tracker=Zqu6KGzxE3ZlaqG7tz.0.1620515943872.Z0FBQUFBQmdseHhuVERzZm5JNDVqVFVKVHREN0VLVTNPQkF6aTd6RHdYaGhOU0hOc0FicDVWVFNDazloN0pFWjBLdVEyZGtCZVdST3hpcHp2aktSc3V6eldJSTRuVkx1ZURZYVhmZEhxNW5Sbi1DS253VmJBdVZlbV93NjBXdUduUTVROHBySTRXUkI; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sun, 09-May-2021 01:19:03 GMT; secure; SameSite=None; Secure",
+            "csv=1; Max-Age=63072000; Domain=.reddit.com; Path=/; Secure; SameSite=None"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "access-control-allow-origin": [
+            "*"
+          ],
+          "access-control-expose-headers": [
+            "X-Moose"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 400,
+          "message": "Bad Request"
+        },
+        "url": "https://oauth.reddit.com/r/reddit.com/wiki/%5CA?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/integration/models/reddit/test_wikipage.py
+++ b/tests/integration/models/reddit/test_wikipage.py
@@ -23,8 +23,9 @@ class TestWikiPage(IntegrationTest):
         page = WikiPage(self.reddit, subreddit, "\\A")
 
         with self.use_cassette():
-            with pytest.raises(RedditAPIException):
+            with pytest.raises(RedditAPIException) as excinfo:
                 page.content_md
+            assert str(excinfo.value) == "INVALID_PAGE_NAME"
 
     def test_edit(self):
         subreddit = self.reddit.subreddit(pytest.placeholders.test_subreddit)

--- a/tests/integration/models/reddit/test_wikipage.py
+++ b/tests/integration/models/reddit/test_wikipage.py
@@ -4,6 +4,7 @@ from unittest import mock
 import pytest
 from prawcore import NotFound
 
+from praw.exceptions import RedditAPIException
 from praw.models import Redditor, WikiPage
 
 from ... import IntegrationTest
@@ -16,6 +17,14 @@ class TestWikiPage(IntegrationTest):
 
         with self.use_cassette():
             assert page.content_md
+
+    def test_content_md__invalid_name(self):
+        subreddit = self.reddit.subreddit("reddit.com")
+        page = WikiPage(self.reddit, subreddit, "\\A")
+
+        with self.use_cassette():
+            with pytest.raises(RedditAPIException):
+                page.content_md
 
     def test_edit(self):
         subreddit = self.reddit.subreddit(pytest.placeholders.test_subreddit)


### PR DESCRIPTION
## Feature Summary and Justification

Reddit.request currently cannot handle Bad Requests when the JSON data only contained the keys "reason" and "message". The wiki endpoints are FULL of 400s, 403s, and 404s that return responses with only those fields—more details to follow in coming PR that adds endpoints `api/wiki/hide` and `api/wiki/revert`. Reddit.request currently assumes that bad requests either [have the keys "error" and "message"](https://github.com/praw-dev/praw/blob/master/praw/reddit.py#L868), or [contain the key "explanation"](https://github.com/praw-dev/praw/blob/master/praw/reddit.py#L876).

This PR includes a test and a cassette that shows this kind of response. You could also execute `reddit.subreddit('reddit.com').wiki['\\A'].content_md` in the current build to see this. 
