### PR TITLE
Revert `EditableMixin.edit` and `ReplyableMixin.reply` positional argument deprecation

### DIFF
--- a/docs/examples/lmgtfy_bot.py
+++ b/docs/examples/lmgtfy_bot.py
@@ -32,7 +32,7 @@ def process_submission(submission):
             url_title = quote_plus(submission.title)
             reply_text = REPLY_TEMPLATE.format(url_title)
             print(f"Replying to: {submission.title}")
-            submission.reply(body=reply_text)
+            submission.reply(reply_text)
             # A reply has been made so do not attempt to match other phrases.
             break
 

--- a/praw/models/reddit/mixins/editable.py
+++ b/praw/models/reddit/mixins/editable.py
@@ -2,7 +2,6 @@
 from typing import TYPE_CHECKING, Union
 
 from ....const import API_PATH
-from ...util import _deprecate_args
 
 if TYPE_CHECKING:  # pragma: no cover
     import praw
@@ -27,10 +26,7 @@ class EditableMixin:
         """
         self._reddit.post(API_PATH["del"], data={"id": self.fullname})
 
-    @_deprecate_args("body")
-    def edit(
-        self, *, body: str
-    ) -> Union["praw.models.Comment", "praw.models.Submission"]:
+    def edit(self, body: str) -> Union["praw.models.Comment", "praw.models.Submission"]:
         """Replace the body of the object with ``body``.
 
         :param body: The Markdown formatted content for the updated object.
@@ -46,7 +42,7 @@ class EditableMixin:
             # construct the text of an edited comment
             # by appending to the old body:
             edited_body = comment.body + "Edit: thanks for the gold!"
-            comment.edit(body=edited_body)
+            comment.edit(edited_body)
 
         """
         data = {

--- a/praw/models/reddit/mixins/replyable.py
+++ b/praw/models/reddit/mixins/replyable.py
@@ -1,8 +1,7 @@
 """Provide the ReplyableMixin class."""
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Union
 
 from ....const import API_PATH
-from ...util import _deprecate_args
 
 if TYPE_CHECKING:  # pragma: no cover
     import praw
@@ -11,14 +10,15 @@ if TYPE_CHECKING:  # pragma: no cover
 class ReplyableMixin:
     """Interface for :class:`.RedditBase` classes that can be replied to."""
 
-    @_deprecate_args("body")
-    def reply(self, *, body: str) -> Optional["praw.models.Comment"]:
+    def reply(
+        self, body: str
+    ) -> Optional[Union["praw.models.Comment", "praw.models.Message"]]:
         """Reply to the object.
 
         :param body: The Markdown formatted content for a comment.
 
-        :returns: A :class:`.Comment` object for the newly created comment or ``None``
-            if Reddit doesn't provide one.
+        :returns: A :class:`.Comment` or :class:`.Message` object for the newly created
+            comment or message or ``None`` if Reddit doesn't provide one.
 
         :raises: ``prawcore.exceptions.Forbidden`` when attempting to reply to some
             items, such as locked submissions/comments or non-replyable messages.

--- a/tests/integration/models/reddit/test_comment.py
+++ b/tests/integration/models/reddit/test_comment.py
@@ -60,7 +60,7 @@ class TestComment(IntegrationTest):
         self.reddit.read_only = False
         with self.use_cassette():
             comment = Comment(self.reddit, "d1616q2")
-            comment.edit(body="New text")
+            comment.edit("New text")
             assert comment.body == "New text"
 
     def test_enable_inbox_replies(self):

--- a/tests/integration/models/reddit/test_comment.py
+++ b/tests/integration/models/reddit/test_comment.py
@@ -232,7 +232,7 @@ class TestComment(IntegrationTest):
         self.reddit.read_only = False
         with self.use_cassette():
             parent_comment = Comment(self.reddit, "d1616q2")
-            comment = parent_comment.reply(body="Comment reply")
+            comment = parent_comment.reply("Comment reply")
             assert comment.author == self.reddit.config.username
             assert comment.body == "Comment reply"
             assert not comment.is_root
@@ -242,7 +242,7 @@ class TestComment(IntegrationTest):
         self.reddit.read_only = False
         comment = Comment(self.reddit, "eear2ml")
         with self.use_cassette():
-            reply = comment.reply(body="TEST")
+            reply = comment.reply("TEST")
         assert reply is None
 
     def test_report(self):

--- a/tests/integration/models/reddit/test_submission.py
+++ b/tests/integration/models/reddit/test_submission.py
@@ -51,7 +51,7 @@ class TestSubmission(IntegrationTest):
         self.reddit.read_only = False
         with self.use_cassette():
             submission = Submission(self.reddit, "4b1tfm")
-            submission.edit(body="New text")
+            submission.edit("New text")
             assert submission.selftext == "New text"
 
     @mock.patch("time.sleep", return_value=None)
@@ -61,7 +61,7 @@ class TestSubmission(IntegrationTest):
         with self.use_cassette():
             submission = Submission(self.reddit, "eippcc")
             with pytest.raises(RedditAPIException):
-                submission.edit(body="rewtwert")
+                submission.edit("rewtwert")
 
     def test_enable_inbox_replies(self):
         self.reddit.read_only = False


### PR DESCRIPTION
## Feature Summary and Justification

After getting feedback from various users, positional arguments for `EditableMixin.edit` and `ReplyableMixin.reply` will no longer be deprecated.