### PR TITLE
Bump shared workflows to v1.1.0 with explicit secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,10 @@
 jobs:
   ci:
     name: CI
-    secrets: inherit
-    uses: praw-dev/.github/.github/workflows/ci.yml@f33b50e54733ad51138f0568b95552963d47b4a3 # v1.0.0
+    secrets:
+      NETWORK_TEST_CLIENT_ID: ${{ secrets.NETWORK_TEST_CLIENT_ID }}
+      NETWORK_TEST_CLIENT_SECRET: ${{ secrets.NETWORK_TEST_CLIENT_SECRET }}
+    uses: praw-dev/.github/.github/workflows/ci.yml@16645281204644e9e0e79c3b249b2472dff307a7 # v1.1.0
     with:
       package: praw
 name: CI

--- a/.github/workflows/pre-commit_autoupdate.yml
+++ b/.github/workflows/pre-commit_autoupdate.yml
@@ -1,13 +1,14 @@
 jobs:
   pre-commit_autoupdate:
     name: Update pre-commit hooks
-    secrets: inherit
-    uses: praw-dev/.github/.github/workflows/pre-commit_autoupdate.yml@f33b50e54733ad51138f0568b95552963d47b4a3 # v1.0.0
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+    uses: praw-dev/.github/.github/workflows/pre-commit_autoupdate.yml@16645281204644e9e0e79c3b249b2472dff307a7 # v1.1.0
 name: Update pre-commit hooks
 on:
   schedule:
     - cron: 0 15 * * 1
   workflow_dispatch:
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -1,10 +1,14 @@
 jobs:
   prepare_release:
     name: Prepare Release
-    secrets: inherit
-    uses: praw-dev/.github/.github/workflows/prepare_release.yml@f33b50e54733ad51138f0568b95552963d47b4a3 # v1.0.0
+    secrets:
+      APP_ID: ${{ secrets.APP_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
+    uses: praw-dev/.github/.github/workflows/prepare_release.yml@16645281204644e9e0e79c3b249b2472dff307a7 # v1.1.0
     with:
+      package: praw
       version: ${{ inputs.version }}
+      version_file: const.py
 name: Prepare Release
 on:
   workflow_dispatch:
@@ -14,4 +18,3 @@ on:
         required: true
 permissions:
   contents: read
-  pull-requests: write

--- a/.github/workflows/set_active_docs.yml
+++ b/.github/workflows/set_active_docs.yml
@@ -1,8 +1,9 @@
 jobs:
   set_active_docs:
     name: Set Active Docs
-    secrets: inherit
-    uses: praw-dev/.github/.github/workflows/set_active_docs.yml@f33b50e54733ad51138f0568b95552963d47b4a3 # v1.0.0
+    secrets:
+      READTHEDOCS_TOKEN: ${{ secrets.READTHEDOCS_TOKEN }}
+    uses: praw-dev/.github/.github/workflows/set_active_docs.yml@16645281204644e9e0e79c3b249b2472dff307a7 # v1.1.0
 name: Set Active Docs
 on:
   release:

--- a/.github/workflows/stale_action.yml
+++ b/.github/workflows/stale_action.yml
@@ -1,7 +1,7 @@
 jobs:
   stale_action:
     name: Close stale issues and PRs
-    uses: praw-dev/.github/.github/workflows/stale_action.yml@f33b50e54733ad51138f0568b95552963d47b4a3 # v1.0.0
+    uses: praw-dev/.github/.github/workflows/stale_action.yml@16645281204644e9e0e79c3b249b2472dff307a7 # v1.1.0
 name: Close stale issues and PRs
 on:
   schedule:

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -1,7 +1,7 @@
 jobs:
   tag_release:
     name: Tag Release
-    uses: praw-dev/.github/.github/workflows/tag_release.yml@f33b50e54733ad51138f0568b95552963d47b4a3 # v1.0.0
+    uses: praw-dev/.github/.github/workflows/tag_release.yml@16645281204644e9e0e79c3b249b2472dff307a7 # v1.1.0
 name: Tag Release
 on:
   push:


### PR DESCRIPTION
Companion to praw-dev/.github#10 (merged, tagged v1.1.0) and prawcore#290.

- All six reusable-workflow refs bumped `f33b50e` (v1.0.0) → `1664528` (v1.1.0)
- `secrets: inherit` replaced with explicit `secrets:` blocks (resolves all 4 remaining zizmor `secrets-inherit` findings — zizmor is now clean on this repo)
- pre-commit_autoupdate / prepare_release pass `APP_ID`/`APP_PRIVATE_KEY` for the new scoped GitHub App token, which can create PRs despite the org-wide Actions PR-creation block (fixes the failing autoupdate runs)
- Caller `permissions:` reduced to `contents: read` where the App token now does the writing
- **Bug fix**: the prepare_release caller was missing the required `package` and `version_file` inputs and would have failed on dispatch