### PR TITLE
Add clarification for `ratelimit_seconds` in the docs

### DIFF
--- a/docs/getting_started/configuration/options.rst
+++ b/docs/getting_started/configuration/options.rst
@@ -88,6 +88,7 @@ These are options that do not belong in another category, but still play a part 
 
         PRAW sleeps for the ratelimit value plus 1 second.
 
+    See :ref:`ratelimits` for more info.
 :timeout: Controls the amount of time PRAW will wait for a request from Reddit to
     complete before throwing an exception. By default, PRAW waits 16 seconds before
     throwing an exception.

--- a/docs/getting_started/ratelimits.rst
+++ b/docs/getting_started/ratelimits.rst
@@ -1,0 +1,44 @@
+.. _ratelimits:
+
+Ratelimits
+==========
+
+Even though PRAW respects the |ratelimit_header|_ and waits the appropriate time between
+requests, there are other unknown ratelimits that Reddit has that might require
+additional wait time (anywhere from milliseconds to minutes) for things such as
+commenting, editing comments/posts, banning users, adding moderators, etc. PRAW will
+sleep and try the request again if the requested wait time (as much as 600s) is less
+than or equal to PRAW's |ratelimit_seconds|_, PRAW will wait for the requested time plus
+1 second. If the requested wait time exceeds the set value of ``ratelimit_seconds``,
+PRAW will raise :class:`.RedditAPIException`.
+
+For example, given the following Reddit instance:
+
+.. code-block:: python
+
+    import praw
+
+    reddit = praw.Reddit(
+        client_id="xxx",
+        client_secret="xxx",
+        username="xxx",
+        password="xxx",
+        user_agent="Example bot v0.0.1 by u/xxx",
+        ratelimit_seconds=300,
+    )
+
+Let's say your bot posts a comment to Reddit every 30s and Reddit returns the ratelimit
+error: ``"You're doing that too much. Try again in 3 minutes."``. PRAW will wait for 181
+seconds since 181 seconds is less than the configured ``ratelimit_seconds`` of 300
+seconds. However, if Reddit returns the ratelimit error: ``"You're doing that too much.
+Try again in 6 minutes."``, PRAW will raise an exception since 360 seconds is greater
+than the configured ``ratelimit_seconds`` of 300 seconds.
+
+.. |ratelimit_header| replace:: ``X-Ratelimit-*`` headers
+
+.. |ratelimit_seconds| replace:: ``ratelimit_seconds`` configuration setting (default:
+    5s)
+
+.. _ratelimit_header: https://github.com/reddit-archive/reddit/wiki/API#rules
+
+.. _ratelimit_seconds: https://praw.readthedocs.io/en/stable/getting_started/configuration/options.html#miscellaneous-configuration-options

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,6 +27,7 @@ application. See :ref:`oauth` for information on using **installed** application
     getting_started/configuration
     getting_started/multiple_instances
     getting_started/logging
+    getting_started/ratelimits
     getting_started/faq
 
 .. _code_overview:


### PR DESCRIPTION
Fixes #1777

## Feature Summary and Justification

This adds some clarification in the docs for `ratelimit_seconds`.