### PR TITLE
Restore User.moderator_subreddits

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ Unreleased
 - :meth:`.Inbox.mark_all_read` to mark all messages as read with one API call.
 - :meth:`~.InboxableMixin.unblock_subreddit` to unblock a subreddit.
 - :meth:`.update_crowd_control_level` to update the crowd control level of a post.
+- :meth:`.moderator_subreddits`, which returns information about the subreddits that the
+  authenticated user moderates, has been restored.
 
 7.3.0 (2021/06/17)
 ------------------

--- a/praw/models/reddit/redditor.py
+++ b/praw/models/reddit/redditor.py
@@ -280,6 +280,8 @@ class Redditor(MessageableMixin, RedditorListingMixin, FullnameMixin, RedditBase
         :returns: A ``list`` of :class:`~.Subreddit` objects. Return ``[]`` if the
             redditor has no moderated subreddits.
 
+        :raises: ``prawcore.ServerError`` in certain cicumstances. See the note below.
+
         .. note::
 
             The redditor's own user profile subreddit will not be returned, but other
@@ -292,6 +294,29 @@ class Redditor(MessageableMixin, RedditorListingMixin, FullnameMixin, RedditBase
             for subreddit in reddit.redditor("spez").moderated():
                 print(subreddit.display_name)
                 print(subreddit.title)
+
+        .. note::
+
+            A ``prawcore.ServerError`` exception may be raised if the redditor moderates
+            a large number of subreddits. If that happens, try switching to
+            :ref:`read-only mode <read_only_application>`. For example,
+
+            .. code-block:: python
+
+                reddit.read_only = True
+                for subreddit in reddit.redditor("reddit").moderated():
+                    print(str(subreddit))
+
+            It is possible that requests made in read-only mode will also raise a
+            ``prawcore.ServerError`` exception.
+
+            When used in read-only mode, this method does not retrieve information about
+            subreddits that require certain special permissions to access, e.g., private
+            subreddits and premium-only subreddits.
+
+        .. seealso::
+
+            :meth:`.User.moderator_subreddits`
 
         """
         return self._reddit.get(API_PATH["moderated"].format(user=self)) or []

--- a/praw/models/user.py
+++ b/praw/models/user.py
@@ -65,10 +65,17 @@ class User(PRAWBase):
     ) -> Iterator["praw.models.Subreddit"]:
         """Return a :class:`.ListingGenerator` of contributor subreddits.
 
-        These are subreddits that the user is a contributor of.
+        These are subreddits in which the user is an approved user.
 
         Additional keyword arguments are passed in the initialization of
         :class:`.ListingGenerator`.
+
+        To print a list of the subreddits that you are an approved user in, try:
+
+        .. code-block:: python
+
+            for subreddit in reddit.user.contributor_subreddits(limit=None):
+                print(str(subreddit))
 
         """
         return ListingGenerator(
@@ -191,6 +198,13 @@ class User(PRAWBase):
 
         Additional keyword arguments are passed in the initialization of
         :class:`.ListingGenerator`.
+
+        To print a list of the subreddits that you are subscribed to, try:
+
+        .. code-block:: python
+
+            for subreddit in reddit.user.subreddits(limit=None):
+                print(str(subreddit))
 
         """
         return ListingGenerator(

--- a/praw/models/user.py
+++ b/praw/models/user.py
@@ -156,6 +156,30 @@ class User(PRAWBase):
             self._me = Redditor(self._reddit, _data=user_data)
         return self._me
 
+    def moderator_subreddits(
+        self, **generator_kwargs: Union[str, int, Dict[str, str]]
+    ) -> Iterator["praw.models.Subreddit"]:
+        """Return a :class:`.ListingGenerator` subreddits that the user moderates.
+
+        Additional keyword arguments are passed in the initialization of
+        :class:`.ListingGenerator`.
+
+        To print a list of the names of the subreddits you moderate, try:
+
+        .. code-block:: python
+
+            for subreddit in reddit.user.moderator_subreddits(limit=None):
+                print(str(subreddit))
+
+        .. seealso::
+
+            :meth:`.Redditor.moderated`
+
+        """
+        return ListingGenerator(
+            self._reddit, API_PATH["my_moderator"], **generator_kwargs
+        )
+
     def multireddits(self) -> List["praw.models.Multireddit"]:
         """Return a list of multireddits belonging to the user."""
         return self._reddit.get(API_PATH["my_multireddits"])

--- a/tests/integration/cassettes/TestUser.test_moderator_subreddits.json
+++ b/tests/integration/cassettes/TestUser.test_moderator_subreddits.json
@@ -1,0 +1,214 @@
+{
+  "http_interactions": [
+    {
+      "recorded_at": "2021-07-14T07:47:34",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": "grant_type=password&password=<PASSWORD>&username=<USERNAME>"
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "152"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/7.3.1.dev0 prawcore/2.2.0"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "close"
+          ],
+          "Content-Length": [
+            "121"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 14 Jul 2021 07:47:35 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "edgebucket=iOZVqzcxgFvwiPreMf; Domain=reddit.com; Max-Age=63071999; Path=/;  secure"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Clacks-Overhead": [
+            "GNU Terry Pratchett"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "max-age=0, must-revalidate"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "299"
+          ],
+          "x-ratelimit-reset": [
+            "145"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2021-07-14T07:47:34",
+      "request": {
+        "body": {
+          "encoding": "utf-8",
+          "string": ""
+        },
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Cookie": [
+            "edgebucket=iOZVqzcxgFvwiPreMf"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/7.3.1.dev0 prawcore/2.2.0"
+          ]
+        },
+        "method": "GET",
+        "uri": "https://oauth.reddit.com/subreddits/mine/moderator/?limit=1024&raw_json=1"
+      },
+      "response": {
+        "body": {
+          "encoding": "UTF-8",
+          "string": "{\"kind\": \"Listing\", \"data\": {\"after\": null, \"dist\": 2, \"modhash\": null, \"geo_filter\": \"\", \"children\": [{\"kind\": \"t5\", \"data\": {\"user_flair_background_color\": null, \"submit_text_html\": null, \"restrict_posting\": true, \"user_is_banned\": false, \"free_form_reports\": true, \"wiki_enabled\": true, \"user_is_muted\": false, \"user_can_flair_in_sr\": null, \"display_name\": \"<TEST_SUBREDDIT>\", \"header_img\": null, \"title\": \"<TEST_SUBREDDIT>\", \"allow_galleries\": true, \"icon_size\": null, \"primary_color\": \"\", \"active_user_count\": null, \"icon_img\": \"\", \"display_name_prefixed\": \"r/<TEST_SUBREDDIT>\", \"accounts_active\": null, \"public_traffic\": false, \"subscribers\": 3, \"user_flair_richtext\": [], \"name\": \"t5_1111\", \"quarantine\": false, \"hide_ads\": false, \"prediction_leaderboard_entry_type\": \"IN_FEED\", \"emojis_enabled\": true, \"advertiser_category\": \"\", \"public_description\": \"\", \"comment_score_hide_mins\": 0, \"allow_predictions\": false, \"user_has_favorited\": false, \"user_flair_template_id\": null, \"community_icon\": \"\", \"banner_background_image\": \"\", \"original_content_tag_enabled\": false, \"community_reviewed\": false, \"submit_text\": \"\", \"description_html\": null, \"spoilers_enabled\": true, \"header_title\": \"\", \"header_size\": null, \"user_flair_position\": \"right\", \"all_original_content\": false, \"has_menu_widget\": false, \"is_enrolled_in_new_modmail\": true, \"key_color\": \"\", \"event_posts_enabled\": true, \"can_assign_user_flair\": false, \"created\": 1600000000.0, \"wls\": null, \"mod_permissions\": [], \"show_media_preview\": true, \"submission_type\": \"any\", \"user_is_subscriber\": true, \"disable_contributor_requests\": true, \"allow_videogifs\": true, \"user_flair_type\": \"text\", \"allow_polls\": false, \"collapse_deleted_comments\": false, \"emojis_custom_size\": null, \"public_description_html\": null, \"allow_videos\": false, \"is_crosspostable_subreddit\": true, \"notification_level\": null, \"can_assign_link_flair\": false, \"accounts_active_is_fuzzed\": false, \"submit_text_label\": \"\", \"link_flair_position\": \"\", \"user_sr_flair_enabled\": null, \"user_flair_enabled_in_sr\": false, \"allow_chat_post_creation\": true, \"allow_discovery\": false, \"user_sr_theme_enabled\": true, \"link_flair_enabled\": false, \"subreddit_type\": \"public\", \"suggested_comment_sort\": null, \"banner_img\": \"\", \"user_flair_text\": null, \"banner_background_color\": \"\", \"show_media\": true, \"id\": \"1111\", \"user_is_moderator\": true, \"over18\": false, \"description\": \"\", \"is_chat_post_feature_enabled\": true, \"submit_link_label\": \"\", \"user_flair_text_color\": null, \"restrict_commenting\": false, \"user_flair_css_class\": null, \"allow_images\": true, \"lang\": \"en\", \"whitelist_status\": null, \"url\": \"/r/<TEST_SUBREDDIT>/\", \"created_utc\": 1600000000.0, \"banner_size\": null, \"mobile_banner_image\": \"\", \"user_is_contributor\": false, \"allow_predictions_tournament\": false}}, {\"kind\": \"t5\", \"data\": {\"user_flair_background_color\": null, \"submit_text_html\": null, \"restrict_posting\": true, \"user_flair_enabled_in_sr\": false, \"user_is_banned\": false, \"free_form_reports\": true, \"wiki_enabled\": true, \"user_is_muted\": false, \"user_can_flair_in_sr\": null, \"display_name\": \"u_<USERNAME>\", \"header_img\": null, \"title\": \"\", \"allow_galleries\": true, \"icon_size\": [256, 256], \"primary_color\": \"\", \"active_user_count\": null, \"icon_img\": \"https://www.redditstatic.com/avatars/avatar_default_11_FF4500.png\", \"display_name_prefixed\": \"u/<USERNAME>\", \"accounts_active\": null, \"public_traffic\": false, \"subscribers\": 2, \"user_flair_richtext\": [], \"videostream_links_count\": 0, \"name\": \"t5_1112\", \"quarantine\": false, \"hide_ads\": false, \"prediction_leaderboard_entry_type\": \"IN_FEED\", \"emojis_enabled\": false, \"advertiser_category\": \"\", \"public_description\": \"\", \"comment_score_hide_mins\": 0, \"allow_predictions\": false, \"user_has_favorited\": false, \"user_flair_template_id\": null, \"community_icon\": \"\", \"banner_background_image\": \"\", \"original_content_tag_enabled\": false, \"community_reviewed\": false, \"submit_text\": \"\", \"description_html\": null, \"spoilers_enabled\": true, \"header_title\": \"\", \"header_size\": null, \"user_flair_position\": \"right\", \"is_default_icon\": [true], \"all_original_content\": false, \"collections_enabled\": true, \"is_enrolled_in_new_modmail\": true, \"key_color\": \"\", \"event_posts_enabled\": true, \"can_assign_user_flair\": false, \"created\": 1600000000.0, \"wls\": null, \"mod_permissions\": [\"all\"], \"show_media_preview\": true, \"submission_type\": \"any\", \"user_is_subscriber\": false, \"disable_contributor_requests\": false, \"allow_videogifs\": true, \"user_flair_type\": \"text\", \"allow_polls\": true, \"collapse_deleted_comments\": true, \"coins\": 0, \"emojis_custom_size\": null, \"public_description_html\": null, \"allow_videos\": true, \"is_crosspostable_subreddit\": true, \"notification_level\": null, \"can_assign_link_flair\": false, \"has_menu_widget\": false, \"accounts_active_is_fuzzed\": false, \"submit_text_label\": \"\", \"link_flair_position\": \"\", \"user_sr_flair_enabled\": null, \"is_default_banner\": true, \"allow_discovery\": true, \"user_sr_theme_enabled\": true, \"link_flair_enabled\": false, \"subreddit_type\": \"user\", \"suggested_comment_sort\": \"qa\", \"banner_img\": \"\", \"user_flair_text\": null, \"banner_background_color\": \"\", \"show_media\": true, \"id\": \"1112\", \"user_is_moderator\": true, \"over18\": false, \"description\": \"\", \"submit_link_label\": \"\", \"user_flair_text_color\": null, \"restrict_commenting\": false, \"user_flair_css_class\": null, \"allow_images\": true, \"lang\": \"en\", \"whitelist_status\": null, \"url\": \"/user/<USERNAME>/\", \"created_utc\": 1600000000.0, \"banner_size\": null, \"mobile_banner_image\": \"\", \"user_is_contributor\": false, \"allow_predictions_tournament\": false}}], \"before\": null}}"
+        },
+        "headers": {
+          "Accept-Ranges": [
+            "bytes"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "5579"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 14 Jul 2021 07:47:35 GMT"
+          ],
+          "Server": [
+            "snooserv"
+          ],
+          "Set-Cookie": [
+            "session_tracker=iczchyyganqajsdxrm.0.1626248855536.Z0FBQUFBQmc3pGFYYzA0bFpXcEcwYnpPS19BeTVEUlFqaUtvOWpjNnB1TFh4bVMxV2p2VGNENlN9eGZCcXdJSjZZLVJ5WE9kMElhR6ZTdzRoSWIxcU1OUEozpVBrX1B4YjNPNE9SarRXeDdTSzRqZlYwcXVmOXVOOExuNkdOZHdiOTZudUhIVmJnNUw; Domain=reddit.com; Max-Age=7199; Path=/; expires=Wed, 14-Jul-2021 09:47:35 GMT; secure; SameSite=None; Secure",
+            "csv=1; Max-Age=63072000; Domain=.reddit.com; Path=/; Secure; SameSite=None"
+          ],
+          "Strict-Transport-Security": [
+            "max-age=15552000; includeSubDomains; preload"
+          ],
+          "Vary": [
+            "accept-encoding"
+          ],
+          "Via": [
+            "1.1 varnish"
+          ],
+          "X-Clacks-Overhead": [
+            "GNU Terry Pratchett"
+          ],
+          "X-Moose": [
+            "majestic"
+          ],
+          "cache-control": [
+            "private, s-maxage=0, max-age=0, must-revalidate, no-store, max-age=0, must-revalidate"
+          ],
+          "expires": [
+            "-1"
+          ],
+          "x-content-type-options": [
+            "nosniff"
+          ],
+          "x-frame-options": [
+            "SAMEORIGIN"
+          ],
+          "x-ratelimit-remaining": [
+            "599.0"
+          ],
+          "x-ratelimit-reset": [
+            "145"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ],
+          "x-ua-compatible": [
+            "IE=edge"
+          ],
+          "x-xss-protection": [
+            "1; mode=block"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/subreddits/mine/moderator/?limit=1024&raw_json=1"
+      }
+    }
+  ],
+  "recorded_with": "betamax/0.8.1"
+}

--- a/tests/integration/models/test_user.py
+++ b/tests/integration/models/test_user.py
@@ -80,6 +80,14 @@ class TestUser(IntegrationTest):
             me.praw_is_cached = True
             assert not hasattr(self.reddit.user.me(use_cache=False), "praw_is_cached")
 
+    @mock.patch("time.sleep", return_value=None)
+    def test_moderator_subreddits(self, _):
+        self.reddit.read_only = False
+        with self.recorder.use_cassette("TestUser.test_moderator_subreddits"):
+            mod_subs = list(self.reddit.user.moderator_subreddits(limit=None))
+            assert mod_subs
+            assert all(isinstance(x, Subreddit) for x in mod_subs)
+
     def test_multireddits(self):
         self.reddit.read_only = False
         with self.use_cassette():


### PR DESCRIPTION
Unfixes 1333

## Feature Summary and Justification

Issue 1142 reported that `User.moderator_subreddits` would not return more than 100 subreddits, and this information was added to the documentation in 1145. The method was deprecated in 1148, with a note to use `Redditor.moderated` instead, and was removed in 1333.

I suspect that the report of the alleged limitation of `User.moderator_subreddits` was not correct, and may have just been the result of a misunderstanding of how `ListingGenerator` works. I tested the sister method of `User.moderator_subreddits`, `User.subreddits`, and found that it also returns only 100 subreddits if you call `list(reddit.user.subreddits())`. But that happens because `ListingGenerator`s default value for `limit` is 100. If you call `list(reddit.user.subreddits(limit=None))`, the ListingGenerator does yield all of the subreddits that you are subscribed to, by retrieving batches of 100 subreddits at a time. From what I can find on Github, it's not clear if anyone tested what happens when you call `moderator_subreddits` with limit set to `None` before the method was removed. The [subreddits/mine/where](https://www.reddit.com/dev/api#GET_subreddits_mine_{where}) endpoints are documented under the same heading, so it's reasonable to think that they would all share the same limitations. I don't see anything in the [initial commit](https://github.com/reddit-archive/reddit/commit/8c4732418dbe09e06f3fb0f7c911fd16386d7944) or the [last released version](https://github.com/reddit-archive/reddit/blob/master/r2/r2/controllers/listingcontroller.py#L1607-L1613) that suggests any kind of endpoint-specific limit.

Even if there were a limit of 100 subreddits returned, `moderated` is not an adequate replacement for `moderator_subreddits` for the vast majority of users. `Moderator_subreddits` loads the data that you would get by calling `Reddit.info` with `sr_names` set to the names of the subs you moderate, and `moderator` returns a much smaller amount of data. You would need to make additional calls to `info`, or filter calls to `contributor_subreddits` to get the same information, which is not very convenient. `Moderator_subreddits` also has the advantage of returning the user subreddit, which is not something that `moderated` does.

`Moderator_subreddits`, which returns a listing, may actually be more robust than moderated, which returns a `ModeratedList`. In certain circumstances, calls to `moderated` may fail altogether, because all of the subreddits are returned at once. For example, request_bot moderates almost 20,000 subreddits. When I tried to use `moderated` with a user-mode token, I got 5xx errors. With a userless token, I was served 12MB and 1MB responses when I set "accept-encoding" to identity and gzip/deflate respectively. There may be a cap to the number of subreddits returned by subreddits/mine/moderator, but since it returns batches of up to 100 results at a time, you should at least be able to retrieve the top n subreddits before a hypothetical cutoff.

## References

* https://www.reddit.com/dev/api#GET_subreddits_mine_{where}
* https://github.com/reddit-archive/reddit/blob/master/r2/r2/controllers/listingcontroller.py#L1607-L1613
