### PR TITLE
Simplify, unify and document pre_push, CIs and pre-commit hooks to all use consistent tools, versions and config

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -26,16 +26,24 @@ One of the simplest ways to help with PRAW is by answering others'
 questions. When responding, always be positive. While something may be obvious
 to you, it likely is not to the person asking the question.
 
-## Pull Request Creation
+## Creating Pull Requests
 
 0. If you are fixing an already filed issue, please indicate your intentions by
    commenting on the issue. This act will hopefully minimize any duplicate
    work.
 
-0. Prior to creating a pull request run the `pre_push.py` script. This script
-   depends on the tools `black` `flake8`, `pylint`, `pydocstyle`, `sphinx` and `sphinx_rtd_theme`. They can
-   be installed via `pip install black flake8 pydocstyle pylint sphinx sphinx_rtd_theme` or via
-   `pip install praw[lint]`.
+0. Before commiting, make sure to install [Pre-Commit](https://pre-commit.com/)
+   and the pre-commit hooks, which ensure any new code conforms to PRAW's
+   quality and style guidelines. To do so, install the linting dependencies
+   with `pip install praw[lint]`, then by the hooks with `pre-commit install`.
+   They will now run automatically every time you commit. If one of the formatters
+   (e.g. Black, isort) changes one or more files, the commit will automatically abort
+   so you can double-check the changes. If everything looks good, just `git add .` and
+   commit again.
+
+0. Prior to creating a pull request, run the `pre_push.py` script.
+   This runs the pre-commit suite on all files, as well as builds the docs.
+   You'll need to have installed the linting dependencies first (see previous).
 
 0. Add yourself as a contributor to the ``AUTHORS.rst``.
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,24 +25,10 @@ jobs:
           v0-${{ runner.os }}-pip-
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip setuptools wheel
         pip install .[lint]
-    - name: Check other phrase usages
-      run: python ./tools/static_word_checks.py
-    - name: Check documentation
-      run: python ./tools/check_documentation.py
-    - name: Run black
-      run: black --check --verbose .
-    - name: Run docstrfmt
-      run: docstrfmt -cvp pyproject.toml -e docs/examples .
-    - name: Run flake8
-      run: flake8 --exclude docs --statistics
-    - name: Run flynt
-      run: flynt -vdf -tc -ll 1000 .
-    - name: Run isort
-      run: isort -cv .
-    - name: Run pydocstyle
-      run: pydocstyle praw
+    - name: Run pre-commit hooks
+      uses: pre-commit/action@v2.0.3
     - name: Run sphinx
       run: sphinx-build -W --keep-going docs/ /tmp/foo
     strategy:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,12 +27,12 @@ repos:
   - repo: https://github.com/psf/black
     hooks:
       - id: black
-        language_version: python3
     rev: 21.9b0
 
   - repo: https://github.com/LilSpazJoekp/docstrfmt
     hooks:
       - id: docstrfmt
+        require_serial: true
     rev: v1.4.1
 
   - repo: https://github.com/pycqa/flake8
@@ -47,7 +47,6 @@ repos:
           - '-ll'
           - '1000'
           - '-tc'
-        language_version: python3.8
     rev: '0.69'
 
   - repo: https://github.com/pycqa/isort

--- a/docs/package_info/contributing.rst
+++ b/docs/package_info/contributing.rst
@@ -5,22 +5,21 @@ PRAW gladly welcomes new contributions. As with most larger projects, we have an
 established consistent way of doing things. A consistent style increases readability,
 decreases bug-potential and makes it faster to understand how everything works together.
 
-PRAW follows :PEP:`8` and :PEP:`257`. The ``pre_push.py`` script can be used to test for
-compliance with these PEPs in addition to providing a few other checks. The following
-are PRAW-specific guidelines in addition to those PEP's.
+PRAW follows :PEP:`8` and :PEP:`257`. `Pre-Commit <https://pre-commit.com>` is used to
+manage a suite of pre-commit hooks that enforce conformance with these PEPs along with
+several other checks. Additionally, the ``pre_push.py`` script can be used to run the
+full pre-commit suite and the docs build prior to submitting a Pull Request. The
+following are PRAW-specific guidelines in addition to those PEPs.
 
 .. note::
 
-    Python 3.6+ is needed to run the script.
-
-.. note::
-
-    In order to install the dependencies needed to run the script, you can install the
-    ``[dev]`` package of praw, like so:
+    In order to use the pre-commit hooks and the ``pre_push.py`` dependencies, install
+    PRAW's ``[lint]`` extra, followed by the appropriate Pre-Commit command:
 
     .. code-block:: bash
 
-        pip install praw[dev]
+        pip install praw[lint]
+        pre-commit install
 
 Code
 ----
@@ -78,9 +77,9 @@ The environment variables are (listed in bash export format):
     export prawtest_username=myusername
     export prawtest_user_agent=praw_pytest
 
-By setting these environment variables prior to running ``python setup.py test``, when
-adding or updating cassettes, instances of ``mypassword`` will be replaced by the
-placeholder text ``<PASSWORD>`` and similar for the other environment variables.
+By setting these environment variables prior to running ``pytest``, when adding or
+updating cassettes, instances of ``mypassword`` will be replaced by the placeholder text
+``<PASSWORD>`` and similar for the other environment variables.
 
 To use tokens instead of username/password set ``prawtest_refresh_token`` instead of
 ``prawtest_password`` and ``prawtest_username``.
@@ -104,8 +103,9 @@ Static Checker
 ~~~~~~~~~~~~~~
 
 PRAW's test suite comes with a checker tool that can warn you of using incorrect
-documentation styles (using ``.. code-block::`` instead of ``.. code::``, using ``/r/``
-instead of ``r/``, etc.).
+documentation styles (using ``.. code::`` instead of ``.. code-block::``, using ``/r/``
+instead of ``r/``, etc.). This is run automatically by the pre-commit hooks and the
+``pre_push.py`` script.
 
 .. autoclass:: tools.static_word_checks.StaticChecker
     :inherited-members:

--- a/pre_push.py
+++ b/pre_push.py
@@ -3,12 +3,8 @@
 
 import argparse
 import sys
-from os import path
-from shutil import rmtree
 from subprocess import CalledProcessError, check_call
-from tempfile import mkdtemp
-
-current_directory = path.abspath(path.join(__file__, ".."))
+from tempfile import TemporaryDirectory
 
 
 def do_process(args, shell=False):
@@ -41,35 +37,10 @@ def run_static():
 
     """
     success = True
-    # Formatters
-    success &= do_process(
-        [
-            sys.executable,
-            path.join(current_directory, "tools", "static_word_checks.py"),
-            "--replace",
-        ]
-    )
-    success &= do_process(["flynt", "-q", "-tc", "-ll", "1000", "."])
-    # needs to be first because flynt is not black compliant
-    success &= do_process(["black", "."])
-    success &= do_process(["docstrfmt", "."])
-    success &= do_process(["isort", "."])
-    # Linters
-    success &= do_process(
-        [
-            sys.executable,
-            path.join(current_directory, "tools", "check_documentation.py"),
-        ]
-    )
-    success &= do_process(["flake8"])
-    success &= do_process(["pydocstyle", "praw"])
-    # success &= do_process(["pylint", "--rcfile=.pylintrc", "praw"])
+    success &= do_process(["pre-commit", "run", "--all-files"])
 
-    tmp_dir = mkdtemp()
-    try:
+    with TemporaryDirectory() as tmp_dir:
         success &= do_process(["sphinx-build", "-W", "--keep-going", "docs", tmp_dir])
-    finally:
-        rmtree(tmp_dir)
 
     return success
 

--- a/setup.py
+++ b/setup.py
@@ -15,14 +15,9 @@ with open(path.join(HERE, PACKAGE_NAME, "const.py"), encoding="utf-8") as fp:
 
 extras = {
     "ci": ["coveralls"],
-    "dev": ["packaging", "pre-commit"],
+    "dev": ["packaging"],
     "lint": [
-        "black",
-        "docstrfmt",
-        "flake8",
-        "flynt",
-        "isort",
-        "pydocstyle",
+        "pre-commit",
         "sphinx",
         "sphinx_rtd_theme",
     ],


### PR DESCRIPTION
Followup to PR #1774 as requested by @LilSpazJoekp 

## Feature Summary and Justification

Per [my comment](https://github.com/praw-dev/praw/pull/1774#pullrequestreview-734610136) on #1774 :

> Given that all the now-duplicate dep installation and lint runner commands [`lint-multi-os` job](https://github.com/praw-dev/praw/blob/ea14f22c8b5f87516cd1ff7f6b4375d9e11ad1e9/.github/workflows/ci.yml#L11) in your CI workflow (aside from the Sphinx build) is now also covered here, I would suggest replacing all that redundancy with the pre-commit Github action which will install and run them through pre-commit, and tweak your caching as needed. This ensures the same checks are run locally as in the CI (right now some of the invocations are different, because they were changed here but not there, and the versions may drift out of sync), keeps things DRY and avoids doubling the maintenance burden, with corresponding issues if things get out of sync.

> Similarly, now that you've done this, I suggest not further duplicating the invocations and versions _again_ in `pre_push.py` and the `setup.py` `lint` extra respectively, and instead replacing all that with a single call to pre-commit, i.e. `pre-commit run` or `pre-commit run --all-files`. In all, this triples the maintenance burden of keeping versions up to date and tweaking invocations (particularly since pre-commit handles the former and much of the latter for you), again ensures consistent behavior between the script and the hooks, and brings the benefits of pre-commit's automated, platform-independent installation, updating, output reporting and more.

Significant changes:
* [x] Simply run the linting suite with pre-commit in the `pre_push.py` script instead of redundant manual invocations of each linter.
* [x] Also in `pre_push.py`, use `TemporaryDirectory` instead of the legacy `tempfile` API to further simplify the code and clean up the temp dir automatically
* [x] Eliminate all the duplicate linter invocations in the Github Actions CI workflow and just use the pre-commit action to run them instead, with consistent tools, invocations and versions
* [x] Remove the now-unused lint dependencies that are installed and managed through pre-commit and not ever run directly from the `lint` extra and move `pre-commit` there, where it belongs
* [x] Document how to install/run the pre-commit hooks in both (...) contributing guides, and streamline and update the guidance for the `pre_push.py` script; also update/remove a few other related obsolete mentions
* [x] Update hook versions, including fixing a hard crash due to missing deps ( LilSpazJoekp/docstrfmt#30 ) that went undetected due to running different tools, versions and config via pre-commit, pre_push and CIs (as fixed in this PR)
* [x] Fix an apparently unnecessary pinned Python version for black and flynt that results in a hard crash on any system without that particular version installed, which again went undetected due to the above
* [x] Improve docstrfmt runtime by nearly 3x (1 min 20 s to 30 s) by avoiding double-parallelization by both pre-commit and the tool itself

Also resulted in two PRs to fix further issues discovered with docstrfmt:

* LilSpazJoekp/docstrfmt#32
* LilSpazJoekp/docstrfmt#33

Thanks!