### PR TITLE
Fix removal reason ordering

### DIFF
--- a/praw/models/reddit/removal_reasons.py
+++ b/praw/models/reddit/removal_reasons.py
@@ -150,8 +150,10 @@ class SubredditRemovalReasons:
             API_PATH["removal_reasons_list"].format(subreddit=self.subreddit)
         )
         return [
-            RemovalReason(self._reddit, self.subreddit, _data=reason_data)
-            for id, reason_data in response["data"].items()
+            RemovalReason(
+                self._reddit, self.subreddit, _data=response["data"][reason_id]
+            )
+            for reason_id in response["order"]
         ]
 
     def __getitem__(self, reason_id: Union[str, int, slice]) -> RemovalReason:

--- a/tests/integration/models/reddit/test_removal_reasons.py
+++ b/tests/integration/models/reddit/test_removal_reasons.py
@@ -54,7 +54,7 @@ class TestRemovalReason(IntegrationTest):
     def test_update_empty(self, reddit):
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
-        reason = subreddit.mod.removal_reasons[0]
+        reason = subreddit.mod.removal_reasons[1]
         reason.update()
 
 


### PR DESCRIPTION
Fixes #1924 

## Feature Summary and Justification

A fix for removal reasons being returned in the wrong order.
