### PR TITLE
Guard requests import only needed for mypy & explicitly req for tests

### DIFF
--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -14,7 +14,9 @@ from xml.etree.ElementTree import XML
 
 import websocket
 from prawcore import Redirect
-from requests import Response
+
+if TYPE_CHECKING:  # pragma: no cover
+    from requests import Response
 
 from ...const import API_PATH, JPEG_HEADER
 from ...exceptions import (
@@ -587,7 +589,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
         self.__dict__.update(other.__dict__)
         self._fetched = True
 
-    def _parse_xml_response(self, response: Response):
+    def _parse_xml_response(self, response: "Response"):
         """Parse the XML from a response and raise any errors found."""
         xml = response.text
         root = XML(xml)

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ extras = {
         "betamax >=0.8, <0.9",
         "betamax-matchers >=0.3.0, <0.5",
         "pytest >=2.7.3",
+        "requests >=2.20.1, <3",
     ],
 }
 extras["dev"] += extras["lint"] + extras["test"]


### PR DESCRIPTION
Fixes #1813 

## Pull Request Summary and Justification

Currently, requests is imported at runtime in `praw` but only used for static type annotations, creating an undeclared implicit dependency. In addition, requests is used a number of places in the test suite and development scripts, but not included in the `tests` extra.

While not terribly harmful in practice at the moment (since `prawcore` currently requires requests, albeit indirectly), it results in warnings and confusion in downstream tooling (e.g. conda-forge/praw-feedstock#20 ) and could pose a problem at some point in the future if this is ever dropped or changed.

Thus, on the advice of @LilSpazJoekp , this PR guards the requests import with `if TYPE_CHECKING` and uses a string type annotation, which avoids this problem at runtime; and also adds `requests` to the `test` dependencies.

To note, the minimum version bound of `2.20.1` is a bit arbitrary and higher than the ancient (6 years old and long-insecure) 2.6.0 minimum required by prawcore, but is motivated by the latest bugfix release of the latest requests release still considered secure, and shortly after the point where requests (2) development more or less stabilized, and is still three years old. Since the dependency is only for tests, and reproducibility is desired, it is generally beneficial to be more strict, but I'm of course happy to change it if desired. Thanks!