### PR TITLE
Don't set conversation.obj_ids since it can be missing data

### DIFF
--- a/praw/objector.py
+++ b/praw/objector.py
@@ -80,7 +80,7 @@ class Objector:
             "state",
         }.issubset(data):
             # not fetched conversation i.e., from conversations()
-            del data["objIds"]  # delete objIds since could be missing data
+            del data["objIds"]  # delete objIds since it could be missing data
             parser = self.parsers["ModmailConversation"]
         elif {"conversationIds", "conversations", "messages"}.issubset(data):
             # modmail conversations


### PR DESCRIPTION
Fixes #1870 

## Feature Summary and Justification

This prevents `conversation.obj_ids` from being set when it doesn't have all the object ids. This also sets `conversation.messages` if `num_messages` is 1.