### PR TITLE
Standardize quotes in error messages and stdout messages

### DIFF
--- a/docs/examples/obtain_refresh_token.py
+++ b/docs/examples/obtain_refresh_token.py
@@ -33,7 +33,7 @@ import praw
 def main():
     """Provide the program's entry point when directly executed."""
     scope_input = input(
-        "Enter a comma separated list of scopes, or `*` for all scopes: "
+        "Enter a comma separated list of scopes, or '*' for all scopes: "
     )
     scopes = [scope.strip() for scope in scope_input.strip().split(",")]
 

--- a/docs/examples/use_file_token_manager.py
+++ b/docs/examples/use_file_token_manager.py
@@ -2,11 +2,11 @@
 """This example demonstrates using the file token manager for refresh tokens.
 
 In order to run this program, you will first need to obtain a valid refresh token. You
-can use the `obtain_refresh_token.py` example to help.
+can use the ``obtain_refresh_token.py`` example to help.
 
-In this example, refresh tokens will be saved into a file `refresh_token.txt` relative
+In this example, refresh tokens will be saved into a file ``refresh_token.txt`` relative
 to your current working directory. If your current working directory is under version
-control it is strongly encouraged you add `refresh_token.txt` to the version control
+control it is strongly encouraged you add ``refresh_token.txt`` to the version control
 ignore list.
 
 Usage:
@@ -36,12 +36,10 @@ def initialize_refresh_token_file():
 
 def main():
     if "praw_client_id" not in os.environ:
-        sys.stderr.write("Environment variable ``praw_client_id`` must be defined\n")
+        sys.stderr.write("Environment variable 'praw_client_id' must be defined\n")
         return 1
     if "praw_client_secret" not in os.environ:
-        sys.stderr.write(
-            "Environment variable ``praw_client_secret`` must be defined\n"
-        )
+        sys.stderr.write("Environment variable 'praw_client_secret' must be defined\n")
         return 1
 
     initialize_refresh_token_file()

--- a/docs/examples/use_sqlite_token_manager.py
+++ b/docs/examples/use_sqlite_token_manager.py
@@ -33,16 +33,15 @@ DATABASE_PATH = "tokens.sqlite3"
 
 def main():
     if "praw_client_id" not in os.environ:
-        sys.stderr.write("Environment variable ``praw_client_id`` must be defined\n")
+        sys.stderr.write("Environment variable 'praw_client_id' must be defined\n")
         return 1
     if "praw_client_secret" not in os.environ:
-        sys.stderr.write(
-            "Environment variable ``praw_client_secret`` must be defined\n"
-        )
+        sys.stderr.write("Environment variable 'praw_client_secret' must be defined\n")
         return 1
     if len(sys.argv) != 2:
         sys.stderr.write(
-            "KEY must be provided.\n\nUsage: python3 use_sqlite_token_manager.py TOKEN_KEY\n"
+            "'KEY' must be provided.\n\nUsage: python3 use_sqlite_token_manager.py"
+            " TOKEN_KEY\n"
         )
         return 1
 

--- a/praw/config.py
+++ b/praw/config.py
@@ -1,4 +1,4 @@
-"""Provides the code to load PRAW's configuration file `praw.ini`."""
+"""Provides the code to load PRAW's configuration file ``praw.ini``."""
 import configparser
 import os
 import sys

--- a/praw/exceptions.py
+++ b/praw/exceptions.py
@@ -139,7 +139,7 @@ class APIException(PRAWException):
 
     def _get_old_attr(self, attrname):
         warn(
-            f"Accessing attribute ``{attrname}`` through APIException is deprecated."
+            f"Accessing attribute '{attrname}' through APIException is deprecated."
             " This behavior will be removed in PRAW 8.0. Check out"
             " https://praw.readthedocs.io/en/latest/package_info/praw7_migration.html"
             " to learn how to migrate your code.",
@@ -184,7 +184,7 @@ class DuplicateReplaceException(ClientException):
         """Initialize a :class:`.DuplicateReplaceException` instance."""
         super().__init__(
             "A duplicate comment has been detected. Are you attempting to call"
-            " ``replace_more_comments`` more than once?"
+            " 'replace_more_comments' more than once?"
         )
 
 
@@ -194,8 +194,8 @@ class InvalidFlairTemplateID(ClientException):
     def __init__(self, template_id: str):
         """Initialize an :class:`.InvalidFlairTemplateID` instance."""
         super().__init__(
-            f"The flair template ID ``{template_id}`` is invalid. If you are trying to"
-            " create a flair, please use the ``add`` method."
+            f"The flair template ID '{template_id}' is invalid. If you are trying to"
+            " create a flair, please use the 'add' method."
         )
 
 
@@ -254,9 +254,9 @@ class WebSocketException(ClientException):
 
     @property
     def original_exception(self) -> Exception:
-        """Access the original_exception attribute (now deprecated)."""
+        """Access the ``original_exception`` attribute (now deprecated)."""
         warn(
-            "Accessing the attribute original_exception is deprecated. Please rewrite"
+            "Accessing the attribute 'original_exception' is deprecated. Please rewrite"
             " your code in such a way that this attribute does not need to be used. It"
             " will be removed in PRAW 8.0.",
             category=DeprecationWarning,

--- a/praw/models/helpers.py
+++ b/praw/models/helpers.py
@@ -111,7 +111,7 @@ class DraftHelper(PRAWBase):
 
         """
         if selftext and url:
-            raise TypeError("Exactly one of `selftext` or `url` must be provided.")
+            raise TypeError("Exactly one of 'selftext' or 'url' must be provided.")
         if isinstance(subreddit, str):
             subreddit = self._reddit.subreddit(subreddit)
 
@@ -206,7 +206,7 @@ class LiveHelper(PRAWBase):
         :param resources: Markdown formatted information that is useful for the
             :class:`.LiveThread`.
 
-        :returns: The new :class`.LiveThread` object.
+        :returns: The new :class:`.LiveThread` object.
 
         """
         return self._reddit.post(

--- a/praw/models/list/trophy.py
+++ b/praw/models/list/trophy.py
@@ -5,7 +5,7 @@ from .base import BaseList
 class TrophyList(BaseList):
     """A list of :class:`.Trophy` objects. Works just like a regular list.
 
-    This class is solely used to parse responses from reddit, so end users should not
+    This class is solely used to parse responses from Reddit, so end users should not
     use this class directly.
 
     """

--- a/praw/models/listing/mixins/base.py
+++ b/praw/models/listing/mixins/base.py
@@ -20,8 +20,10 @@ class BaseListingMixin(PRAWBase):
 
         """
         if time_filter not in BaseListingMixin.VALID_TIME_FILTERS:
-            valid_time_filters = ", ".join(BaseListingMixin.VALID_TIME_FILTERS)
-            raise ValueError(f"time_filter must be one of: {valid_time_filters}")
+            valid_time_filters = ", ".join(
+                map("{!r}".format, BaseListingMixin.VALID_TIME_FILTERS)
+            )
+            raise ValueError(f"'time_filter' must be one of: {valid_time_filters}")
 
     def _prepare(self, *, arguments, sort):
         """Fix for :class:`.Redditor` methods that use a query param rather than subpath."""

--- a/praw/models/mod_notes.py
+++ b/praw/models/mod_notes.py
@@ -160,14 +160,14 @@ class BaseModNotes:
             redditor = getattr(self, "redditor", redditor) or thing.author
             subreddit = getattr(self, "subreddit", subreddit) or thing.subreddit
         redditor = self._ensure_attribute(
-            "Either the `redditor` or `thing` parameters must be provided or this"
-            " method must be called from a Redditor instance (e.g., `redditor.notes`).",
+            "Either the 'redditor' or 'thing' parameters must be provided or this"
+            " method must be called from a Redditor instance (e.g., 'redditor.notes').",
             redditor=redditor,
         )
         subreddit = self._ensure_attribute(
-            "Either the `subreddit` or `thing` parameters must be provided or this"
+            "Either the 'subreddit' or 'thing' parameters must be provided or this"
             " method must be called from a Subreddit instance (e.g.,"
-            " `subreddit.mod.notes`).",
+            " 'subreddit.mod.notes').",
             subreddit=subreddit,
         )
         data = {
@@ -249,17 +249,17 @@ class BaseModNotes:
 
         """
         redditor = self._ensure_attribute(
-            "Either the `redditor` parameter must be provided or this method must be called"
-            " from a Redditor instance (e.g., `redditor.notes`).",
+            "Either the 'redditor' parameter must be provided or this method must be"
+            " called from a Redditor instance (e.g., 'redditor.notes').",
             redditor=redditor,
         )
         subreddit = self._ensure_attribute(
-            "Either the `subreddit` parameter must be provided or this method must be called"
-            " from a Subreddit instance (e.g., `subreddit.mod.notes`).",
+            "Either the 'subreddit' parameter must be provided or this method must be"
+            " called from a Subreddit instance (e.g., 'subreddit.mod.notes').",
             subreddit=subreddit,
         )
         if not delete_all and note_id is None:
-            raise TypeError("Either `note_id` or `delete_all` must be provided.")
+            raise TypeError("Either 'note_id' or 'delete_all' must be provided.")
         if delete_all:
             for note in self._notes(True, [redditor], [subreddit]):
                 note.delete()
@@ -413,7 +413,7 @@ class RedditModNotes(BaseModNotes):
             things = []
         if not (pairs + redditors + subreddits + things):
             raise TypeError(
-                "Either the `pairs`, `redditors`, `subreddits`, or `things` parameters"
+                "Either the 'pairs', 'redditors', 'subreddits', or 'things' parameters"
                 " must be provided."
             )
         if (
@@ -421,9 +421,9 @@ class RedditModNotes(BaseModNotes):
             and len(redditors) + len(subreddits) > 0
         ):
             raise TypeError(
-                "`redditors` must be non-empty if `subreddits` is not empty."
+                "'redditors' must be non-empty if 'subreddits' is not empty."
                 if len(subreddits) > 0
-                else "`subreddits` must be non-empty if `redditors` is not empty."
+                else "'subreddits' must be non-empty if 'redditors' is not empty."
             )
 
         merged_redditors = []

--- a/praw/models/reddit/collections.py
+++ b/praw/models/reddit/collections.py
@@ -304,7 +304,8 @@ class Collection(RedditBase):
         """
         if (_data, collection_id, permalink).count(None) != 2:
             raise TypeError(
-                "Exactly one of _data, collection_id, or permalink must be provided."
+                "Exactly one of '_data', 'collection_id', or 'permalink' must be"
+                " provided."
             )
 
         if permalink:
@@ -553,7 +554,7 @@ class SubredditCollections(PRAWBase):
         """
         if (collection_id is None) == (permalink is None):
             raise TypeError(
-                "Exactly one of collection_id or permalink must be provided."
+                "Exactly one of 'collection_id' or 'permalink' must be provided."
             )
         return Collection(
             self._reddit, collection_id=collection_id, permalink=permalink

--- a/praw/models/reddit/comment.py
+++ b/praw/models/reddit/comment.py
@@ -149,7 +149,7 @@ class Comment(InboxableMixin, UserContentMixin, FullnameMixin, RedditBase):
     ):
         """Initialize a :class:`.Comment` instance."""
         if (id, url, _data).count(None) != 2:
-            raise TypeError("Exactly one of `id`, `url`, or `_data` must be provided.")
+            raise TypeError("Exactly one of 'id', 'url', or '_data' must be provided.")
         fetched = False
         self._replies = []
         self._submission = None
@@ -223,7 +223,7 @@ class Comment(InboxableMixin, UserContentMixin, FullnameMixin, RedditBase):
 
             comment = reddit.comment("cklhv0f")
             parent = comment.parent()
-            # `replies` is empty until the comment is refreshed
+            # 'replies' is empty until the comment is refreshed
             print(parent.replies)  # Output: []
             parent.refresh()
             print(parent.replies)  # Output is at least: [Comment(id="cklhv0f")]

--- a/praw/models/reddit/draft.py
+++ b/praw/models/reddit/draft.py
@@ -92,7 +92,7 @@ class Draft(RedditBase):
     ):
         """Initialize a :class:`.Draft` instance."""
         if (id, _data).count(None) != 1:
-            raise TypeError("Exactly one of `id` or `_data` must be provided.")
+            raise TypeError("Exactly one of 'id' or '_data' must be provided.")
         fetched = False
         if id:
             self.id = id
@@ -286,7 +286,8 @@ class Draft(RedditBase):
         submit_kwargs["draft_id"] = self.id
         if not (self.subreddit or subreddit):
             raise ValueError(
-                "`subreddit` must be set on the Draft or passed as a keyword argument."
+                "'subreddit' must be set on the Draft instance or passed as a keyword"
+                " argument."
             )
         for key, attribute in [
             ("flair_id", flair_id),

--- a/praw/models/reddit/live.py
+++ b/praw/models/reddit/live.py
@@ -393,7 +393,7 @@ class LiveThread(RedditBase):
 
         """
         if (id, _data).count(None) != 1:
-            raise TypeError("Either `id` or `_data` must be provided.")
+            raise TypeError("Either 'id' or '_data' must be provided.")
         if id:
             self.id = id
         super().__init__(reddit, _data=_data)
@@ -567,7 +567,7 @@ class LiveThreadContribution:
 
             thread = reddit.live("xyu8kmjvfrww")
 
-            # update `title` and `nsfw`
+            # update 'title' and 'nsfw'
             updated_thread = thread.contrib.update(title=new_title, nsfw=True)
 
         If Reddit introduces new settings, you must specify ``None`` for the setting you
@@ -575,7 +575,7 @@ class LiveThreadContribution:
 
         .. code-block:: python
 
-            # update `nsfw` and maintain new setting `foo`
+            # update 'nsfw' and maintain new setting 'foo'
             thread.contrib.update(nsfw=True, foo=None)
 
         """
@@ -738,7 +738,7 @@ class LiveUpdate(FullnameMixin, RedditBase):
             self._thread = LiveThread(self._reddit, thread_id)
         else:
             raise TypeError(
-                "Either `thread_id` and `update_id`, or `_data` must be provided."
+                "Either 'thread_id' and 'update_id', or '_data' must be provided."
             )
 
     def __setattr__(self, attribute: str, value: Any):

--- a/praw/models/reddit/mixins/gildable.py
+++ b/praw/models/reddit/mixins/gildable.py
@@ -110,7 +110,7 @@ class GildableMixin:
     def gild(self) -> dict:
         """Alias for :meth:`.award` to maintain backwards compatibility."""
         warn(
-            "`.gild` has been renamed to `.award`.",
+            "'.gild' has been renamed to '.award'.",
             category=DeprecationWarning,
             stacklevel=2,
         )

--- a/praw/models/reddit/modmail.py
+++ b/praw/models/reddit/modmail.py
@@ -122,7 +122,7 @@ class ModmailConversation(RedditBase):
 
         """
         if bool(id) == bool(_data):
-            raise TypeError("Either `id` or `_data` must be provided.")
+            raise TypeError("Either 'id' or '_data' must be provided.")
 
         if id:
             self.id = id

--- a/praw/models/reddit/redditor.py
+++ b/praw/models/reddit/redditor.py
@@ -154,7 +154,7 @@ class Redditor(MessageableMixin, RedditorListingMixin, FullnameMixin, RedditBase
         """
         if (name, fullname, _data).count(None) != 2:
             raise TypeError(
-                "Exactly one of `name`, `fullname`, or `_data` must be provided."
+                "Exactly one of 'name', 'fullname', or '_data' must be provided."
             )
         if _data:
             assert (

--- a/praw/models/reddit/removal_reasons.py
+++ b/praw/models/reddit/removal_reasons.py
@@ -39,10 +39,10 @@ class RemovalReason(RedditBase):
         """
         if reason_id_value is not None:
             warn(
-                "Parameter ``reason_id`` is deprecated. Either use positional"
-                ' arguments (reason_id="x" -> "x") or change the parameter '
-                'name to ``id`` (reason_id="x" -> id="x"). The parameter will'
-                " be removed in PRAW 8.",
+                "Parameter 'reason_id' is deprecated. Either use positional arguments"
+                ' (e.g., reason_id="x" -> "x") or change the parameter name to \'id\''
+                ' (e.g., reason_id="x" -> id="x"). This parameter will be removed in'
+                " PRAW 8.",
                 category=DeprecationWarning,
                 stacklevel=3,
             )

--- a/praw/models/reddit/rules.py
+++ b/praw/models/reddit/rules.py
@@ -203,7 +203,7 @@ class SubredditRules:
             also use slices, to get a subset of rules, such as the last three rules with
             ``rules[-3:]``.
 
-        For example, to fetch the second rule of ``AskReddit``:
+        For example, to fetch the second rule of r/test:
 
         .. code-block:: python
 

--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -574,7 +574,7 @@ class Submission(SubmissionListingMixin, UserContentMixin, FullnameMixin, Reddit
 
         """
         if (id, url, _data).count(None) != 2:
-            raise TypeError("Exactly one of `id`, `url`, or `_data` must be provided.")
+            raise TypeError("Exactly one of 'id', 'url', or '_data' must be provided.")
         self.comment_limit = 2048
 
         # Specify the sort order for ``comments``

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -554,7 +554,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
 
         """
         if (display_name, _data).count(None) != 1:
-            raise TypeError("Either `display_name` or `_data` must be provided.")
+            raise TypeError("Either 'display_name' or '_data' must be provided.")
         if display_name:
             self.display_name = display_name
         super().__init__(reddit, _data=_data)
@@ -601,7 +601,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
     def _submit_media(
         self, *, data: Dict[Any, Any], timeout: int, websocket_url: Optional[str] = None
     ):
-        """Submit and return an `image`, `video`, or `videogif`.
+        """Submit and return an ``image``, ``video``, or ``videogif``.
 
         This is a helper method for submitting posts that are not link posts or self
         posts.
@@ -988,7 +988,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
 
         """
         if (bool(selftext) or selftext == "") == bool(url):
-            raise TypeError("Either `selftext` or `url` must be provided.")
+            raise TypeError("Either 'selftext' or 'url' must be provided.")
 
         data = {
             "sr": str(self),
@@ -1830,8 +1830,8 @@ class SubredditFlair:
         """
         if css_class and flair_template_id is not None:
             raise TypeError(
-                "Parameter `css_class` cannot be used in conjunction with"
-                " `flair_template_id`."
+                "Parameter 'css_class' cannot be used in conjunction with"
+                " 'flair_template_id'."
             )
         data = {"name": str(redditor), "text": text}
         if flair_template_id is not None:
@@ -3534,7 +3534,7 @@ class Modmail:
         params = {}
         if after:
             warn(
-                "The `after` argument is deprecated and should be moved to the `params`"
+                "The 'after' argument is deprecated and should be moved to the 'params'"
                 " dictionary argument.",
                 category=DeprecationWarning,
                 stacklevel=3,
@@ -3993,7 +3993,7 @@ class SubredditStylesheet:
         if align is not None:
             if align not in {"left", "centered", "right"}:
                 raise ValueError(
-                    "align argument must be either `left`, `centered`, or `right`"
+                    "'align' argument must be either 'left', 'centered', or 'right'"
                 )
             alignment["bannerPositionedImagePosition"] = align
 

--- a/praw/models/reddit/user_subreddit.py
+++ b/praw/models/reddit/user_subreddit.py
@@ -82,9 +82,9 @@ class UserSubreddit(Subreddit):
 
         def wrapper(*args, **kwargs):
             warn(
-                "`Redditor.subreddit` is no longer a dict and is now an `UserSubreddit`"
-                f" object. Using `{func.__name__}` is deprecated and will be removed in PRAW"
-                " 8.",
+                "'Redditor.subreddit' is no longer a dict and is now an UserSubreddit"
+                f" object. Using '{func.__name__}' is deprecated and will be removed in"
+                " PRAW 8.",
                 category=DeprecationWarning,
                 stacklevel=2,
             )
@@ -106,9 +106,9 @@ class UserSubreddit(Subreddit):
         return UserSubredditModeration(self)
 
     def __getitem__(self, item):
-        """Show deprecation notice for dict method `__getitem__`."""
+        """Show deprecation notice for dict method ``__getitem__``."""
         warn(
-            "`Redditor.subreddit` is no longer a dict and is now an `UserSubreddit`"
+            "'Redditor.subreddit' is no longer a dict and is now an UserSubreddit"
             " object. Accessing attributes using string indices is deprecated.",
             category=DeprecationWarning,
             stacklevel=2,

--- a/praw/models/reddit/widgets.py
+++ b/praw/models/reddit/widgets.py
@@ -330,7 +330,7 @@ class SubredditWidgets(PRAWBase):
         self._fetch()
 
     def __getattr__(self, attribute: str) -> Any:
-        """Return the value of `attr`."""
+        """Return the value of ``attr``."""
         if not attribute.startswith("_") and not self._fetched:
             self._fetch()
             return getattr(self, attribute)

--- a/praw/models/subreddits.py
+++ b/praw/models/subreddits.py
@@ -36,7 +36,7 @@ class Subreddits(PRAWBase):
     def gold(self, **generator_kwargs) -> Iterator["praw.models.Subreddit"]:
         """Alias for :meth:`.premium` to maintain backwards compatibility."""
         warn(
-            "`subreddits.gold` has be renamed to `subreddits.premium`.",
+            "'subreddits.gold' has be renamed to 'subreddits.premium'.",
             category=DeprecationWarning,
             stacklevel=2,
         )

--- a/praw/models/user.py
+++ b/praw/models/user.py
@@ -156,8 +156,8 @@ class User(PRAWBase):
         if self._reddit.read_only:
             if not self._reddit.config.custom.get("praw8_raise_exception_on_me"):
                 warn(
-                    "The `None` return value is deprecated, and will raise a"
-                    " `ReadOnlyException` beginning with PRAW 8. See documentation for"
+                    "The 'None' return value is deprecated, and will raise a"
+                    " ReadOnlyException beginning with PRAW 8. See documentation for"
                     " forward compatibility options.",
                     category=DeprecationWarning,
                     stacklevel=2,

--- a/praw/reddit.py
+++ b/praw/reddit.py
@@ -250,7 +250,7 @@ class Reddit:
 
         required_message = (
             "Required configuration setting {!r} missing. \nThis setting can be"
-            " provided in a praw.ini file, as a keyword argument to the `Reddit` class"
+            " provided in a praw.ini file, as a keyword argument to the Reddit class"
             " constructor, or as an environment variable."
         )
         for attribute in ("client_id", "user_agent"):
@@ -262,7 +262,7 @@ class Reddit:
             raise MissingRequiredAttributeException(
                 f"{required_message.format('client_secret')}\nFor installed"
                 " applications this value must be set to None via a keyword argument"
-                " to the `Reddit` class constructor."
+                " to the Reddit class constructor."
             )
 
         self._check_for_update()
@@ -481,8 +481,8 @@ class Reddit:
             )
             if self.config.refresh_token:
                 raise TypeError(
-                    "``refresh_token`` setting cannot be provided when providing"
-                    " ``token_manager``"
+                    "'refresh_token' setting cannot be provided when providing"
+                    " 'token_manager'"
                 )
 
             self._token_manager.reddit = self
@@ -674,7 +674,7 @@ class Reddit:
         none_count = (fullnames, url, subreddits).count(None)
         if none_count != 2:
             raise TypeError(
-                "Either `fullnames`, `url`, or `subreddits` must be provided."
+                "Either 'fullnames', 'url', or 'subreddits' must be provided."
             )
 
         is_using_fullnames = fullnames is not None
@@ -683,7 +683,7 @@ class Reddit:
         if ids_or_names is not None:
             if isinstance(ids_or_names, str):
                 raise TypeError(
-                    "`fullnames` and `subreddits` must be a non-str iterable."
+                    "'fullnames' and 'subreddits' must be a non-str iterable."
                 )
 
             api_parameter_name = "id" if is_using_fullnames else "sr_name"
@@ -936,7 +936,7 @@ class Reddit:
         if self.config.check_for_async:
             self._check_for_async()
         if data and json:
-            raise ClientException("At most one of `data` or `json` is supported.")
+            raise ClientException("At most one of 'data' or 'json' is supported.")
         try:
             return self._core.request(
                 data=data,

--- a/praw/util/cache.py
+++ b/praw/util/cache.py
@@ -5,15 +5,15 @@ from typing import Any, Callable, Optional
 class cachedproperty:
     """A decorator for caching a property's result.
 
-    Similar to `property`, but the wrapped method's result is cached on the instance.
-    This is achieved by setting an entry in the object's instance dictionary with the
-    same name as the property. When the name is later accessed, the value in the
-    instance dictionary takes precedence over the (non-data descriptor) property.
+    Similar to :py:class:`property`, but the wrapped method's result is cached on the
+    instance. This is achieved by setting an entry in the object's instance dictionary
+    with the same name as the property. When the name is later accessed, the value in
+    the instance dictionary takes precedence over the (non-data descriptor) property.
 
     This is useful for implementing lazy-loaded properties.
 
-    The cache can be invalidated via `delattr()`, or by modifying `__dict__` directly.
-    It will be repopulated on next access.
+    The cache can be invalidated via :py:meth:`delattr`, or by modifying ``__dict__``
+    directly. It will be repopulated on next access.
 
     .. versionadded:: 6.3.0
 

--- a/praw/util/snake.py
+++ b/praw/util/snake.py
@@ -7,7 +7,7 @@ _re_camel_to_snake = re.compile(r"([a-z0-9](?=[A-Z])|[A-Z](?=[A-Z][a-z]))")
 
 
 def camel_to_snake(name: str) -> str:
-    """Convert `name` from camelCase to snake_case."""
+    """Convert ``name`` from camelCase to snake_case."""
     return _re_camel_to_snake.sub(r"\1_", name).lower()
 
 

--- a/praw/util/token_manager.py
+++ b/praw/util/token_manager.py
@@ -32,7 +32,7 @@ class BaseTokenManager(ABC):
     def reddit(self, value):
         if self._reddit is not None:
             raise RuntimeError(
-                "``reddit`` can only be set once and is done automatically"
+                "'reddit' can only be set once and is done automatically"
             )
         self._reddit = value
 

--- a/setup.py
+++ b/setup.py
@@ -49,7 +49,7 @@ setup(
         "Topic :: Utilities",
     ],
     description=(
-        "PRAW, an acronym for `Python Reddit API Wrapper`, is a python package that"
+        'PRAW, an acronym for "Python Reddit API Wrapper", is a python package that'
         " allows for simple access to  Reddit's API."
     ),
     extras_require=extras,

--- a/tests/unit/models/reddit/test_comment.py
+++ b/tests/unit/models/reddit/test_comment.py
@@ -27,7 +27,7 @@ class TestComment(UnitTest):
         assert comment2 == "dummy1"
 
     def test_construct_failure(self):
-        message = "Exactly one of `id`, `url`, or `_data` must be provided."
+        message = "Exactly one of 'id', 'url', or '_data' must be provided."
         with pytest.raises(TypeError) as excinfo:
             Comment(self.reddit)
         assert str(excinfo.value) == message

--- a/tests/unit/models/reddit/test_draft.py
+++ b/tests/unit/models/reddit/test_draft.py
@@ -9,7 +9,7 @@ from ... import UnitTest
 
 class TestDraft(UnitTest):
     def test_construct_failure(self):
-        message = "Exactly one of `id` or `_data` must be provided."
+        message = "Exactly one of 'id' or '_data' must be provided."
         with pytest.raises(TypeError) as excinfo:
             Draft(self.reddit)
         assert str(excinfo.value) == message
@@ -26,7 +26,7 @@ class TestDraft(UnitTest):
         with pytest.raises(TypeError) as excinfo:
             self.reddit.drafts.create(url="url", selftext="selftext")
         assert (
-            str(excinfo.value) == "Exactly one of `selftext` or `url` must be provided."
+            str(excinfo.value) == "Exactly one of 'selftext' or 'url' must be provided."
         )
 
     def test_equality(self):
@@ -134,5 +134,5 @@ class TestDraft(UnitTest):
             draft.submit()
             assert (
                 str(excinfo.value)
-                == "`subreddit` must be set on the Draft or passed as a keyword argument."
+                == "'subreddit' must be set on the Draft or passed as a keyword argument."
             )

--- a/tests/unit/models/reddit/test_live.py
+++ b/tests/unit/models/reddit/test_live.py
@@ -26,7 +26,7 @@ class TestLiveThread(UnitTest):
         assert thread.id == thread_id
 
     def test_construct_failure(self):
-        message = "Either `id` or `_data` must be provided."
+        message = "Either 'id' or '_data' must be provided."
         with pytest.raises(TypeError) as excinfo:
             LiveThread(self.reddit)
         assert str(excinfo.value) == message
@@ -126,7 +126,7 @@ class TestLiveUpdate(UnitTest):
         assert update._fetched
 
     def test_construct_failure(self):
-        message = "Either `thread_id` and `update_id`, or `_data` must be provided."
+        message = "Either 'thread_id' and 'update_id', or '_data' must be provided."
         thread_id = "dummy_thread_id"
         update_id = "dummy_update_id"
 

--- a/tests/unit/models/reddit/test_modmail.py
+++ b/tests/unit/models/reddit/test_modmail.py
@@ -7,7 +7,7 @@ from ... import UnitTest
 
 class TestModmailConversation(UnitTest):
     def test_construct_failure(self):
-        message = "Either `id` or `_data` must be provided."
+        message = "Either 'id' or '_data' must be provided."
         with pytest.raises(TypeError) as excinfo:
             ModmailConversation(self.reddit)
         assert str(excinfo.value) == message

--- a/tests/unit/models/reddit/test_redditor.py
+++ b/tests/unit/models/reddit/test_redditor.py
@@ -22,7 +22,7 @@ class TestRedditor(UnitTest):
         assert redditor2 == "dummy1"
 
     def test_construct_failure(self):
-        message = "Exactly one of `name`, `fullname`, or `_data` must be provided."
+        message = "Exactly one of 'name', 'fullname', or '_data' must be provided."
         with pytest.raises(TypeError) as excinfo:
             Redditor(self.reddit)
         assert str(excinfo.value) == message

--- a/tests/unit/models/reddit/test_submission.py
+++ b/tests/unit/models/reddit/test_submission.py
@@ -23,7 +23,7 @@ class TestSubmission(UnitTest):
         assert submission2 == "dummy1"
 
     def test_construct_failure(self):
-        message = "Exactly one of `id`, `url`, or `_data` must be provided."
+        message = "Exactly one of 'id', 'url', or '_data' must be provided."
         with pytest.raises(TypeError) as excinfo:
             Submission(self.reddit)
         assert str(excinfo.value) == message

--- a/tests/unit/models/reddit/test_subreddit.py
+++ b/tests/unit/models/reddit/test_subreddit.py
@@ -26,7 +26,7 @@ class TestSubreddit(UnitTest):
         assert subreddit2 == "dummy1"
 
     def test_construct_failure(self):
-        message = "Either `display_name` or `_data` must be provided."
+        message = "Either 'display_name' or '_data' must be provided."
         with pytest.raises(TypeError) as excinfo:
             Subreddit(self.reddit)
         assert str(excinfo.value) == message
@@ -99,8 +99,8 @@ class TestSubreddit(UnitTest):
         with pytest.raises(TypeError) as excinfo:
             self.reddit.subreddit("SubTestBot1").mod.notes.delete(note_id="111")
         assert excinfo.value.args[0] == (
-            "Either the `redditor` parameter must be provided or this method must be"
-            " called from a Redditor instance (e.g., `redditor.notes`)."
+            "Either the 'redditor' parameter must be provided or this method must be"
+            " called from a Redditor instance (e.g., 'redditor.notes')."
         )
 
     def test_pickle(self):
@@ -129,7 +129,7 @@ class TestSubreddit(UnitTest):
         assert str(subreddit) == "name"
 
     def test_submit_failure(self):
-        message = "Either `selftext` or `url` must be provided."
+        message = "Either 'selftext' or 'url' must be provided."
         subreddit = Subreddit(self.reddit, display_name="name")
 
         with pytest.raises(TypeError) as excinfo:

--- a/tests/unit/models/test_mod_notes.py
+++ b/tests/unit/models/test_mod_notes.py
@@ -18,7 +18,7 @@ class TestBaseModNotes(UnitTest):
             self.reddit.subreddit("a").mod.notes.delete(redditor="redditor")
         assert (
             excinfo.value.args[0]
-            == "Either `note_id` or `delete_all` must be provided."
+            == "Either 'note_id' or 'delete_all' must be provided."
         )
 
 
@@ -36,7 +36,7 @@ class TestRedditModNotes(UnitTest):
             self.reddit.notes()
         assert (
             excinfo.value.args[0]
-            == "Either the `pairs`, `redditors`, `subreddits`, or `things` parameters must be provided."
+            == "Either the 'pairs', 'redditors', 'subreddits', or 'things' parameters must be provided."
         )
 
     def test__call__redditors_missing_subreddits(self):
@@ -44,7 +44,7 @@ class TestRedditModNotes(UnitTest):
             self.reddit.notes(subreddits=[1])
         assert (
             excinfo.value.args[0]
-            == "`redditors` must be non-empty if `subreddits` is not empty."
+            == "'redditors' must be non-empty if 'subreddits' is not empty."
         )
 
 

--- a/tests/unit/test_deprecations.py
+++ b/tests/unit/test_deprecations.py
@@ -28,14 +28,14 @@ class TestDeprecation(UnitTest):
     def test_gild_method(self):
         with pytest.raises(DeprecationWarning) as excinfo:
             self.reddit.submission("1234").gild()
-            assert excinfo.value.args[0] == "`.gild` has been renamed to `.award`."
+            assert excinfo.value.args[0] == "'.gild' has been renamed to '.award'."
 
     def test_gold_method(self):
         with pytest.raises(DeprecationWarning) as excinfo:
             self.reddit.subreddits.gold()
             assert (
                 excinfo.value.args[0]
-                == "`subreddits.gold` has be renamed to `subreddits.premium`."
+                == "'subreddits.gold' has be renamed to 'subreddits.premium'."
             )
 
     def test_reddit_token_manager(self):
@@ -67,12 +67,12 @@ class TestDeprecation(UnitTest):
             assert display_name == "test"
             assert (
                 warning_info.list[0].message.args[0]
-                == "`Redditor.subreddit` is no longer a dict and is now an `UserSubreddit` object. Accessing attributes using string indices is deprecated."
+                == "'Redditor.subreddit' is no longer a dict and is now an UserSubreddit object. Accessing attributes using string indices is deprecated."
             )
             assert user_subreddit.keys() == user_subreddit.__dict__.keys()
             assert (
                 warning_info.list[1].message.args[0]
-                == "`Redditor.subreddit` is no longer a dict and is now an `UserSubreddit` object. Using `keys` is deprecated and will be removed in PRAW 8."
+                == "'Redditor.subreddit' is no longer a dict and is now an UserSubreddit object. Using 'keys' is deprecated and will be removed in PRAW 8."
             )
 
     def test_validate_on_submit(self):
@@ -90,5 +90,5 @@ class TestDeprecation(UnitTest):
             _ = exc.original_exception
         assert (
             excinfo.value.args[0]
-            == "Accessing the attribute original_exception is deprecated. Please rewrite your code in such a way that this attribute does not need to be used. It will be removed in PRAW 8.0."
+            == "Accessing the attribute 'original_exception' is deprecated. Please rewrite your code in such a way that this attribute does not need to be used. It will be removed in PRAW 8.0."
         )

--- a/tests/unit/test_exceptions.py
+++ b/tests/unit/test_exceptions.py
@@ -112,7 +112,7 @@ class TestDuplicateReplaceException:
     def test_message(self):
         assert (
             str(DuplicateReplaceException())
-            == "A duplicate comment has been detected. Are you attempting to call ``replace_more_comments`` more than once?"
+            == "A duplicate comment has been detected. Are you attempting to call 'replace_more_comments' more than once?"
         )
 
 
@@ -123,7 +123,7 @@ class TestInvalidFlairTemplateID:
     def test_str(self):
         assert (
             str(InvalidFlairTemplateID("123"))
-            == "The flair template ID ``123`` is invalid. If you are trying to create a flair, please use the ``add`` method."
+            == "The flair template ID '123' is invalid. If you are trying to create a flair, please use the 'add' method."
         )
 
 

--- a/tests/unit/test_reddit.py
+++ b/tests/unit/test_reddit.py
@@ -88,7 +88,7 @@ class TestReddit(UnitTest):
             )
         assert (
             str(excinfo.value)
-            == "``refresh_token`` setting cannot be provided when providing ``token_manager``"
+            == "'refresh_token' setting cannot be provided when providing 'token_manager'"
         )
 
     def test_context_manager(self):
@@ -99,7 +99,7 @@ class TestReddit(UnitTest):
         with pytest.raises(TypeError) as excinfo:
             self.reddit.info(fullnames=None)
 
-        err_str = "Either `fullnames`, `url`, or `subreddits` must be provided."
+        err_str = "Either 'fullnames', 'url', or 'subreddits' must be provided."
         assert str(excinfo.value) == err_str
 
         with pytest.raises(TypeError) as excinfo:
@@ -479,7 +479,7 @@ class TestReddit(UnitTest):
                 data={"key": "value"}, json={"key": "value"}, method="POST", path="/"
             )
         assert str(excinfo.value).startswith(
-            "At most one of `data` or `json` is supported."
+            "At most one of 'data' or 'json' is supported."
         )
 
     def test_submission(self):

--- a/tests/unit/util/test_token_manager.py
+++ b/tests/unit/util/test_token_manager.py
@@ -37,7 +37,7 @@ class TestBaseTokenManager(UnitTest):
             manager.reddit = None
         assert (
             str(excinfo.value)
-            == "``reddit`` can only be set once and is done automatically"
+            == "'reddit' can only be set once and is done automatically"
         )
 
 

--- a/tools/generate_award_table.py
+++ b/tools/generate_award_table.py
@@ -135,8 +135,8 @@ def main():
         choices=["a", "g", "s", "m"],
         default="g",
         help=(
-            "One of ``a`` for all, ``g`` for global, ``s`` for subreddit, or ``m`` for"
-            " moderator. Determines the types of awards to give (default: ``g``)."
+            "One of 'a' for all, 'g' for global, 's' for subreddit, or 'm' for"
+            " moderator. Determines the types of awards to give (default: 'g')."
         ),
     )
     parser.add_argument(
@@ -145,7 +145,7 @@ def main():
         action="store",
         choices=["j", "r"],
         default="r",
-        help="One of ``j`` for json or ``r`` for rst (default: ``r``).",
+        help="One of 'j' for json or 'r' for rst (default: 'r').",
     )
     parser.add_argument(
         "-c",

--- a/tools/static_word_checks.py
+++ b/tools/static_word_checks.py
@@ -43,13 +43,13 @@ class StaticChecker:
             with open(filename, "w") as fp:
                 fp.write(new_content)
             print(
-                f"{filename}: Replaced all instances of ``/r/`` and/or ``/u/`` to"
-                " ``r/`` and/or ``u/``."
+                f"{filename}: Replaced all instances of '/r/' and/or '/u/' to"
+                " 'r/' and/or 'u/'."
             )
             return True
         print(
-            f"{filename}: This file contains instances of ``/r/`` and/or ``/u/``."
-            " Please change them to ``r/`` and/or ``u/``."
+            f"{filename}: This file contains instances of '/r/' and/or '/u/'."
+            " Please change them to 'r/' and/or 'u/'."
         )
         return False
 
@@ -65,8 +65,8 @@ class StaticChecker:
         """
         if "noreturn" in content.lower():
             print(
-                f"{filename}: Line {line_number} has phrase ``noreturn``, please edit"
-                " and remove this."
+                f"{filename}: Line {line_number} has phrase 'noreturn', please edit and"
+                " remove this."
             )
             return False
         return True


### PR DESCRIPTION
## Feature Summary and Justification

This standardizes the usage of `` ` `` vs `'` for quoting literals in strings used for errors, warnings, and stdout messages.
