### PR TITLE
Rename `setup` in tests to `setup_method`

### DIFF
--- a/tests/integration/__init__.py
+++ b/tests/integration/__init__.py
@@ -14,7 +14,7 @@ class IntegrationTest:
 
     logger = logging.getLogger(__name__)
 
-    def setup(self):
+    def setup_method(self):
         """Setup runs before all test cases."""
         self._overrode_reddit_setup = True
         self.setup_reddit()

--- a/tests/integration/models/reddit/test_more.py
+++ b/tests/integration/models/reddit/test_more.py
@@ -4,8 +4,8 @@ from ... import IntegrationTest
 
 
 class TestMore(IntegrationTest):
-    def setup(self):
-        super().setup()
+    def setup_method(self):
+        super().setup_method()
         # Responses do not decode well on travis so manually renable gzip.
         self.reddit._core._requestor._http.headers["Accept-Encoding"] = "gzip"
 

--- a/tests/integration/models/test_comment_forest.py
+++ b/tests/integration/models/test_comment_forest.py
@@ -10,8 +10,8 @@ from .. import IntegrationTest
 
 
 class TestCommentForest(IntegrationTest):
-    def setup(self):
-        super().setup()
+    def setup_method(self):
+        super().setup_method()
         # Responses do not decode well on travis so manually re-enable gzip.
         self.reddit._core._requestor._http.headers["Accept-Encoding"] = "gzip"
 

--- a/tests/unit/__init__.py
+++ b/tests/unit/__init__.py
@@ -5,7 +5,7 @@ from praw import Reddit
 class UnitTest:
     """Base class for PRAW unit tests."""
 
-    def setup(self):
+    def setup_method(self):
         """Setup runs before all test cases."""
         self.reddit = Reddit(
             client_id="dummy", client_secret="dummy", user_agent="dummy"

--- a/tests/unit/models/list/test_base.py
+++ b/tests/unit/models/list/test_base.py
@@ -16,10 +16,10 @@ class Dummy:
 
 
 class TestBaseList:
-    def setup(self):
+    def setup_method(self):
         self._prev_child_attribute = BaseList.CHILD_ATTRIBUTE
 
-    def teardown(self):
+    def teardown_method(self):
         BaseList.CHILD_ATTRIBUTE = self._prev_child_attribute
 
     def test__init__CHILD_ATTRIBUTE_not_set(self):

--- a/tests/unit/util/test_deprecate_args.py
+++ b/tests/unit/util/test_deprecate_args.py
@@ -27,7 +27,7 @@ class ArgTest:
 
 
 class TestDeprecateArgs(UnitTest):
-    def setup(self):
+    def setup_method(self):
         self.arg_test = ArgTest()
 
     def test_arg_test(self):


### PR DESCRIPTION
## Feature Summary and Justification

This fixes a deprecation warning thrown during tests.

## References

- https://docs.pytest.org/en/stable/deprecations.html#support-for-tests-written-for-nose
