### PR TITLE
Bump prawcore dependency version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
   "Topic :: Utilities"
 ]
 dependencies = [
-  "prawcore >=2.1, <3",
+  "prawcore >=2.4, <3",
   "update_checker >=0.18",
   "websocket-client >=0.54.0"
 ]


### PR DESCRIPTION
## Feature Summary and Justification

This pull request updates pyproject.toml to require a prawcore version 2.4.0 or later. praw 7.8.0 uses the window_core attribute of prawcore.session when initializing an instance of praw.Reddit, which does not exist before version 2.4.0. Although this discrepancy does not cause issues with fresh installs of praw, it may affect users who are upgrading from older version installed before the release of prawcore 2.4.0.

## References

- https://github.com/praw-dev/praw/blob/fdb847e5f0160867b4eb56495fdda0050f13aabd/praw/reddit.py#L553
- https://github.com/praw-dev/prawcore/compare/v2.3.0...v2.4.0#diff-eaadbdb53e986a834aaeaf0846d686305211bcdab6ea8b7a5c99522dd6309190
