### PR TITLE
Replace relative imports with absolute when TYPE_CHECKING to fix mypy

### DIFF
--- a/praw/models/base.py
+++ b/praw/models/base.py
@@ -3,7 +3,7 @@ from copy import deepcopy
 from typing import TYPE_CHECKING, Any, Dict, Optional
 
 if TYPE_CHECKING:  # pragma: no cover
-    from ... import praw
+    import praw
 
 
 class PRAWBase:

--- a/praw/models/comment_forest.py
+++ b/praw/models/comment_forest.py
@@ -6,7 +6,7 @@ from ..exceptions import DuplicateReplaceException
 from .reddit.more import MoreComments
 
 if TYPE_CHECKING:  # pragma: no cover
-    from ... import praw
+    import praw
 
 
 class CommentForest:

--- a/praw/models/front.py
+++ b/praw/models/front.py
@@ -6,7 +6,7 @@ from .listing.generator import ListingGenerator
 from .listing.mixins import SubredditListingMixin
 
 if TYPE_CHECKING:  # pragma: no cover
-    from ... import praw
+    import praw
 
 
 class Front(SubredditListingMixin):

--- a/praw/models/helpers.py
+++ b/praw/models/helpers.py
@@ -8,7 +8,7 @@ from .reddit.live import LiveThread
 from .reddit.multi import Multireddit, Subreddit
 
 if TYPE_CHECKING:  # pragma: no cover
-    from ... import praw
+    import praw
 
 
 class LiveHelper(PRAWBase):

--- a/praw/models/inbox.py
+++ b/praw/models/inbox.py
@@ -7,7 +7,7 @@ from .listing.generator import ListingGenerator
 from .util import stream_generator
 
 if TYPE_CHECKING:  # pragma: no cover
-    from ... import praw
+    import praw
 
 
 class Inbox(PRAWBase):

--- a/praw/models/list/base.py
+++ b/praw/models/list/base.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Dict, Iterator
 from ..base import PRAWBase
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .... import praw
+    import praw
 
 
 class BaseList(PRAWBase):

--- a/praw/models/listing/domain.py
+++ b/praw/models/listing/domain.py
@@ -5,7 +5,7 @@ from ...const import API_PATH
 from .mixins import BaseListingMixin, RisingListingMixin
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .... import praw
+    import praw
 
 
 class DomainListing(BaseListingMixin, RisingListingMixin):

--- a/praw/models/listing/generator.py
+++ b/praw/models/listing/generator.py
@@ -6,7 +6,7 @@ from ..base import PRAWBase
 from .listing import FlairListing
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .... import praw
+    import praw
 
 
 class ListingGenerator(PRAWBase, Iterator):

--- a/praw/models/listing/mixins/redditor.py
+++ b/praw/models/listing/mixins/redditor.py
@@ -8,7 +8,7 @@ from .base import BaseListingMixin
 from .gilded import GildedListingMixin
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .... import praw
+    import praw
 
 
 class SubListing(BaseListingMixin):

--- a/praw/models/listing/mixins/rising.py
+++ b/praw/models/listing/mixins/rising.py
@@ -6,7 +6,7 @@ from ...base import PRAWBase
 from ..generator import ListingGenerator
 
 if TYPE_CHECKING:  # pragma: no cover
-    from ..... import praw
+    import praw
 
 
 class RisingListingMixin(PRAWBase):

--- a/praw/models/listing/mixins/submission.py
+++ b/praw/models/listing/mixins/submission.py
@@ -6,7 +6,7 @@ from ...base import PRAWBase
 from ..generator import ListingGenerator
 
 if TYPE_CHECKING:  # pragma: no cover
-    from ..... import praw
+    import praw
 
 
 class SubmissionListingMixin(PRAWBase):

--- a/praw/models/listing/mixins/subreddit.py
+++ b/praw/models/listing/mixins/subreddit.py
@@ -10,7 +10,7 @@ from .gilded import GildedListingMixin
 from .rising import RisingListingMixin
 
 if TYPE_CHECKING:  # pragma: no cover
-    from ..... import praw
+    import praw
 
 
 class CommentHelper(PRAWBase):

--- a/praw/models/mod_action.py
+++ b/praw/models/mod_action.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Union
 from .base import PRAWBase
 
 if TYPE_CHECKING:  # pragma: no cover
-    from ... import praw
+    import praw
 
 
 class ModAction(PRAWBase):

--- a/praw/models/preferences.py
+++ b/praw/models/preferences.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Dict, Union
 from ..const import API_PATH
 
 if TYPE_CHECKING:  # pragma: no cover
-    from ... import praw
+    import praw
 
 
 class Preferences:

--- a/praw/models/reddit/base.py
+++ b/praw/models/reddit/base.py
@@ -6,7 +6,7 @@ from ...exceptions import InvalidURL
 from ..base import PRAWBase
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .... import praw
+    import praw
 
 
 class RedditBase(PRAWBase):

--- a/praw/models/reddit/collections.py
+++ b/praw/models/reddit/collections.py
@@ -10,7 +10,7 @@ from .submission import Submission
 from .subreddit import Subreddit
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .... import praw
+    import praw
 
 
 class CollectionModeration(PRAWBase):

--- a/praw/models/reddit/comment.py
+++ b/praw/models/reddit/comment.py
@@ -15,7 +15,7 @@ from .mixins import (
 from .redditor import Redditor
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .... import praw
+    import praw
 
 
 class Comment(InboxableMixin, UserContentMixin, FullnameMixin, RedditBase):

--- a/praw/models/reddit/emoji.py
+++ b/praw/models/reddit/emoji.py
@@ -7,7 +7,7 @@ from ...exceptions import ClientException
 from .base import RedditBase
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .... import praw
+    import praw
 
 
 class Emoji(RedditBase):

--- a/praw/models/reddit/live.py
+++ b/praw/models/reddit/live.py
@@ -11,7 +11,7 @@ from .mixins import FullnameMixin
 from .redditor import Redditor
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .... import praw
+    import praw
 
 
 class LiveContributorRelationship:

--- a/praw/models/reddit/message.py
+++ b/praw/models/reddit/message.py
@@ -8,7 +8,7 @@ from .redditor import Redditor
 from .subreddit import Subreddit
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .... import praw
+    import praw
 
 
 class Message(InboxableMixin, ReplyableMixin, FullnameMixin, RedditBase):

--- a/praw/models/reddit/mixins/messageable.py
+++ b/praw/models/reddit/mixins/messageable.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Optional, Union
 from ....const import API_PATH
 
 if TYPE_CHECKING:  # pragma: no cover
-    from ..... import praw
+    import praw
 
 
 class MessageableMixin:

--- a/praw/models/reddit/modmail.py
+++ b/praw/models/reddit/modmail.py
@@ -6,7 +6,7 @@ from ...util import snake_case_keys
 from .base import RedditBase
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .... import praw
+    import praw
 
 
 class ModmailConversation(RedditBase):

--- a/praw/models/reddit/more.py
+++ b/praw/models/reddit/more.py
@@ -5,7 +5,7 @@ from ...const import API_PATH
 from ..base import PRAWBase
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .... import praw
+    import praw
 
 
 class MoreComments(PRAWBase):

--- a/praw/models/reddit/multi.py
+++ b/praw/models/reddit/multi.py
@@ -11,7 +11,7 @@ from .redditor import Redditor
 from .subreddit import Subreddit, SubredditStream
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .... import praw
+    import praw
 
 
 class Multireddit(SubredditListingMixin, RedditBase):

--- a/praw/models/reddit/redditor.py
+++ b/praw/models/reddit/redditor.py
@@ -10,7 +10,7 @@ from .base import RedditBase
 from .mixins import FullnameMixin, MessageableMixin
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .... import praw
+    import praw
 
 
 class Redditor(MessageableMixin, RedditorListingMixin, FullnameMixin, RedditBase):

--- a/praw/models/reddit/removal_reasons.py
+++ b/praw/models/reddit/removal_reasons.py
@@ -8,7 +8,7 @@ from ...util.cache import cachedproperty
 from .base import RedditBase
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .... import praw
+    import praw
 
 
 class RemovalReason(RedditBase):

--- a/praw/models/reddit/rules.py
+++ b/praw/models/reddit/rules.py
@@ -9,7 +9,7 @@ from ...util.cache import cachedproperty
 from .base import RedditBase
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .... import praw
+    import praw
 
 
 class Rule(RedditBase):

--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -17,7 +17,7 @@ from .redditor import Redditor
 from .subreddit import Subreddit
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .... import praw
+    import praw
 
 
 class SubmissionFlair:

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -39,7 +39,7 @@ from .widgets import SubredditWidgets, WidgetEncoder
 from .wikipage import WikiPage
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .... import praw
+    import praw
 
 
 class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBase):

--- a/praw/models/reddit/user_subreddit.py
+++ b/praw/models/reddit/user_subreddit.py
@@ -7,7 +7,7 @@ from ...util.cache import cachedproperty
 from .subreddit import Subreddit, SubredditModeration
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .... import praw
+    import praw
 
 
 class UserSubreddit(Subreddit):

--- a/praw/models/reddit/wikipage.py
+++ b/praw/models/reddit/wikipage.py
@@ -8,7 +8,7 @@ from .base import RedditBase
 from .redditor import Redditor
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .... import praw
+    import praw
 
 
 class WikiPageModeration:

--- a/praw/models/redditors.py
+++ b/praw/models/redditors.py
@@ -11,7 +11,7 @@ from .listing.generator import ListingGenerator
 from .util import stream_generator
 
 if TYPE_CHECKING:  # pragma: no cover
-    from ... import praw
+    import praw
 
 
 class PartialRedditor(SimpleNamespace):

--- a/praw/models/subreddits.py
+++ b/praw/models/subreddits.py
@@ -9,7 +9,7 @@ from .listing.generator import ListingGenerator
 from .util import stream_generator
 
 if TYPE_CHECKING:  # pragma: no cover
-    from ... import praw
+    import praw
 
 
 class Subreddits(PRAWBase):

--- a/praw/models/trophy.py
+++ b/praw/models/trophy.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Dict, Union
 from .base import PRAWBase
 
 if TYPE_CHECKING:  # pragma: no cover
-    from ... import praw
+    import praw
 
 
 class Trophy(PRAWBase):

--- a/praw/models/user.py
+++ b/praw/models/user.py
@@ -12,7 +12,7 @@ from .reddit.redditor import Redditor
 from .reddit.subreddit import Subreddit
 
 if TYPE_CHECKING:  # pragma: no cover
-    from ... import praw
+    import praw
 
 
 class User(PRAWBase):

--- a/praw/objector.py
+++ b/praw/objector.py
@@ -8,7 +8,7 @@ from .models.reddit.base import RedditBase
 from .util import snake_case_keys
 
 if TYPE_CHECKING:  # pragma: no cover
-    from ... import praw
+    import praw
 
 
 class Objector:

--- a/praw/reddit.py
+++ b/praw/reddit.py
@@ -52,7 +52,7 @@ except ImportError:  # pragma: no cover
     UPDATE_CHECKER_MISSING = True
 
 if TYPE_CHECKING:  # pragma: no cover
-    from .. import praw
+    import praw
 
 Comment = models.Comment
 Redditor = models.Redditor


### PR DESCRIPTION
Fixes #1765 

## Feature Summary and Justification

### The problem

Fixes the ability to statically type check PRAW's code that was apparently broken by #1676 and never caught, since there is apparently no continuous type checking. In summary, 37 files contain `if TYPE_CHECKING` blocks with imports of `praw` that only are considered statically by the type checker, which are relative imports that traverse outside the package. This causes mypy, stubgen, etc. runs to fail with a critical error, as traversal outside a Python package is not valid for relative imports.

### The solution

Instead, the exact same intended effect (exposing the top level `praw` package as a valid name to the type checker) can be achieved by using a shorter absolute import (`import praw`), which has the added benefit of not breaking if the file is ever moved (as one apparently was). This has no effect at runtime or in any context but static type checking, given `TYPE_CHECKING` is always false otherwise and thus the blocks will not execute.

## Additional tests performed

In addition to the automated tests with this PR, I also tested this locally by multiple means:
* pre_push.py output no errors and made no modifications (static mode)
* Building the docs worked with no errors
* The docs were byte-by-byte identical before and after this PR, and displayed fine
* MyPy worked following this PR, not failing with a critical error nor reporting missing import errors related to this PR
* `pip install -e .` worked fine
* Running a full suite of tests with my PRAW-powered application was fully successful with this PR branch
* Running MyPy against my application with `py.typed` active in the root of the PRAW package worked with no errors or messages
* Uninstalling my release copy of praw from the active env and repeating all of the above confirmed everything was working and there were no issues with pulling in the installed version

## Future work

I was originally going to add a `py.typed` file in this PR per PEP 561 to enable type checking PRAW-using applications against the library, but I figure its best to leave that to a separate PR to keep this one's scope as narrow as possible. I also hope to clean up the remaining type errors in PRAW, add type hints to prawcore and (if desired) add type checking to the CIs and/or locally to catch errors and avoid future regressions like this one.