### PR TITLE
Add oauth endpoint username_available

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -7,6 +7,7 @@ Unreleased
 **Added**
 
 - :class:`.UserSubreddit` for the ``subreddit`` attribute of :class:`.Redditor`.
+- :meth:`.Reddit.username_available` checks if a username is available.
 
 **Changed**
 

--- a/praw/endpoints.py
+++ b/praw/endpoints.py
@@ -202,6 +202,7 @@ API_PATH = {
     "user_about":              "user/{user}/about/",
     "user_by_fullname":        "/api/user_data_by_account_ids",
     "user_flair":              "r/{subreddit}/api/user_flair_v2",
+    "username_available":      "api/username_available",
     "users_new":               "users/new",
     "users_popular":           "users/popular",
     "users_search":            "users/search",

--- a/praw/objector.py
+++ b/praw/objector.py
@@ -142,8 +142,8 @@ class Objector:
         return parser.parse(data, self._reddit)
 
     def objectify(
-        self, data: Optional[Union[Dict[str, Any], List[Any]]]
-    ) -> Optional[Union[RedditBase, Dict[str, Any], List[Any]]]:
+        self, data: Optional[Union[Dict[str, Any], List[Any], bool]]
+    ) -> Optional[Union[RedditBase, Dict[str, Any], List[Any], bool]]:
         """Create RedditBase objects from data.
 
         :param data: The structured data.
@@ -157,6 +157,8 @@ class Objector:
             return None
         if isinstance(data, list):
             return [self.objectify(item) for item in data]
+        if isinstance(data, bool):  # Reddit.username_available
+            return data
         if "json" in data and "errors" in data["json"]:
             errors = data["json"]["errors"]
             if len(errors) > 0:

--- a/praw/reddit.py
+++ b/praw/reddit.py
@@ -887,3 +887,17 @@ class Reddit:
 
         """
         return models.Submission(self, id=id, url=url)
+
+    def username_available(self, name: str) -> bool:
+        """Check to see if the username is available.
+
+        For example, to check if the username ``bboe`` is availible, try:
+
+        .. code-block:: python
+
+            reddit.redditor("bboe").available()
+
+        """
+        return self._objectify_request(
+            path=API_PATH["username_available"], params={"user": name}, method="GET"
+        )

--- a/tests/integration/cassettes/TestReddit.test_username_available__available.json
+++ b/tests/integration/cassettes/TestReddit.test_username_available__available.json
@@ -1,0 +1,218 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2021-06-05T21:46:57",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=client_credentials"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "29"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/7.2.1.dev0 prawcore/2.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "109"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sat, 05 Jun 2021 21:46:57 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "edgebucket=WqRuCIRCynj2; Domain=reddit.com; Max-Age=63071999; Path=/;  secure"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Clacks-Overhead": [
+            "GNU Terry Pratchett"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299"
+          ],
+          "x-ratelimit-reset": [
+            "183"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-reddit-loid": [
+            "0000000000cjtffrxa.2.1622929617237.Z0FBQUFBQmd1X0RSNFB3MnUxTEpxMDRKSHZzVHljbVNgZkRKd1dvTjFONGxQVkZKUXcmdHRHWUNxNk9pRkdXeXktMzN6SXA0eWRfMXp0dS1hZzJ1MGVUbnRXc3F3YmtqUjJBSTA4RVB0VUtMRltzYV9hTUhXM2VLV1uxNjNwUTBsUDVORy14VkxCa1M"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2021-06-05T21:46:57",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "edgebucket=WqRuCIRCynj2"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/7.2.1.dev0 prawcore/2.0.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/api/username_available?user=<AVAILABLE_NAME>&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "true"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "4"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sat, 05 Jun 2021 21:46:57 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+           "loid=0000000000cjtffrxa.2.1622929617237.Z0FBQUmBQmd1X0RSX2hYdGFBcmN2T1NfMVJybzFkeE5Yb0szaGdtOTNMS3JkNER6ZVgxdzU2VW1xU3dzMkI3LWpYc2t6MDZWUkhVaThEcHpJSGNjRWNONWtBdDIzdGotampUdy1LTWlKRUJmYjNWQ3ZhUzFzM3dHeHJKWUtMLVExRzMwa2FHTTVpcms; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Mon, 05-Jun-2023 21:46:57 GMT; secure; SameSite=None; Secure",
+            "session_tracker=zq8vchmApmUERmLnla.0.1622929617434.Z0FBQUFBQmd1X0RSR1lPdW1JUFFnYXw0SXl6Nk15cm1ncEFKQzAwaThpMi1KN0REUVNMOUNGaHFhWThQMDhfMXVpX29yZVpsa2xvWkdHTjNCN0RqN1Q4U3Q4dUd0dlVZcUVNT3g1ZsVvWjUxdWMzM2pIcjkY5ME9YrF9EOXZRVGV1b0RfMkh6Y3d2bzY; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 05-Jun-2021 23:46:57 GMT; secure; SameSite=None; Secure",
+            "csv=1; Max-Age=63072000; Domain=.reddit.com; Path=/; Secure; SameSite=None"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Clacks-Overhead": [
+            "GNU Terry Pratchett"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "access-control-allow-origin": [
+            "*"
+          ],
+          "access-control-expose-headers": [
+            "X-Moose"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299"
+          ],
+          "x-ratelimit-reset": [
+            "183"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/username_available?user=<AVAILABLE_NAME>&raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/integration/cassettes/TestReddit.test_username_available__unavailable.json
+++ b/tests/integration/cassettes/TestReddit.test_username_available__unavailable.json
@@ -1,0 +1,218 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2021-06-05T21:19:30",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=client_credentials"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "29"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/7.2.1.dev0 prawcore/2.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "109"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sat, 05 Jun 2021 21:19:30 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "edgebucket=nec0gBhGi0CDhw54Oo; Domain=reddit.com; Max-Age=63071999; Path=/;  secure"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Clacks-Overhead": [
+            "GNU Terry Pratchett"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299"
+          ],
+          "x-ratelimit-reset": [
+            "30"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-reddit-loid": [
+            "0000000000cjswxacy.2.1622927970961.Z0FBQUFBQmd1LXBpSEF5X1JqMFhobjdCT1JhbjNMSy1GT2N2bGFvOW1yboliOW9BbkV3V3BFMjNLWnRFQURLZtJzcC1KUlkwcDVjcVVhNkJOQ0psQkwwWGlyNTJvZTdjRjd0QTBrNG9yX2duVnkwb1hJNDFUT2h5Z0ZwXzl2WngtaFVtMm5GaU9JZnE"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2021-06-05T21:19:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "edgebucket=nec0gBhGi0CDhw54Oo"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/7.2.1.dev0 prawcore/2.0.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/api/username_available?user=bboe&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "false"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "5"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sat, 05 Jun 2021 21:19:31 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "loid=0000000000cjswxacy.2.1622927970961.Z0FBQUFBQmd1LXBqR1BwVlpoOFYscGlYcmRQWnR1NVF4TWMzSldEaVJJZWlZemVvSjlOUsVQc2tWSDhrRDEtZWRXQkZ5YjR6b2NEczhscUlBWS1TbjlXV1Znd04zV2RCT3VZMElfVkNLN2F2oWxkZFRFU0MpSGgzX1dTdmo2WUI4ZGxzWEVabWZKU0M; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Mon, 05-Jun-2023 21:19:31 GMT; secure; SameSite=None; Secure",
+            "session_tracker=edpajfgjrklffpdgmh.0.1622927971126.Z0FBQUFBQmd1LXBqY2J2XzgwYTVGMkd0MlE1eUNZS0NjenQ2UHZxbG1Fa3piUXVkU1Z5d1V6WUY5cUE4WTRNcGV1aXZKU0lUMGRER0RfWkIxdDM5cDBhbUhVQVdXSTZkTk1kZy00WTJYMG53cVBsMUg3SUUxb3JzSExySHRscGdvc0Q1UDRqekZlcGk; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 05-Jun-2021 23:19:31 GMT; secure; SameSite=None; Secure",
+            "csv=1; Max-Age=63072000; Domain=.reddit.com; Path=/; Secure; SameSite=None"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Clacks-Overhead": [
+            "GNU Terry Pratchett"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "access-control-allow-origin": [
+            "*"
+          ],
+          "access-control-expose-headers": [
+            "X-Moose"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299"
+          ],
+          "x-ratelimit-reset": [
+            "29"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/username_available?user=bboe&raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/integration/cassettes/TestReddit.test_username_available_exception.json
+++ b/tests/integration/cassettes/TestReddit.test_username_available_exception.json
@@ -1,0 +1,218 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2021-06-05T21:19:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=client_credentials"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "29"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/7.2.1.dev0 prawcore/2.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "109"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sat, 05 Jun 2021 21:19:31 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "edgebucket=yn9DLgeQ6w9gaBMp7j; Domain=reddit.com; Max-Age=63071999; Path=/;  secure"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Clacks-Overhead": [
+            "GNU Terry Pratchett"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "298"
+          ],
+          "x-ratelimit-reset": [
+            "29"
+          ],
+          "x-ratelimit-used": [
+            "2"
+          ],
+          "x-reddit-loid": [
+            "0000000000cjswx8cz.2.1622927971589.Z0FBQUFBQmd1LXBqN0RjZThnZWFUYWNIcGdmQmo4alI2eUpvVmkwWWhWMkd3eXVDNnd0d3RScnkyVUdUd0pUMjQyTktXRFJkQndaRlhhzml0RVFodUtZZDlBNkdVVFM3RWNXS0dJYUo3YVluQWo5aG5SWHc5OUtGTmdDWEFBOURvbnFuYzBOR3UyUDY"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2021-06-05T21:19:31",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "edgebucket=yn9DLgeQ6w9gaBMp7j"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/7.2.1.dev0 prawcore/2.0.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/api/username_available?user=a&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"json\": {\"errors\": [[\"BAD_USERNAME\", \"invalid user name\", \"user\"]]}}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "69"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Sat, 05 Jun 2021 21:19:31 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "loid=0000000000cjswx8c5.2.1622927971589.Z0FBQUFBQmd1LXBqZ1FyeEp6NjgwTF9ZWHhnUW5tczJjV0xpMVpqZHYxVDJaT3pIOWJMNjVQMmRdQ2dPTmlhMTM5LVZYYjZtepdwOF9vMWNvaGtQkE9TcTFVWGptN19xTkFKNld3T1VUVjJOclFuTDFPenRvaWRxTEJzZTJVQnRfSXRkeTVpRWhfY3A; Domain=reddit.com; Max-Age=63071999; Path=/; expires=Mon, 05-Jun-2023 21:19:31 GMT; secure; SameSite=None; Secure",
+            "session_tracker=qhiapjmgmjaqgodqdk.0.1622927971721.Z0FBQUFBQmd1LXBqcnA2aW03YjlVcHZHeUtVV2jvRzJLaXZmSFZQRFdhb0l1MWxnQk5CcGv3akg2X3ZETk9ma1poUEQeUjR4dmlmODA2SmIwNG9hVktWTXpoWTQzWThPV3ZzWWVuRno4UFRRN1FmTGYzUzNmTVJ0WFd2WUdtY05EUTA4aVk3X1VxZW4; Domain=reddit.com; Max-Age=7199; Path=/; expires=Sat, 05-Jun-2021 23:19:31 GMT; secure; SameSite=None; Secure",
+            "csv=1; Max-Age=63072000; Domain=.reddit.com; Path=/; Secure; SameSite=None"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Clacks-Overhead": [
+            "GNU Terry Pratchett"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "access-control-allow-origin": [
+            "*"
+          ],
+          "access-control-expose-headers": [
+            "X-Moose"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299"
+          ],
+          "x-ratelimit-reset": [
+            "29"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/username_available?user=a&raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/integration/test_reddit.py
+++ b/tests/integration/test_reddit.py
@@ -186,6 +186,26 @@ class TestReddit(IntegrationTest):
         with self.use_cassette():
             assert self.reddit.subreddit("random").display_name != "random"
 
+    def test_username_available__available(self):
+        fake_user = "prawtestuserabcd1234"
+        with self.use_cassette(
+            placeholders=self.recorder.configure().default_cassette_options[
+                "placeholders"
+            ]
+            + [{"placeholder": "<AVAILABLE_NAME>", "replace": fake_user}]
+        ):
+            assert self.reddit.username_available(fake_user)
+
+    def test_username_available__unavailable(self):
+        with self.use_cassette():
+            assert not self.reddit.username_available("bboe")
+
+    def test_username_available_exception(self):
+        with self.use_cassette():
+            with pytest.raises(RedditAPIException) as exc:
+                self.reddit.username_available("a")
+            assert str(exc.value) == "BAD_USERNAME: 'invalid user name' on field 'user'"
+
 
 class TestDomainListing(IntegrationTest):
     def test_controversial(self):


### PR DESCRIPTION
## Feature Summary and Justification

Adds the /api/username_available endpoint and method Redditor.available.

The username_available endpoint was removed in commit 7a72c1e because [at the time](https://web.archive.org/web/20161108093457/https://www.reddit.com/dev/api#GET_api_username_available) it was a non-oauth endpoint. It is [now](https://www.reddit.com/dev/api#GET_api_username_available) an oauth endpoint, so it can be re-added. This endpoint can return bools, so objector.py needed a small tweak.

## References

* https://web.archive.org/web/20161108093457/https://www.reddit.com/dev/api#GET_api_username_available
* https://www.reddit.com/dev/api#GET_api_username_available