### PR TITLE
Fix typo in docs

### DIFF
--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -2230,7 +2230,7 @@ class SubredditLinkFlairTemplates(SubredditFlairTemplates):
 
         .. code-block:: python
 
-            reddit.subreddit("test").flair.templates.add(
+            reddit.subreddit("test").flair.link_templates.add(
                 "PRAW",
                 css_class="praw",
                 text_editable=True,


### PR DESCRIPTION
Fixes #1871

## Feature Summary and Justification

This fixes a typo in the link templates docs.