### PR TITLE
Fix media upload endpoint

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -17,6 +17,10 @@ Unreleased
 
 - Drop support for Python 3.7, which is end-of-life on 2023-06-27.
 
+**Fixed**
+
+- Fixed upload lease endpoint for media posts.
+
 7.7.1 (2023/07/11)
 ------------------
 

--- a/praw/endpoints.py
+++ b/praw/endpoints.py
@@ -104,7 +104,7 @@ API_PATH = {
     "lock":                    "api/lock/",
     "marknsfw":                "api/marknsfw/",
     "me":                      "api/v1/me",
-    "media_asset":             "api/media/asset.json",
+    "media_asset":             "api/image_upload_s3.json",
     "mentions":                "message/mentions",
     "message":                 "message/messages/{id}/",
     "messages":                "message/messages/",


### PR DESCRIPTION
## Feature Summary and Justification

It seems Reddit changed the endpoint for requesting an s3 lease when uploaded media.