### PR TITLE
CommentForest: replace_more typing

### DIFF
--- a/praw/models/comment_forest.py
+++ b/praw/models/comment_forest.py
@@ -112,7 +112,7 @@ class CommentForest:
 
     @_deprecate_args("limit", "threshold")
     def replace_more(
-        self, *, limit: int = 32, threshold: int = 0
+        self, *, limit: int | None = 32, threshold: int = 0
     ) -> List["praw.models.MoreComments"]:
         """Update the comment forest by resolving instances of :class:`.MoreComments`.
 

--- a/praw/models/comment_forest.py
+++ b/praw/models/comment_forest.py
@@ -112,7 +112,7 @@ class CommentForest:
 
     @_deprecate_args("limit", "threshold")
     def replace_more(
-        self, *, limit: int | None = 32, threshold: int = 0
+        self, *, limit: Optional[int] = 32, threshold: int = 0
     ) -> List["praw.models.MoreComments"]:
         """Update the comment forest by resolving instances of :class:`.MoreComments`.
 


### PR DESCRIPTION
## Feature Summary and Justification

Just a small change in the CommentForest.replace_more method: limit can be `None`, as per documentation.

A small question: Praw has typing annotation but it's not published annotated, is that intended?