### PR TITLE
Fix docstrfmt pre-commit hook failing under click >= 8.2

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,11 @@ repos:
   - repo: https://github.com/LilSpazJoekp/docstrfmt
     hooks:
       - id: docstrfmt
+        # docstrfmt 2.0.2's CLI is incompatible with click >= 8.2, which raises
+        # "TypeError: main() missing 1 required positional argument:
+        # 'section_adornments'" before any file is processed. Pin click until
+        # docstrfmt ships a compatible release.
+        additional_dependencies: ["click<8.2"]
     rev: v2.0.2
 
   - repo: https://github.com/MarcoGorelli/auto-walrus


### PR DESCRIPTION
## Problem

The `docstrfmt` lint hook currently fails on every PR/CI run (the last green `main` CI run was 2026-04-27). It crashes during CLI argument parsing, **before any file is read**:

```
TypeError: main() missing 1 required positional argument: 'section_adornments'
```

`docstrfmt` 2.0.2 (the latest release, pinned here) is incompatible with `click >= 8.2`. CI runners now install `click >= 8.2` by default, so the hook env picks it up and the crash is content-independent — it affects all branches and PRs regardless of their changes.

## Fix

Pin `click < 8.2` via `additional_dependencies` on the `docstrfmt` hook until `docstrfmt` ships a release compatible with newer `click`.

## Verification

```
$ pre-commit run docstrfmt --all-files
[INFO] Installing environment for https://github.com/LilSpazJoekp/docstrfmt.
docstrfmt................................................................Passed
```

Reproduced the crash with `click 8.4.x`, and confirmed it disappears with `click 8.1.x`, where `docstrfmt` formats the codebase cleanly.