### PR TITLE
Revert "Add py.typed stub"

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,5 @@
 include CHANGES.rst LICENSE.txt README.rst
 include praw/praw.ini
-include praw/py.typed
 include "praw/images/PRAW logo.png"
 include docs/Makefile
 recursive-include docs *.png *.py *.rst

--- a/setup.py
+++ b/setup.py
@@ -48,7 +48,6 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Topic :: Utilities",
-        "Typing :: Typed",
     ],
     description=(
         'PRAW, an acronym for "Python Reddit API Wrapper", is a python package that'
@@ -63,10 +62,7 @@ setup(
     keywords="reddit api wrapper",
     license="Simplified BSD License",
     long_description=README,
-    package_data={
-        "": ["LICENSE.txt"],
-        PACKAGE_NAME: ["*.ini", "py.typed", "images/*.png"],
-    },
+    package_data={"": ["LICENSE.txt"], PACKAGE_NAME: ["*.ini", "images/*.png"]},
     packages=find_packages(exclude=["tests", "tests.*", "tools", "tools.*"]),
     project_urls={
         "Change Log": "https://praw.readthedocs.io/en/latest/package_info/change_log.html",
@@ -75,5 +71,4 @@ setup(
         "Source Code": "https://github.com/praw-dev/praw",
     },
     version=VERSION,
-    zip_safe=False,
 )


### PR DESCRIPTION
Reverts praw-dev/praw#1936

Typing improvement are needed to be made to PRAW before this is fully MyPy compatible. Becoming MyPy compatible may also be problematic as PRAW dynamically defines attributes on deserialized objects from Reddit. 

The reason for the dynamically defining attributes is because Reddit is known for adding and removing attributes without notice and it removes the burden of maintaining accurate attributes on every type that PRAW deserializes from Reddit from PRAW.