### PR TITLE
Fixed error causing typo

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ instantiate an instance of PRAW like so:
         client_secret="CLIENT_SECRET",
         password="PASSWORD",
         user_agent="USERAGENT",
-        username="USERNAME",
+        username="USERNAME"
     )
 
 With the ``reddit`` instance you can then interact with Reddit:


### PR DESCRIPTION
Just removed a comma that would otherwise cause crashes.
