### PR TITLE
Don't pre-populate ModmailConversation.messages

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,11 @@ PRAW follows `semantic versioning <http://semver.org/>`_.
 Unreleased
 ----------
 
+**Fixed**
+
+- An issue where :class:`.ModmailConversation`'s ``messages`` attribute would only
+  contain the latest message.
+
 7.6.0 (2022/05/10)
 ------------------
 

--- a/tests/unit/models/reddit/test_modmail.py
+++ b/tests/unit/models/reddit/test_modmail.py
@@ -18,6 +18,7 @@ class TestModmailConversation(UnitTest):
 
     def test_str(self):
         conversation = ModmailConversation(self.reddit, _data={"id": "ik72"})
+        assert str(conversation) == "ik72"
 
         conversation = ModmailConversation(self.reddit, "ik72")
         assert str(conversation) == "ik72"


### PR DESCRIPTION
Fixes #1870 

## Feature Summary and Justification

This changes the objector behavior to not preemptively set ``messages`` or ``mod_actions`` when building `ModmailConversation` objects.
