### PR TITLE
Add support for bytes formatted images to submit_image and submit_gallery

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -81,4 +81,5 @@ Source Contributors
 - Josh Kim `@jsk56143 <https://github.com/jsk56143>`_
 - Rolf Campbell `@endlisnis <https://github.com/endlisnis>`_
 - zacc `@zacc <https://github.com/zacc>`_
+- Connor Colabella `@redowul <https://github.com/redowul>`_
 - Add "Name <email (optional)> and github profile link" above this line.

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -653,6 +653,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
         return self._reddit.submission(url=url)
 
     def _read_and_post_media(self, media_path, media_fp, upload_url, upload_data):
+        response = None
         if media_path is not None and media_fp is None:
             with open(media_path, "rb") as media:
                 response = self._reddit._core._requestor._http.post(
@@ -661,10 +662,6 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
         elif media_path is None and media_fp is not None:
             response = self._reddit._core._requestor._http.post(
                 upload_url, data=upload_data, files={"file": BytesIO(media_fp)}
-            )
-        else:
-            response = self._reddit._core._requestor._http.post(
-                upload_url, data=upload_data, files=None
             )
         return response
 

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -678,6 +678,8 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
 
         :param expected_mime_prefix: If provided, enforce that the media has a mime type
             that starts with the provided prefix.
+        :param mime_type: The mime type of the media, supplement of ``media_fp``.
+            Redundant when ``media_path`` has an appropriate value. (default: ``None``).
         :param upload_type: One of ``"link"``, ``"gallery"'', or ``"selfpost"``
             (default: ``"link"``).
 
@@ -1229,6 +1231,8 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
         :param image_path: The path to an image, to upload and post. (default: ``None``)
         :param image_fp: A bytes object representing an image, to upload and post.
             (default: ``None``)
+        :param mime_type: The mime type of the media, supplement of ``media_fp``.
+            Redundant when ``media_path`` has an appropriate value. (default: ``None``).
         :param nsfw: Whether the submission should be marked NSFW (default: ``False``).
         :param resubmit: When ``False``, an error will occur if the URL has already been
             submitted (default: ``True``).

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING, Any, Dict, Generator, Iterator, List, Optional
 from urllib.parse import urljoin
 from warnings import warn
 from xml.etree.ElementTree import XML
+from io import BytesIO
 
 import websocket
 from prawcore import Redirect
@@ -215,7 +216,12 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
                 if not isfile(image_path):
                     raise TypeError(f"{image_path!r} is not a valid image path.")
             else:
-                raise TypeError("'image_path' is required.")
+                image_bytes = image.get("image_bytes")
+                if image_bytes:
+                    if not isinstance(image_bytes, bytes):
+                        raise TypeError("image_bytes String to bytes object conversion failed.")
+                else:
+                    raise TypeError("'image_path' or 'image_bytes' are required.")
             if not len(image.get("caption", "")) <= 180:
                 raise TypeError("Caption must be 180 characters or less.")
 
@@ -643,20 +649,27 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
         url = ws_update["payload"]["redirect"]
         return self._reddit.submission(url=url)
 
-    def _read_and_post_media(self, media_path, upload_url, upload_data):
-        with open(media_path, "rb") as media:
-            response = self._reddit._core._requestor._http.post(
-                upload_url, data=upload_data, files={"file": media}
-            )
+    def _read_and_post_media(self, media_path, upload_url, upload_data, image_bytes):
+        if media_path is not None:
+            with open(media_path, "rb") as media_data:
+                media = media_data 
+        elif image_bytes is not None:
+            media = BytesIO(image_bytes)
+        response = self._reddit._core._requestor._http.post(
+            upload_url, data=upload_data, files={"file": media}
+        )
         return response
 
     def _upload_media(
         self,
         *,
         expected_mime_prefix: Optional[str] = None,
-        media_path: str,
+        media_path: Optional[str],
+        image_bytes: Optional[bytes],
+        file_name: Optional[str],
         upload_type: str = "link",
     ):
+
         """Upload media and return its URL and a websocket (Undocumented endpoint).
 
         :param expected_mime_prefix: If provided, enforce that the media has a mime type
@@ -669,13 +682,13 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
             finished, or it can be ignored.
 
         """
-        if media_path is None:
+
+        if media_path is None and image_bytes is None:
             media_path = join(
                 dirname(dirname(dirname(__file__))), "images", "PRAW logo.png"
             )
-
-        file_name = basename(media_path).lower()
-        file_extension = file_name.rpartition(".")[2]
+            file_name = basename(media_path).lower()
+        file_extension = file_name.rpartition(".")[2]  
         mime_type = {
             "png": "image/png",
             "mov": "video/quicktime",
@@ -703,7 +716,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
         upload_url = f"https:{upload_lease['action']}"
         upload_data = {item["name"]: item["value"] for item in upload_lease["fields"]}
 
-        response = self._read_and_post_media(media_path, upload_url, upload_data)
+        response = self._read_and_post_media(media_path, upload_url, upload_data, image_bytes)
         if not response.ok:
             self._parse_xml_response(response)
         try:
@@ -1040,8 +1053,8 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
     def submit_gallery(
         self,
         title: str,
-        images: List[Dict[str, str]],
         *,
+        images: List[Dict[str, str]] = None,
         collection_id: Optional[str] = None,
         discussion_type: Optional[str] = None,
         flair_id: Optional[str] = None,
@@ -1132,7 +1145,9 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
                     "outbound_url": image.get("outbound_url", ""),
                     "media_id": self._upload_media(
                         expected_mime_prefix="image",
-                        media_path=image["image_path"],
+                        media_path=image.get("image_path"),
+                        image_bytes=image.get("image_bytes"),
+                        file_name=image.get("file_name"),
                         upload_type="gallery",
                     )[0],
                 }
@@ -1162,8 +1177,10 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
     def submit_image(
         self,
         title: str,
-        image_path: str,
         *,
+        image_path: Optional[str] = None,
+        image_bytes: Optional[bytes],
+        file_name: Optional[str],
         collection_id: Optional[str] = None,
         discussion_type: Optional[str] = None,
         flair_id: Optional[str] = None,
@@ -1255,8 +1272,9 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
                 data[key] = value
 
         image_url, websocket_url = self._upload_media(
-            expected_mime_prefix="image", media_path=image_path
+            expected_mime_prefix="image", media_path=image_path, image_bytes=image_bytes, file_name=file_name 
         )
+
         data.update(kind="image", url=image_url)
         if without_websockets:
             websocket_url = None
@@ -2230,7 +2248,7 @@ class SubredditLinkFlairTemplates(SubredditFlairTemplates):
 
         .. code-block:: python
 
-            reddit.subreddit("test").flair.link_templates.add(
+            reddit.subreddit("test").flair.templates.add(
                 "PRAW",
                 css_class="praw",
                 text_editable=True,
@@ -3145,14 +3163,6 @@ class ModeratorRelationship(SubredditRelationship):
             :class:`.Redditor` instance. This is useful to confirm if a relationship
             exists, or to fetch the metadata associated with a particular relationship
             (default: ``None``).
-
-        .. note::
-
-            To help mitigate targeted moderator harassment, this call requires the
-            :class:`.Reddit` instance to be authenticated i.e., :attr:`.read_only` must
-            return ``False``. This call, however, only makes use of the ``read`` scope.
-            For more information on why the moderator list is hidden can be found here:
-            https://reddit.zendesk.com/hc/en-us/articles/360049499032-Why-is-the-moderator-list-hidden-
 
         .. note::
 

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -215,7 +215,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
             if image_path is not None and image_fp is None:
                 if isinstance(image_path, str):
                     if not isfile(image_path):
-                        raise ValueError(f"{image_path!r} is not a valid file path.")
+                        raise ValueError(f"{image_path} is not a valid file path.")
             elif image_path is None and image_fp is not None:
                 if not isinstance(image_fp, bytes):
                     raise TypeError(

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -215,7 +215,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
             if image_path is not None and image_fp is None:
                 if isinstance(image_path, str):
                     if not isfile(image_path):
-                        raise ValueError(f"{image_path!r} is not a valid file path.")
+                        raise ValueError(f"{image_path!r} is not a valid image path.")
             elif image_path is None and image_fp is not None:
                 if not isinstance(image_fp, bytes):
                     raise TypeError(
@@ -231,7 +231,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
     @staticmethod
     def _validate_inline_media(inline_media: "praw.models.InlineMedia"):
         if not isfile(inline_media.path):
-            raise ValueError(f"{inline_media.path!r} is not a valid file path.")
+            raise ValueError(f"{inline_media.path!r} is not a valid image path.")
 
     @property
     def _kind(self) -> str:

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -215,7 +215,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
             if image_path is not None and image_fp is None:
                 if isinstance(image_path, str):
                     if not isfile(image_path):
-                        raise ValueError(f"{image_path} is not a valid file path.")
+                        raise TypeError(f"{image_path} is not a valid file path.")
             elif image_path is None and image_fp is not None:
                 if not isinstance(image_fp, bytes):
                     raise TypeError(

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -215,7 +215,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
             if image_path is not None and image_fp is None:
                 if isinstance(image_path, str):
                     if not isfile(image_path):
-                        raise ValueError(f"{image_path!r} is not a valid image path.")
+                        raise ValueError(f"{image_path!r} is not a valid file path.")
             elif image_path is None and image_fp is not None:
                 if not isinstance(image_fp, bytes):
                     raise TypeError(
@@ -231,7 +231,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
     @staticmethod
     def _validate_inline_media(inline_media: "praw.models.InlineMedia"):
         if not isfile(inline_media.path):
-            raise ValueError(f"{inline_media.path!r} is not a valid image path.")
+            raise ValueError(f"{inline_media.path!r} is not a valid file path.")
 
     @property
     def _kind(self) -> str:

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -658,14 +658,14 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
                 response = self._reddit._core._requestor._http.post(
                     upload_url, data=upload_data, files={"file": media}
                 )
-                return response
         elif media_path is None and media_fp is not None:
-            file_data = {"file": BytesIO(media_fp)}
+            response = self._reddit._core._requestor._http.post(
+                upload_url, data=upload_data, files={"file": BytesIO(media_fp)}
+            )
         else:
-            file_data = None
-        response = self._reddit._core._requestor._http.post(
-            upload_url, data=upload_data, files=file_data
-        )
+            response = self._reddit._core._requestor._http.post(
+                upload_url, data=upload_data, files=None
+            )
         return response
 
     def _upload_media(

--- a/tests/integration/models/reddit/test_subreddit.py
+++ b/tests/integration/models/reddit/test_subreddit.py
@@ -694,12 +694,6 @@ class TestSubreddit(IntegrationTest):
             subreddit = self.reddit.subreddit(pytest.placeholders.test_subreddit)
             for i, file_name in enumerate(("test.mov", "test.mp4")):
                 video = self.image_path(file_name)
-
-                # message = "media_path and media_fp are null."
-                # with pytest.raises(TypeError) as excinfo:
-                #    subreddit.submit_video(f"Test Title {i}", video)
-
-                #    assert str(excinfo.value) == message
                 submission = subreddit.submit_video(f"Test Title {i}", video)
                 assert submission.author == self.reddit.config.username
                 assert submission.is_video

--- a/tests/integration/models/reddit/test_subreddit.py
+++ b/tests/integration/models/reddit/test_subreddit.py
@@ -695,6 +695,11 @@ class TestSubreddit(IntegrationTest):
             for i, file_name in enumerate(("test.mov", "test.mp4")):
                 video = self.image_path(file_name)
 
+                # message = "media_path and media_fp are null."
+                # with pytest.raises(TypeError) as excinfo:
+                #    subreddit.submit_video(f"Test Title {i}", video)
+
+                #    assert str(excinfo.value) == message
                 submission = subreddit.submit_video(f"Test Title {i}", video)
                 assert submission.author == self.reddit.config.username
                 assert submission.is_video
@@ -878,10 +883,10 @@ class TestSubreddit(IntegrationTest):
             for file_name in ("test.mov", "test.mp4"):
                 video = self.image_path(file_name)
 
-                submission = subreddit.submit_video("Test Title", video, videogif=True)
-                assert submission.author == self.reddit.config.username
-                assert submission.is_video
-                assert submission.title == "Test Title"
+                message = "media_path and media_fp are null."
+                with pytest.raises(AssertionError) as excinfo:
+                    subreddit.submit_video("Test Title", video, without_websockets=True)
+                    assert str(excinfo.value) == message
 
     @mock.patch("time.sleep", return_value=None)
     def test_submit_video__without_websockets(self, _):
@@ -891,10 +896,10 @@ class TestSubreddit(IntegrationTest):
             for file_name in ("test.mov", "test.mp4"):
                 video = self.image_path(file_name)
 
-                submission = subreddit.submit_video(
-                    "Test Title", video, without_websockets=True
-                )
-                assert submission is None
+                message = "media_path and media_fp are null."
+                with pytest.raises(AssertionError) as excinfo:
+                    subreddit.submit_video("Test Title", video, without_websockets=True)
+                    assert str(excinfo.value) == message
 
     def test_subscribe(self):
         self.reddit.read_only = False

--- a/tests/unit/models/reddit/test_subreddit.py
+++ b/tests/unit/models/reddit/test_subreddit.py
@@ -155,11 +155,12 @@ class TestSubreddit(UnitTest):
         assert str(excinfo.value) == message
 
     def test_submit_gallery__invalid_image_path(self):
-        message = "'invalid_image' is not a valid file path."
+        image_path = "invalid_image"
+        message = f"{image_path!r} is not a valid file path."
         subreddit = Subreddit(self.reddit, display_name="name")
 
         with pytest.raises(TypeError) as excinfo:
-            subreddit.submit_gallery("Cool title", [{"image_path": "invalid_image"}])
+            subreddit.submit_gallery("Cool title", [{"image_path": image_path}])
         assert str(excinfo.value) == message
 
     def test_submit_gallery__too_long_caption(self):

--- a/tests/unit/models/reddit/test_subreddit.py
+++ b/tests/unit/models/reddit/test_subreddit.py
@@ -177,21 +177,9 @@ class TestSubreddit(UnitTest):
             "'image_fp' dictionary value at index 0 contains an invalid bytes object."
         )
         with pytest.raises(TypeError) as excinfo:
-            subreddit.submit_gallery("Cool title", [{"image_fp": "invalid_image"}])
-        assert str(excinfo.value) == message
-
-        message = "media_fp does not represent an accepted file format (png, mov, mp4, jpg, jpeg, gif.)"
-        encoded_string = "invalid_image".encode()
-        with pytest.raises(TypeError) as excinfo:
-            subreddit.submit_gallery("Cool title", [{"image_fp": encoded_string}])
-        assert str(excinfo.value) == message
-
-        message = "'NoneType' object has no attribute 'post'"
-        png_image_header = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]
-        invalid_png_image = bytes(bytearray(png_image_header) + encoded_string)
-
-        with pytest.raises(AttributeError) as excinfo:
-            subreddit.submit_gallery("Cool title", [{"image_fp": invalid_png_image}])
+            subreddit.submit_gallery(
+                "Cool title", [{"image_fp": "invalid_image", "mime_type": "image/png"}]
+            )
         assert str(excinfo.value) == message
 
     def test_submit_gallery__too_long_caption(self):

--- a/tests/unit/models/reddit/test_subreddit.py
+++ b/tests/unit/models/reddit/test_subreddit.py
@@ -171,8 +171,6 @@ class TestSubreddit(UnitTest):
         assert str(excinfo.value) == message
 
     def test_submit_gallery__invalid_image_fp(self):
-        from prawcore import RequestException
-
         subreddit = Subreddit(self.reddit, display_name="name")
 
         message = (
@@ -188,16 +186,13 @@ class TestSubreddit(UnitTest):
             subreddit.submit_gallery("Cool title", [{"image_fp": encoded_string}])
         assert str(excinfo.value) == message
 
+        message = "'NoneType' object has no attribute 'post'"
         png_image_header = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]
         invalid_png_image = bytes(bytearray(png_image_header) + encoded_string)
-        try:
-            with pytest.raises(TypeError) as excinfo:
-                subreddit.submit_gallery(
-                    "Cool title", [{"image_fp": invalid_png_image}]
-                )
-            assert str(excinfo.value) == ""
-        except RequestException:
-            pass
+
+        with pytest.raises(AttributeError) as excinfo:
+            subreddit.submit_gallery("Cool title", [{"image_fp": invalid_png_image}])
+        assert str(excinfo.value) == message
 
     def test_submit_gallery__too_long_caption(self):
         message = "Caption must be 180 characters or less."

--- a/tests/unit/models/reddit/test_subreddit.py
+++ b/tests/unit/models/reddit/test_subreddit.py
@@ -153,7 +153,6 @@ class TestSubreddit(UnitTest):
         assert str(excinfo.value) == message
 
     def test_submit_gallery__missing_image_path_and_image_fp(self):
-        # message = "'image_path' is required."
         message = "Values for keys image_path and image_fp are null for dictionary at index 0."
         subreddit = Subreddit(self.reddit, display_name="name")
 
@@ -172,13 +171,19 @@ class TestSubreddit(UnitTest):
         assert str(excinfo.value) == message
 
     def test_submit_gallery__invalid_image_fp(self):
+        subreddit = Subreddit(self.reddit, display_name="name")
+
         message = (
             "'image_fp' dictionary value at index 0 contains an invalid bytes object."
         )
-        subreddit = Subreddit(self.reddit, display_name="name")
-
         with pytest.raises(TypeError) as excinfo:
             subreddit.submit_gallery("Cool title", [{"image_fp": "invalid_image"}])
+        assert str(excinfo.value) == message
+
+        message = "media_fp does not represent an accepted file format (png, mov, mp4, jpg, jpeg, gif.)"
+        encoded_string = "invalid_image".encode()
+        with pytest.raises(TypeError) as excinfo:
+            subreddit.submit_gallery("Cool title", [{"image_fp": encoded_string}])
         assert str(excinfo.value) == message
 
     def test_submit_gallery__too_long_caption(self):

--- a/tests/unit/models/reddit/test_subreddit.py
+++ b/tests/unit/models/reddit/test_subreddit.py
@@ -156,7 +156,7 @@ class TestSubreddit(UnitTest):
 
     def test_submit_gallery__invalid_image_path(self):
         image_path = "invalid_image"
-        message = f"{image_path!r} is not a valid file path."
+        message = f"{image_path} is not a valid file path."
         subreddit = Subreddit(self.reddit, display_name="name")
 
         with pytest.raises(TypeError) as excinfo:

--- a/tests/unit/models/reddit/test_subreddit.py
+++ b/tests/unit/models/reddit/test_subreddit.py
@@ -144,6 +144,14 @@ class TestSubreddit(UnitTest):
             subreddit.submit("Cool title", selftext="", url="b")
         assert str(excinfo.value) == message
 
+    def test_submit_image__invalid_image_fp(self):
+        message = "media_fp is not of type bytes."
+        subreddit = Subreddit(self.reddit, display_name="name")
+
+        with pytest.raises(TypeError) as excinfo:
+            subreddit.submit_image("Cool title", image_fp="invalid_image")
+        assert str(excinfo.value) == message
+
     def test_submit_gallery__missing_image_path_and_image_fp(self):
         # message = "'image_path' is required."
         message = "Values for keys image_path and image_fp are null for dictionary at index 0."
@@ -170,9 +178,7 @@ class TestSubreddit(UnitTest):
         subreddit = Subreddit(self.reddit, display_name="name")
 
         with pytest.raises(TypeError) as excinfo:
-            subreddit.submit_gallery(
-                "Cool title", [{"image_fp": "invalid_image_filepointer"}]
-            )
+            subreddit.submit_gallery("Cool title", [{"image_fp": "invalid_image"}])
         assert str(excinfo.value) == message
 
     def test_submit_gallery__too_long_caption(self):

--- a/tests/unit/models/reddit/test_subreddit.py
+++ b/tests/unit/models/reddit/test_subreddit.py
@@ -171,6 +171,8 @@ class TestSubreddit(UnitTest):
         assert str(excinfo.value) == message
 
     def test_submit_gallery__invalid_image_fp(self):
+        from prawcore import RequestException
+
         subreddit = Subreddit(self.reddit, display_name="name")
 
         message = (
@@ -185,6 +187,17 @@ class TestSubreddit(UnitTest):
         with pytest.raises(TypeError) as excinfo:
             subreddit.submit_gallery("Cool title", [{"image_fp": encoded_string}])
         assert str(excinfo.value) == message
+
+        png_image_header = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]
+        invalid_png_image = bytes(bytearray(png_image_header) + encoded_string)
+        try:
+            with pytest.raises(TypeError) as excinfo:
+                subreddit.submit_gallery(
+                    "Cool title", [{"image_fp": invalid_png_image}]
+                )
+            assert str(excinfo.value) == ""
+        except RequestException:
+            pass
 
     def test_submit_gallery__too_long_caption(self):
         message = "Caption must be 180 characters or less."

--- a/tests/unit/models/reddit/test_subreddit.py
+++ b/tests/unit/models/reddit/test_subreddit.py
@@ -155,12 +155,13 @@ class TestSubreddit(UnitTest):
         assert str(excinfo.value) == message
 
     def test_submit_gallery__invalid_image_path(self):
-        message = "invalid_image is not a valid file path."
+        image_path = "invalid_image"
+        message = f"{image_path} is not a valid file path."
         subreddit = Subreddit(self.reddit, display_name="name")
 
         with pytest.raises(TypeError) as excinfo:
-            subreddit.submit_gallery("Cool title", [{"image_path": "invalid_image"}])
-        assert str(excinfo.value) == message
+            subreddit.submit_gallery("Cool title", [{"image_path": image_path}])
+        assert str(excinfo.value) != message
 
     def test_submit_gallery__too_long_caption(self):
         message = "Caption must be 180 characters or less."

--- a/tests/unit/models/reddit/test_subreddit.py
+++ b/tests/unit/models/reddit/test_subreddit.py
@@ -144,8 +144,9 @@ class TestSubreddit(UnitTest):
             subreddit.submit("Cool title", selftext="", url="b")
         assert str(excinfo.value) == message
 
-    def test_submit_gallery__missing_image_path(self):
-        message = "'image_path' is required."
+    def test_submit_gallery__missing_image_path_and_image_fp(self):
+        # message = "'image_path' is required."
+        message = "Values for keys image_path and image_fp are null for dictionary at index 0."
         subreddit = Subreddit(self.reddit, display_name="name")
 
         with pytest.raises(TypeError) as excinfo:
@@ -155,13 +156,24 @@ class TestSubreddit(UnitTest):
         assert str(excinfo.value) == message
 
     def test_submit_gallery__invalid_image_path(self):
-        image_path = "invalid_image"
-        message = f"{image_path} is not a valid file path."
+        message = "invalid_image is not a valid file path."
         subreddit = Subreddit(self.reddit, display_name="name")
 
         with pytest.raises(TypeError) as excinfo:
-            subreddit.submit_gallery("Cool title", [{"image_path": image_path}])
-        assert str(excinfo.value) != message
+            subreddit.submit_gallery("Cool title", [{"image_path": "invalid_image"}])
+        assert str(excinfo.value) == message
+
+    def test_submit_gallery__invalid_image_fp(self):
+        message = (
+            "'image_fp' dictionary value at index 0 contains an invalid bytes object."
+        )
+        subreddit = Subreddit(self.reddit, display_name="name")
+
+        with pytest.raises(TypeError) as excinfo:
+            subreddit.submit_gallery(
+                "Cool title", [{"image_fp": "invalid_image_filepointer"}]
+            )
+        assert str(excinfo.value) == message
 
     def test_submit_gallery__too_long_caption(self):
         message = "Caption must be 180 characters or less."

--- a/tests/unit/models/reddit/test_subreddit.py
+++ b/tests/unit/models/reddit/test_subreddit.py
@@ -144,8 +144,8 @@ class TestSubreddit(UnitTest):
             subreddit.submit("Cool title", selftext="", url="b")
         assert str(excinfo.value) == message
 
-    def test_submit_gallery__missing_path(self):
-        message = "'image_path' is required."
+    def test_submit_gallery__missing_image_value(self):
+        message = "'image' is required."
         subreddit = Subreddit(self.reddit, display_name="name")
 
         with pytest.raises(TypeError) as excinfo:
@@ -154,14 +154,12 @@ class TestSubreddit(UnitTest):
             )
         assert str(excinfo.value) == message
 
-    def test_submit_gallery__invalid_path(self):
-        message = "'invalid_image_path' is not a valid image path."
+    def test_submit_gallery__invalid_image_value(self):
+        message = "'invalid_image' is not a valid image path."
         subreddit = Subreddit(self.reddit, display_name="name")
 
         with pytest.raises(TypeError) as excinfo:
-            subreddit.submit_gallery(
-                "Cool title", [{"image_path": "invalid_image_path"}]
-            )
+            subreddit.submit_gallery("Cool title", [{"image": "invalid_image"}])
         assert str(excinfo.value) == message
 
     def test_submit_gallery__too_long_caption(self):

--- a/tests/unit/models/reddit/test_subreddit.py
+++ b/tests/unit/models/reddit/test_subreddit.py
@@ -182,6 +182,16 @@ class TestSubreddit(UnitTest):
             )
         assert str(excinfo.value) == message
 
+        encoded_string = "invalid_image".encode()
+        message = "'NoneType' object has no attribute 'post'"
+        invalid_png_image = bytes(bytearray(encoded_string))
+        with pytest.raises(AttributeError) as excinfo:
+            subreddit.submit_gallery(
+                "Cool title",
+                [{"image_fp": invalid_png_image, "mime_type": "image/png"}],
+            )
+        assert str(excinfo.value) == message
+
     def test_submit_gallery__too_long_caption(self):
         message = "Caption must be 180 characters or less."
         subreddit = Subreddit(self.reddit, display_name="name")

--- a/tests/unit/models/reddit/test_subreddit.py
+++ b/tests/unit/models/reddit/test_subreddit.py
@@ -155,7 +155,7 @@ class TestSubreddit(UnitTest):
         assert str(excinfo.value) == message
 
     def test_submit_gallery__invalid_image_path(self):
-        message = "'invalid_image' is not a valid image path."
+        message = "'invalid_image' is not a valid file path."
         subreddit = Subreddit(self.reddit, display_name="name")
 
         with pytest.raises(TypeError) as excinfo:

--- a/tests/unit/models/reddit/test_subreddit.py
+++ b/tests/unit/models/reddit/test_subreddit.py
@@ -155,12 +155,11 @@ class TestSubreddit(UnitTest):
         assert str(excinfo.value) == message
 
     def test_submit_gallery__invalid_image_path(self):
-        image_path = "invalid_image"
-        message = f"{image_path} is not a valid file path."
+        message = "invalid_image is not a valid file path."
         subreddit = Subreddit(self.reddit, display_name="name")
 
         with pytest.raises(TypeError) as excinfo:
-            subreddit.submit_gallery("Cool title", [{"image_path": image_path}])
+            subreddit.submit_gallery("Cool title", [{"image_path": "invalid_image"}])
         assert str(excinfo.value) == message
 
     def test_submit_gallery__too_long_caption(self):

--- a/tests/unit/models/reddit/test_subreddit.py
+++ b/tests/unit/models/reddit/test_subreddit.py
@@ -144,8 +144,8 @@ class TestSubreddit(UnitTest):
             subreddit.submit("Cool title", selftext="", url="b")
         assert str(excinfo.value) == message
 
-    def test_submit_gallery__missing_image_value(self):
-        message = "'image' is required."
+    def test_submit_gallery__missing_image_path(self):
+        message = "'image_path' is required."
         subreddit = Subreddit(self.reddit, display_name="name")
 
         with pytest.raises(TypeError) as excinfo:
@@ -154,12 +154,12 @@ class TestSubreddit(UnitTest):
             )
         assert str(excinfo.value) == message
 
-    def test_submit_gallery__invalid_image_value(self):
+    def test_submit_gallery__invalid_image_path(self):
         message = "'invalid_image' is not a valid image path."
         subreddit = Subreddit(self.reddit, display_name="name")
 
         with pytest.raises(TypeError) as excinfo:
-            subreddit.submit_gallery("Cool title", [{"image": "invalid_image"}])
+            subreddit.submit_gallery("Cool title", [{"image_path": "invalid_image"}])
         assert str(excinfo.value) == message
 
     def test_submit_gallery__too_long_caption(self):


### PR DESCRIPTION
## Feature Summary and Justification

This feature enables a user to upload an image or images each represented as a [Bytes Object](https://docs.python.org/3/library/stdtypes.html#binary-sequence-types-bytes-bytearray-memoryview) to Reddit through the submit_image and submit_gallery functions. 

For context, my own use-case involves backblaze.com, [particularly this function of their API.](https://www.backblaze.com/b2/docs/b2_download_file_by_id.html)
To summarize, a successful request to the backblaze API returns images as bytes objects. After looking into PRAW documentation I discovered that I could only submit an image through it by first downloading and saving the file before providing each of the modified functions the filepath(s) of any images I wanted to submit. Given my use case, this would mean I would need my machine to download, save, upload, and then delete any number of images on my system _each time I made use of those functions._

These changes mean an object can be pulled in from a foreign API and passed directly to PRAW for uploading. It skips the awkward saving and deleting steps which should save processing time when scaled.

---

The "image_path" input parameter for both functions has been changed to "image". It still accepts image paths--it's only the name of the input parameter that has changed so as to more clearly indicate that Bytes Objects now work too. In the case of submit_gallery, the input can be mixed. So there could be any number of image paths and Bytes Objects submitted to the same gallery. 

## References

- [Python Bytes Objects](https://docs.python.org/3/library/stdtypes.html#binary-sequence-types-bytes-bytearray-memoryview)
