### PR TITLE
docs: add `likes` attribute to Comment and Submission model doc comments

### DIFF
--- a/praw/models/reddit/comment.py
+++ b/praw/models/reddit/comment.py
@@ -33,6 +33,9 @@ class Comment(InboxableMixin, UserContentMixin, FullnameMixin, RedditBase):
     ``id``            The ID of the comment.
     ``is_submitter``  Whether or not the comment author is also the author of the
                       submission.
+    ``likes``         The user's current vote status on the comment: ``True`` if
+                      upvoted, ``False`` if downvoted, and ``None`` if not voted or not
+                      logged in.
     ``link_id``       The submission ID that the comment belongs to.
     ``parent_id``     The ID of the parent comment (prefixed with ``t1_``). If it is a
                       top-level comment, this returns the submission ID instead

--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -414,6 +414,9 @@ class Submission(SubmissionListingMixin, UserContentMixin, FullnameMixin, Reddit
     ``is_original_content``    Whether or not the submission has been set as original
                                content.
     ``is_self``                Whether or not the submission is a selfpost (text-only).
+    ``likes``                  The user's current vote status on the submission:
+                               ``True`` if upvoted, ``False`` if downvoted, and ``None``
+                               if not voted or not logged in.
     ``link_flair_template_id`` The link flair's ID.
     ``link_flair_text``        The link flair's text content, or ``None`` if not
                                flaired.


### PR DESCRIPTION
## Feature Summary and Justification

Adds documentation for the `likes` attribute to `praw.models.Submission` and `praw.models.Comment` models.

There's no current open issue for this, although #726 was filed in 2017 that mentioned adding documentation for `Submission.likes` (among many other fields, some of which have been added already by other PRs, but `likes` hasn't). #208 is a related issue filed in 2013 by a user who wasn't yet aware of the `likes` attribute.

## References

- https://github.com/reddit-archive/reddit/wiki/JSON#comment-implements-votable--created
- https://github.com/reddit-archive/reddit/wiki/JSON#link-implements-votable--created
- https://github.com/reddit-archive/reddit/wiki/JSON#votable-implementation
- https://www.reddit.com/r/redditdev/comments/2y26ty/praw_python_what_happened_to_the_likes_attribute/
- https://www.reddit.com/r/redditdev/comments/8bomna/how_to_check_if_a_submission_is_already_upvoted/
- Note: Reddit's current API docs don't mention `likes`, but testing manually shows that it is provided for both `Comment` and `Submission` instances, with its value corresponding to actual vote status as described above