### PR TITLE
Update submission.py

### DIFF
--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -396,6 +396,8 @@ class Submission(SubmissionListingMixin, UserContentMixin, FullnameMixin, Reddit
     Attribute                  Description
     ========================== =========================================================
     ``author``                 Provides an instance of :class:`.Redditor`.
+    ``author_flair_text``      The text content of the authors flair, or ``None`` if not
+                               flaired. 
     ``clicked``                Whether or not the submission has been clicked by the
                                client.
     ``comments``               Provides an instance of :class:`.CommentForest`.

--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -396,8 +396,8 @@ class Submission(SubmissionListingMixin, UserContentMixin, FullnameMixin, Reddit
     Attribute                  Description
     ========================== =========================================================
     ``author``                 Provides an instance of :class:`.Redditor`.
-    ``author_flair_text``      The text content of the authors flair, or ``None`` if not
-                               flaired.
+    ``author_flair_text``      The text content of the author's flair, or ``None`` if
+                               not flaired.
     ``clicked``                Whether or not the submission has been clicked by the
                                client.
     ``comments``               Provides an instance of :class:`.CommentForest`.

--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -397,7 +397,7 @@ class Submission(SubmissionListingMixin, UserContentMixin, FullnameMixin, Reddit
     ========================== =========================================================
     ``author``                 Provides an instance of :class:`.Redditor`.
     ``author_flair_text``      The text content of the authors flair, or ``None`` if not
-                               flaired. 
+                               flaired.
     ``clicked``                Whether or not the submission has been clicked by the
                                client.
     ``comments``               Provides an instance of :class:`.CommentForest`.


### PR DESCRIPTION
Fixes #1864

## Feature Summary and Justification

This pull request provides enhancement to the docs.
It's adds the `author_flair_text` attribute to the `Submission` documentation.
`author_flair_text` is the text of the flair that is attached to a author within a specific subreddit.
