### PR TITLE
Constrain click<8.4 in docstrfmt hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,6 +27,7 @@ repos:
   - repo: https://github.com/LilSpazJoekp/docstrfmt
     hooks:
       - id: docstrfmt
+        additional_dependencies: [click<8.4]
     rev: v2.0.2
 
   - repo: https://github.com/MarcoGorelli/auto-walrus


### PR DESCRIPTION
CI lint has been failing since 2026-06-03 (first run after click 8.4.0 reached the pre-commit hook env):

```
TypeError: main() missing 1 required positional argument: 'section_adornments'
```

**Cause:** click 8.4.0 changed context internals that docstrfmt v2.0.2's `_parse_pyproject_config`/`_validate_adornments` callbacks rely on (they pop from and wholesale-replace `context.params`). The crash triggers whenever `[tool.docstrfmt] section-adornments` is set in pyproject.toml — which praw is the only praw-dev repo to do. Bisected: click 8.3.0 ✅ → 8.4.0 ❌. Also reproduces against docstrfmt master, so LilSpazJoekp/docstrfmt#178 doesn't cover this path.

**Fix:** constrain `click<8.4` via `additional_dependencies` in the hook until a fixed docstrfmt release exists, at which point the constraint can be dropped.