### PR TITLE
Add warning about concurrent use of CommentForest.replace_more

### DIFF
--- a/praw/models/comment_forest.py
+++ b/praw/models/comment_forest.py
@@ -124,6 +124,8 @@ class CommentForest:
 
         :returns: A list of :class:`.MoreComments` instances that were not replaced.
 
+        :raises: ``prawcore.TooManyRequests`` when used concurrently.
+
         For example, to replace up to 32 :class:`.MoreComments` instances of a
         submission try:
 
@@ -144,9 +146,8 @@ class CommentForest:
         .. note::
 
             This method can take a long time as each replacement will discover at most
-            20 new :class:`.Comment` or :class:`.MoreComments` instances. As a result,
-            consider looping and handling exceptions until the method returns
-            successfully. For example:
+            100 new :class:`.Comment` instances. As a result, consider looping and
+            handling exceptions until the method returns successfully. For example:
 
             .. code-block:: python
 


### PR DESCRIPTION
Fixes #1716 

## Feature Summary and Justification

I added a warning about making concurrent requests to the morechildren endpoint. Now that https://github.com/praw-dev/prawcore/pull/112 has been merged, the documentation can mention the new TooManyRequests exception that can be triggered when this happens.

I also updated the documentation about the maximum number of comments returned in each request. The number is now 100, and that number refers to the number of *comments* returned, not comments and morechildren instances (and not the maximum number of comments you can include in a request). In the test I ran, the number of comments returned was indeed capped at 100. but the total of comments + more instances returned in each request reached as high as 140.

## References

* https://github.com/praw-dev/prawcore/pull/112
* https://www.reddit.com/dev/api#GET_api_morechildren
