### PR TITLE
Exclude paths that start with .venv from pre_push checks

### DIFF
--- a/pre_push.py
+++ b/pre_push.py
@@ -61,7 +61,7 @@ def run_static():
             path.join(current_directory, "tools", "check_documentation.py"),
         ]
     )
-    success &= do_process(["flake8", "--exclude=.eggs,build,docs,.venv"])
+    success &= do_process(["flake8", "--exclude=.eggs,build,docs,.venv*"])
     success &= do_process(["pydocstyle", "praw"])
     # success &= do_process(["pylint", "--rcfile=.pylintrc", "praw"])
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,7 @@
 [tool.black]
-exclude = '/(\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv|_build|buck-out|build|dist)/'
+exclude = '/(\.eggs|\.git|\.hg|\.mypy_cache|\.nox|\.tox|\.venv.*|_build|buck-out|build|dist)/'
 line-length = 88
 
 [tool.isort]
 profile = "black"
+skip_glob = '.venv*'


### PR DESCRIPTION
This just adds `.venv*` to the excluded files/folders for pre_push.py checks.