### PR TITLE
Bugfix/coveralls GitHub action updated

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,14 +92,13 @@ jobs:
         python -m pip install --upgrade pip
         pip install .[test]
         pip install .[ci]
-    - name: Test with pytest ${{ matrix.python-version }}
+    - name: Test with pytest
       run: coverage run --source praw --module pytest
-    - name: Coveralls Parallel
-      uses: coverallsapp/github-action@master
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
-        flag-name: run-${{ matrix.python-version }}
-        parallel: true
+    - env:
+        COVERALLS_PARALLEL: true
+        COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      name: Submit to coveralls
+      run: coveralls --service=github
     - name: Check coverage
       run: coverage report -m --fail-under=100
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,8 @@ jobs:
     needs: test-multi-python
     runs-on: ubuntu-latest
     steps:
-    - uses: coverallsapp/github-action@57daa114ba54fd8e1c8563e8027325c0bf2f5e80
+    - name: Coveralls Finished
+      uses: coverallsapp/github-action@master
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         parallel-finished: true
@@ -90,14 +91,15 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install .[test]
-        pip install https://github.com/bboe/coveralls-python/archive/github_actions.zip
-    - name: Test with pytest
+        pip install .[ci]
+    - name: Test with pytest ${{ matrix.python-version }}
       run: coverage run --source praw --module pytest
-    - env:
-        COVERALLS_PARALLEL: true
-        COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      name: Submit to coveralls
-      run: coveralls
+    - name: Coveralls Parallel
+      uses: coverallsapp/github-action@master
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        flag-name: run-${{ matrix.python-version }}
+        parallel: true
     - name: Check coverage
       run: coverage report -m --fail-under=100
     strategy:


### PR DESCRIPTION
The coverallsapp in GitHub actions was pinned to a particular commit from a year ago. It was done here https://github.com/praw-dev/praw/pull/1402 
This branch pins itself to the master branch of coverallsapp to avoid technical debt.

Also, for the `coveralls` command, it uses the https://coveralls-python.readthedocs.io/en
instead of https://github.com/bboe/coveralls-python/archive/github_actions.zip
But the coveralls-python seems to be maintained and up to date.
I am not too convinced about this. 


FYI: Ideally, we would not be using the coveralls command in section: `Submit to coveralls`. But because of this issue https://github.com/coverallsapp/github-action/issues/30 this seems to be the simpler choice
