### PR TITLE
Catch a requests HTTPError and instead raise a prawcore ServerError.

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -78,4 +78,5 @@ Source Contributors
 - Justin Krejcha <justin@justinkrejcha.com> `@jkrejcha <https://github.com/jkrejcha>`_
 - Dio Brando `@isFakeAccount <https://github.com/isFakeAccount>`_
 - Josh Kim `@jsk56143 <https://github.com/jsk56143>`_
+- Rolf Campbell `@endlisnis <https://github.com/endlisnis>`_
 - Add "Name <email (optional)> and github profile link" above this line.

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -11,6 +11,8 @@ from typing import TYPE_CHECKING, Any, Dict, Generator, Iterator, List, Optional
 from urllib.parse import urljoin
 from warnings import warn
 from xml.etree.ElementTree import XML
+from requests.exceptions import HTTPError
+from prawcore.exceptions import ServerError
 
 import websocket
 from prawcore import Redirect
@@ -694,7 +696,10 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
             )
         if not response.ok:
             self._parse_xml_response(response)
-        response.raise_for_status()
+        try:
+            response.raise_for_status()
+        except HTTPError as err:
+            raise ServerError(response=err.response)
 
         websocket_url = upload_response["asset"]["websocket_url"]
 

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -11,11 +11,11 @@ from typing import TYPE_CHECKING, Any, Dict, Generator, Iterator, List, Optional
 from urllib.parse import urljoin
 from warnings import warn
 from xml.etree.ElementTree import XML
-from requests.exceptions import HTTPError
-from prawcore.exceptions import ServerError
 
 import websocket
 from prawcore import Redirect
+from prawcore.exceptions import ServerError
+from requests.exceptions import HTTPError
 
 from ...const import API_PATH, JPEG_HEADER
 from ...exceptions import (

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -638,6 +638,13 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
         url = ws_update["payload"]["redirect"]
         return self._reddit.submission(url=url)
 
+    def _read_and_post_media(self, media_path, upload_url, upload_data):
+        with open(media_path, "rb") as media:
+            response = self._reddit._core._requestor._http.post(
+                upload_url, data=upload_data, files={"file": media}
+            )
+        return response
+
     def _upload_media(
         self,
         media_path: str,
@@ -690,10 +697,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
         upload_url = f"https:{upload_lease['action']}"
         upload_data = {item["name"]: item["value"] for item in upload_lease["fields"]}
 
-        with open(media_path, "rb") as media:
-            response = self._reddit._core._requestor._http.post(
-                upload_url, data=upload_data, files={"file": media}
-            )
+        response = self._read_and_post_media(media_path, upload_url, upload_data)
         if not response.ok:
             self._parse_xml_response(response)
         try:

--- a/tests/unit/models/reddit/test_subreddit.py
+++ b/tests/unit/models/reddit/test_subreddit.py
@@ -83,13 +83,13 @@ class TestSubreddit(UnitTest):
         from prawcore.exceptions import ServerError
         from requests.exceptions import HTTPError
 
-        httpResponse = mock.Mock()
-        httpResponse.status_code = 500
+        http_response = mock.Mock()
+        http_response.status_code = 500
 
         response = mock.Mock()
         response.ok = True
         response.raise_for_status = mock.Mock(
-            side_effect=HTTPError(response=httpResponse)
+            side_effect=HTTPError(response=http_response)
         )
         mock_method.return_value = response
         with pytest.raises(ServerError):

--- a/tests/unit/models/reddit/test_subreddit.py
+++ b/tests/unit/models/reddit/test_subreddit.py
@@ -70,6 +70,31 @@ class TestSubreddit(UnitTest):
         with pytest.raises(MediaPostFailed):
             self.reddit.subreddit("test").submit_image("Test", "dummy path")
 
+    @mock.patch("praw.models.Subreddit._read_and_post_media")
+    @mock.patch(
+        "praw.Reddit.post",
+        return_value={
+            "json": {"data": {"websocket_url": ""}},
+            "args": {"action": "", "fields": []},
+        },
+    )
+    @mock.patch("websocket.create_connection")
+    def test_media_upload_500(self, connection_mock, _mock_post, mock_method):
+        from prawcore.exceptions import ServerError
+        from requests.exceptions import HTTPError
+
+        httpResponse = mock.Mock()
+        httpResponse.status_code = 500
+
+        response = mock.Mock()
+        response.ok = True
+        response.raise_for_status = mock.Mock(
+            side_effect=HTTPError(response=httpResponse)
+        )
+        mock_method.return_value = response
+        with pytest.raises(ServerError):
+            self.reddit.subreddit("test").submit_image("Test", "/dev/null")
+
     def test_pickle(self):
         subreddit = Subreddit(
             self.reddit, _data={"display_name": "name", "id": "dummy"}


### PR DESCRIPTION
## Feature Summary and Justification

This pull request provides a native (prawcore) exception instead of an "requests" exception for one specific function path.

## References

- #1825