### PR TITLE
Fix pre-commit hook for flynt

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,6 +47,7 @@ repos:
           - '-ll'
           - '1000'
           - '-tc'
+        language_version: python3.9
     rev: '0.69'
 
   - repo: https://github.com/pycqa/isort


### PR DESCRIPTION
This pins the Python version to 3.9 for the Flynt pre-commit hook.