### PR TITLE
Update quick_start.rst - fixed typo in docs

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -29,6 +29,7 @@ Documentation Contributors
 - Mohammad Ghalayini `@mghalayini <https://github.com/mghalayini>`_
 - Jason Haines `@jghaines <https://github.com/jghaines>`_
 - Johanna Rührig `@TheRealVira <https://github.com/TheRealVira>`_
+- Sam Snarr `@sss-ng <https://github.com/sss-ng>`_
 - Add "Name <email (optional)> and github profile link" above this line.
 
 Logo Creator

--- a/docs/getting_started/quick_start.rst
+++ b/docs/getting_started/quick_start.rst
@@ -91,7 +91,7 @@ Just like that, you now have a read-only :class:`.Reddit` instance.
     # Output: True
 
 With a read-only instance, you can do something like obtaining 10 "hot" submissions from
-``r/learnpython``:
+``r/test``:
 
 .. code-block:: python
 


### PR DESCRIPTION
Changed subreddit "test" to "learnprogramming" in quick start example


