### PR TITLE
added "public_as_subreddit" type to send_removal_message

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -31,6 +31,7 @@ Documentation Contributors
 - Johanna Rührig `@TheRealVira <https://github.com/TheRealVira>`_
 - Sam Snarr `@sss-ng <https://github.com/sss-ng>`_
 - Moshe Dicker `@dickermoshe <https://github.com/dickermoshe>`_
+- u/gkanor `@gkanor <https://github.com/gkanor>`_
 - Add "Name <email (optional)> and github profile link" above this line.
 
 Logo Creator

--- a/praw/models/reddit/mixins/__init__.py
+++ b/praw/models/reddit/mixins/__init__.py
@@ -206,15 +206,18 @@ class ThingModerationMixin(ModNoteMixin):
 
         Reddit adds human-readable information about the object to the message.
 
-        :param type: One of ``"public"``, ``"private"``, or ``"private_exposed"``.
-            ``"public"`` leaves a stickied comment on the post. ``"private"`` sends a
-            modmail message with hidden username. ``"private_exposed"`` sends a modmail
-            message without hidden username (default: ``"public"``).
+        :param type: One of ``"public"``, ``"public_as_subreddit"``, ``"private"``, or
+            ``"private_exposed"``. ``"public"`` leaves a stickied comment on the post.
+            ``"public_as_subreddit"`` leaves a stickied comment on the post with the
+            u/subreddit-ModTeam account. ``"private"`` sends a modmail message with
+            hidden username. ``"private_exposed"`` sends a modmail message without
+            hidden username (default: ``"public"``).
         :param title: The short reason given in the message. Ignored if type is
-            ``"public"``.
+            ``"public"`` or ``"public_as_subreddit"``.
         :param message: The body of the message.
 
-        :returns: The new :class:`.Comment` if ``type`` is ``"public"``.
+        :returns: The new :class:`.Comment` if ``type`` is ``"public"`` or
+            ``"public_as_subreddit"``.
 
         """
         # The API endpoint used to send removal messages is different for posts and


### PR DESCRIPTION
 for u/subreddit-ModTeam usage

Fixes # (provide issue number if applicable)

## Feature Summary and Justification

Adds documentation for the u/subreddit-ModTeam account removal notification

## References

- 
