### PR TITLE
Docs: Add more explicit description about the `sendreplies` methods

### DIFF
--- a/praw/models/reddit/mixins/inboxtoggleable.py
+++ b/praw/models/reddit/mixins/inboxtoggleable.py
@@ -8,6 +8,10 @@ class InboxToggleableMixin:
     def disable_inbox_replies(self):
         """Disable inbox replies for the item.
 
+        .. note::
+
+            This can only apply to items created by the authenticated user.
+
         Example usage:
 
         .. code-block:: python
@@ -29,6 +33,10 @@ class InboxToggleableMixin:
 
     def enable_inbox_replies(self):
         """Enable inbox replies for the item.
+
+        .. note::
+
+            This can only apply to items created by the authenticated user.
 
         Example usage:
 


### PR DESCRIPTION
## Feature Summary and Justification

This pull request provides a more explicit description for the `sendreplies` methods, which can only be applied to a thing created by the user.

## References

- https://www.reddit.com/dev/api/#POST_api_sendreplies
