### PR TITLE
Only import sqlite3 in SQLiteTokenManager class

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,11 @@ Unreleased
 - :meth:`.user_selectable` to get available subreddit link flairs.
 - Automatic RateLimit handling will support errors with millisecond resolution.
 
+**Fixed**
+
+- An import error when using PRAW in environments where ``libsqlite3-dev`` is needed to
+  utilize the ``sqlite3`` builtin.
+
 7.4.0 (2021/07/30)
 ------------------
 

--- a/praw/util/token_manager.py
+++ b/praw/util/token_manager.py
@@ -11,7 +11,6 @@ PRAW users will create their own token manager classes suitable for their needs.
     Tokens managers have been depreciated and will be removed in the near future.
 
 """
-import sqlite3
 from abc import ABC, abstractmethod
 
 
@@ -121,6 +120,8 @@ class SQLiteTokenManager(BaseTokenManager):
 
         """
         super().__init__()
+        import sqlite3
+
         self._connection = sqlite3.connect(database)
         self._connection.execute(
             "CREATE TABLE IF NOT EXISTS tokens (id, refresh_token, updated_at)"


### PR DESCRIPTION
Fixes #1748 

## Feature Summary and Justification

This fixes an import error when using PRAW in environments where `libsqlite3-dev` is needed to utilize the `sqlite3` builtin.

## References

- https://github.com/praw-dev/praw/issues/1748#issuecomment-864178047