### PR TITLE
Print warning when comment_sort is set after fetch

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,7 +8,7 @@ Unreleased
 
 **Added**
 
-- Log a warning if a submissions ``comment_sort`` attribute is updated after the
+- Log a warning if a submission's ``comment_sort`` attribute is updated after the
   submission has already been fetched and a ``warn_comment_sort`` config setting to turn
   off the warning.
 

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,12 @@ PRAW follows `semantic versioning <http://semver.org/>`_.
 Unreleased
 ----------
 
+**Added**
+
+- Log a warning if a submissions ``comment_sort`` attribute is updated after the
+  submission has already been fetched and a ``warn_comment_sort`` config setting to turn
+  off the warning.
+
 7.4.0 (2021/07/30)
 ------------------
 

--- a/docs/getting_started/configuration/options.rst
+++ b/docs/getting_started/configuration/options.rst
@@ -93,6 +93,8 @@ These are options that do not belong in another category, but still play a part 
 :timeout: Controls the amount of time PRAW will wait for a request from Reddit to
     complete before throwing an exception. By default, PRAW waits 16 seconds before
     throwing an exception.
+:warn_comment_sort: When ``true``, log a warning when the ``comment_sort`` attribute of
+    a submission is updated after _fetch() has been called. (default: ``true``)
 
 .. _custom_options:
 

--- a/praw/config.py
+++ b/praw/config.py
@@ -117,6 +117,9 @@ class Config:
         self.check_for_updates = self._config_boolean(
             self._fetch_or_not_set("check_for_updates")
         )
+        self.warn_comment_sort = self._config_boolean(
+            self._fetch_default("warn_comment_sort", True)
+        )
         self.kinds = {
             x: self._fetch(f"{x}_kind")
             for x in [

--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -1,7 +1,7 @@
 """Provide the Submission class."""
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 from urllib.parse import urljoin
-from logging import getLogger
+from warnings import warn
 
 from prawcore import Conflict
 
@@ -19,8 +19,6 @@ from .subreddit import Subreddit
 
 if TYPE_CHECKING:  # pragma: no cover
     import praw
-
-logger = getLogger("praw")
 
 
 class SubmissionFlair:
@@ -594,8 +592,13 @@ class Submission(SubmissionListingMixin, UserContentMixin, FullnameMixin, Reddit
             value = Subreddit(self._reddit, value)
         elif attribute == "poll_data":
             value = PollData(self._reddit, value)
-        elif attribute == "comment_sort" and self._fetched:
-            logger.warning(
+        elif (
+            self._reddit.config.warn_comment_sort
+            and attribute == "comment_sort"
+            and hasattr(self, "_fetched")
+            and self._fetched
+        ):
+            warn(
                 "The comments for this submission have already been fetched, "
                 "so the updated comment_sort will not have any effect"
             )

--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -1,6 +1,7 @@
 """Provide the Submission class."""
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 from urllib.parse import urljoin
+from logging import getLogger
 
 from prawcore import Conflict
 
@@ -18,6 +19,8 @@ from .subreddit import Subreddit
 
 if TYPE_CHECKING:  # pragma: no cover
     import praw
+
+logger = getLogger("praw")
 
 
 class SubmissionFlair:
@@ -591,6 +594,11 @@ class Submission(SubmissionListingMixin, UserContentMixin, FullnameMixin, Reddit
             value = Subreddit(self._reddit, value)
         elif attribute == "poll_data":
             value = PollData(self._reddit, value)
+        elif attribute == "comment_sort" and self._fetched:
+            logger.warning(
+                "The comments for this submission have already been fetched, "
+                "so the updated comment_sort will not have any effect"
+            )
         super().__setattr__(attribute, value)
 
     def _chunk(self, other_submissions, chunk_size):

--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -593,10 +593,11 @@ class Submission(SubmissionListingMixin, UserContentMixin, FullnameMixin, Reddit
         elif attribute == "poll_data":
             value = PollData(self._reddit, value)
         elif (
-            self._reddit.config.warn_comment_sort
-            and attribute == "comment_sort"
+            attribute == "comment_sort"
             and hasattr(self, "_fetched")
             and self._fetched
+            and hasattr(self, "_reddit")
+            and self._reddit.config.warn_comment_sort
         ):
             warn(
                 "The comments for this submission have already been fetched, "

--- a/tests/unit/models/reddit/test_submission.py
+++ b/tests/unit/models/reddit/test_submission.py
@@ -49,6 +49,26 @@ class TestSubmission(UnitTest):
         with pytest.raises(ValueError):
             Submission(self.reddit, url="")
 
+    @pytest.mark.filterwarnings("error", category=UserWarning)
+    def test_comment_sort_warning(self):
+        with pytest.raises(UserWarning) as excinfo:
+            submission = self.reddit.submission("1234")
+            submission._fetched = True
+            submission.comment_sort = "new"
+        assert (
+            excinfo.value.args[0]
+            == "The comments for this submission have already been fetched, "
+            "so the updated comment_sort will not have any effect"
+        )
+
+    @pytest.mark.filterwarnings("error", category=UserWarning)
+    def test_comment_sort_warning__disabled(self, caplog):
+        self.reddit.config.warn_comment_sort = False
+        submission = self.reddit.submission("1234")
+        submission._fetched = True
+        submission.comment_sort = "new"
+        assert caplog.records == []
+
     def test_construct_from_url(self):
         assert Submission(self.reddit, url="http://my.it/2gmzqe") == "2gmzqe"
 
@@ -114,23 +134,3 @@ class TestSubmission(UnitTest):
     def test_shortlink(self):
         submission = Submission(self.reddit, _data={"id": "dummy"})
         assert submission.shortlink == "https://redd.it/dummy"
-
-    @pytest.mark.filterwarnings("error", category=UserWarning)
-    def test_comment_sort_warning(self):
-        with pytest.raises(UserWarning) as excinfo:
-            submission = self.reddit.submission("1234")
-            submission._fetched = True
-            submission.comment_sort = "new"
-        assert (
-            excinfo.value.args[0]
-            == "The comments for this submission have already been fetched, "
-            "so the updated comment_sort will not have any effect"
-        )
-
-    @pytest.mark.filterwarnings("error", category=UserWarning)
-    def test_comment_sort_warning__disabled(self, caplog):
-        self.reddit.config.warn_comment_sort = False
-        submission = self.reddit.submission("1234")
-        submission._fetched = True
-        submission.comment_sort = "new"
-        assert caplog.records == []

--- a/tests/unit/models/reddit/test_submission.py
+++ b/tests/unit/models/reddit/test_submission.py
@@ -114,3 +114,23 @@ class TestSubmission(UnitTest):
     def test_shortlink(self):
         submission = Submission(self.reddit, _data={"id": "dummy"})
         assert submission.shortlink == "https://redd.it/dummy"
+
+    @pytest.mark.filterwarnings("error", category=UserWarning)
+    def test_comment_sort_warning(self):
+        with pytest.raises(UserWarning) as excinfo:
+            submission = self.reddit.submission("1234")
+            submission._fetched = True
+            submission.comment_sort = "new"
+        assert (
+            excinfo.value.args[0]
+            == "The comments for this submission have already been fetched, "
+            "so the updated comment_sort will not have any effect"
+        )
+
+    @pytest.mark.filterwarnings("error", category=UserWarning)
+    def test_comment_sort_warning__disabled(self, caplog):
+        self.reddit.config.warn_comment_sort = False
+        submission = self.reddit.submission("1234")
+        submission._fetched = True
+        submission.comment_sort = "new"
+        assert caplog.records == []


### PR DESCRIPTION
Print a warning if the `comment_sort` field is set on a submission after the fetch has already happened. Hopefully this will reduce issues with users wondering why they are changing the sort without any effect.

https://www.reddit.com/r/redditdev/comments/ovr7na/praw_how_to_sort_comments/

First draft, wanted to get feedback on whether it's worth adding a config field to turn this off. There could be a viable use case for people who want to set the sort, fetch comments, change the sort and fetch again, and it would be annoying to have the log message each time. On the other hand that would be really rare (and avoidable by just recreating the submission instance), so I'm not sure whether it's worth "polluting" the config docs/code with a field almost no one will ever set.

Also not sure if it's possible to add a test for a log message.