### PR TITLE
Fix bug in FullnameMixin.fullname

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -24,6 +24,7 @@ Unreleased
   when the JSON data contained only the keys "reason" and "message".
 - Fixed bug where :meth:`.Reddit.request` could not handle instances of ``BadRequest``\s
   when the response did not contain valid JSON data.
+- Fixed bug where :meth:`.FullnameMixin.fullname` sometimes returned the wrong fullname.
 
 **Deprecated**
 

--- a/docs/code_overview/other.rst
+++ b/docs/code_overview/other.rst
@@ -38,6 +38,7 @@ them bound to an attribute of one of the PRAW models.
     :caption: Moderation Helpers
 
     other/commentmoderation
+    other/fullnamemixin
     other/submissionmoderation
     other/rulemoderation
     other/subredditmoderation

--- a/docs/code_overview/other/fullnamemixin.rst
+++ b/docs/code_overview/other/fullnamemixin.rst
@@ -1,0 +1,5 @@
+ThingModerationMixin
+====================
+
+.. autoclass:: praw.models.reddit.mixins.FullnameMixin
+    :inherited-members:

--- a/praw/models/reddit/mixins/fullname.py
+++ b/praw/models/reddit/mixins/fullname.py
@@ -14,4 +14,6 @@ class FullnameMixin:
         the object's base36 ID, e.g., ``t1_c5s96e0``.
 
         """
+        if "_" in self.id:
+            return self.id
         return f"{self._kind}_{self.id}"

--- a/tests/integration/cassettes/TestUser.test_blocked_fullname.json
+++ b/tests/integration/cassettes/TestUser.test_blocked_fullname.json
@@ -1,0 +1,212 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2021-06-03T22:04:25",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "152"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/7.2.1.dev0 prawcore/2.0.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "117"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 03 Jun 2021 22:04:26 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "edgebucket=xv9G43FoT8byxpcnXO; Domain=reddit.com; Max-Age=63071999; Path=/;  secure"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Clacks-Overhead": [
+            "GNU Terry Pratchett"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299"
+          ],
+          "x-ratelimit-reset": [
+            "334"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2021-06-03T22:04:25",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "edgebucket=xv9G43FoT8byxpcnXO"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/7.2.1.dev0 prawcore/2.0.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/prefs/blocked/?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"UserList\", \"data\": {\"children\": [{\"date\": 1622757760.0, \"rel_id\": \"r9_2mb7wa\", \"name\": \"PyAPITestUser3\", \"id\": \"t2_6c1xj\"}]}}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "135"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Thu, 03 Jun 2021 22:04:27 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "session_tracker=cjEkqZRBNI4rGvqvgO.0.1622757867083.Z0FBQUFBQmd1VkhySm5lUGlmRFVJckpsUGM1N3VKaTF6ay1HYlkBQ0g4a1B5WUhWamVtdGV4V25IM0QxNkVHQjaSdTdtNmRNY21OSnpzSExsR3RPS3lWZHVvVVQxb3gyNlExVTJVSlltS2U0SG9LX3poc0R3QlZUS1dtZmIwUkJktnNBeHVMMWh3N3c; Domain=reddit.com; Max-Age=7199; Path=/; expires=Fri, 04-Jun-2021 00:04:27 GMT; secure; SameSite=None; Secure",
+            "redesign_optout=true; Domain=reddit.com; Max-Age=94607999; Path=/; expires=Sun, 02-Jun-2024 22:04:27 GMT; secure",
+            "csv=1; Max-Age=63072000; Domain=.reddit.com; Path=/; Secure; SameSite=None"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Clacks-Overhead": [
+            "GNU Terry Pratchett"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, no-store, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "595.0"
+          ],
+          "x-ratelimit-reset": [
+            "333"
+          ],
+          "x-ratelimit-used": [
+            "5"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/prefs/blocked/?raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/integration/models/test_user.py
+++ b/tests/integration/models/test_user.py
@@ -17,6 +17,13 @@ class TestUser(IntegrationTest):
         assert len(blocked) > 0
         assert all(isinstance(user, Redditor) for user in blocked)
 
+    def test_blocked_fullname(self):
+        self.reddit.read_only = False
+        with self.use_cassette():
+            blocked = next(iter(self.reddit.user.blocked()))
+            assert blocked.fullname.startswith("t2_")
+            assert not blocked.fullname.startswith("t2_t2")
+
     def test_contributor_subreddits(self):
         self.reddit.read_only = False
         with self.use_cassette():


### PR DESCRIPTION
## Feature Summary and Justification

Unfortunately, Reddit is inconsistent about the difference between an id and a fullname. The API sometimes returns fields marked "id" that are actually fullnames. For example, if you have no blocked users, executing 

    reddit=praw.Reddit()
    reddit.redditor("PyAPITestUser3").block()
    blocked = next(iter(reddit.user.blocked()))
    blocked.fullname

produces ``t2_t2_6c1xj``, because Reddit's response to reddit.user.blocked() is 

    {'kind': 'UserList', 'data': {'children': [{'date': 1622757760.0, 'rel_id': 'r9_2mb7wa', 'name': 'PyAPITestUser3', 'id': 't2_6c1xj'}]}}

This PR changes FullnameMixin.fullname so that it checks for underscores in ids. 

Docs were modified so that the method could be referenced in CHANGES.rst.

Possibly related to [this.](https://github.com/praw-dev/praw/issues/1437#issuecomment-639138366)

## References

* https://github.com/praw-dev/praw/issues/1437#issuecomment-639138366
