### PR TITLE
Fix duplicate-word typos in docstrings

### DIFF
--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -32,6 +32,7 @@ Documentation Contributors
 - Sam Snarr `@sss-ng <https://github.com/sss-ng>`_
 - Moshe Dicker `@dickermoshe <https://github.com/dickermoshe>`_
 - u/gkanor `@gkanor <https://github.com/gkanor>`_
+- Labib Bin Salam `@Labib-Bin-Salam <https://github.com/Labib-Bin-Salam>`_
 - Add "Name <email (optional)> and github profile link" above this line.
 
 Logo Creator

--- a/praw/models/reddit/redditor.py
+++ b/praw/models/reddit/redditor.py
@@ -312,7 +312,7 @@ class Redditor(MessageableMixin, RedditorListingMixin, FullnameMixin, RedditBase
     def multireddits(self) -> list[models.Multireddit]:
         """Return a list of the redditor's public multireddits.
 
-        For example, to to get :class:`.Redditor` u/spez's multireddits:
+        For example, to get :class:`.Redditor` u/spez's multireddits:
 
         .. code-block:: python
 

--- a/praw/models/reddit/user_subreddit.py
+++ b/praw/models/reddit/user_subreddit.py
@@ -40,7 +40,7 @@ class UserSubreddit(Subreddit):
                               "You must be invited to visit this community" page (if
                               applicable).
     ``spoilers_enabled``      Whether the spoiler tag feature is enabled.
-    ``subscribers``           Count of subscribers. This will be ``0`` unless unless the
+    ``subscribers``           Count of subscribers. This will be ``0`` unless the
                               authenticated user is a moderator.
     ``user_is_banned``        Whether the authenticated user is banned.
     ``user_is_moderator``     Whether the authenticated user is a moderator.


### PR DESCRIPTION
## Summary

Two public API docstrings contain accidental repeated words. This fixes both:

- `Redditor.multireddits` — "For example, **to to** get ..." → "For example, **to** get ..." (`praw/models/reddit/redditor.py`)
- `UserSubreddit` `subscribers` attribute — "Count of subscribers. This will be `0` **unless unless** the authenticated user is a moderator." → "... `0` **unless** the ..." (`praw/models/reddit/user_subreddit.py`)

Both strings render in the published API documentation, so the typos are user-visible.

## Changes

- Fix the two duplicate-word typos.
- Add myself to the **Documentation Contributors** list in `AUTHORS.rst` (per the contributing guide, for a first contribution).

No `CHANGES.rst` entry, as this is a documentation-only fix with no behavioral change.

## Verification

- `ruff check` passes on both edited files.
- The `user_subreddit.py` edit keeps the RST simple-table wrapping intact (the description column is 58 chars wide; the edited line is well within it and the following word still wraps to the next line), so `docstrfmt` reformats nothing.