### PR TITLE
Consolidate media uploads into Media classes

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,11 @@ praw follows `semantic versioning <https://semver.org/>`_.
 - Add support for Python 3.14.
 - Add support for optional Markdown-formatted ``selftext`` when submitting link, image,
   gallery, and video posts.
+- Add :class:`.Media` and its subclasses :class:`.EmojiMedia`, :class:`.PostMedia`,
+  :class:`.StylesheetAsset`, :class:`.StylesheetImage`, and :class:`.WidgetMedia` to
+  consolidate media uploads. Media can be constructed from a file path, or from
+  ``bytes`` content along with a ``name``, so media no longer has to be written to disk
+  before uploading.
 
 **Changed**
 
@@ -38,6 +43,44 @@ praw follows `semantic versioning <https://semver.org/>`_.
   :meth:`.Subreddit.submit_image` now accept an optional Markdown-formatted ``selftext``
   parameter.
 - The ``reason_id`` argument to :class:`.RemovalReason` has been renamed to ``id``.
+- Media upload methods now accept :class:`.Media` instances instead of file paths:
+
+  - The ``image_path`` argument to :meth:`.SubredditEmoji.add` has been replaced by
+    ``emoji_media``, which takes an :class:`.EmojiMedia` instance.
+  - The ``image_path`` arguments to :meth:`.SubredditStylesheet.upload`,
+    :meth:`.upload_header`, :meth:`.upload_mobile_header`, and
+    :meth:`.upload_mobile_icon` have been replaced by ``image_media``, which takes a
+    :class:`.StylesheetImage` instance.
+  - The ``image_path`` arguments to :meth:`.SubredditStylesheet.upload_banner`,
+    :meth:`.upload_banner_additional_image`, :meth:`.upload_banner_hover_image`, and
+    :meth:`.upload_mobile_banner` have been replaced by ``image_media``, which takes a
+    :class:`.StylesheetAsset` instance.
+  - The ``image_media`` arguments to the :class:`.SubredditStylesheet` ``upload_*``
+    methods, other than :meth:`.SubredditStylesheet.upload`, must be passed
+    positionally.
+  - The ``file_path`` argument to :meth:`.SubredditWidgetsModeration.upload_image` has
+    been replaced by ``image_media``, which takes a :class:`.WidgetMedia` instance and
+    must be passed positionally.
+  - The ``image_path`` argument to :meth:`.Subreddit.submit_image` has been replaced by
+    ``image_media``, which takes a :class:`.PostMedia` instance. All arguments,
+    including ``title``, must now be passed by keyword.
+  - The ``video_path`` and ``thumbnail_path`` arguments to
+    :meth:`.Subreddit.submit_video` have been replaced by ``video_media`` and
+    ``thumbnail_media``, which take :class:`.PostMedia` instances. All arguments,
+    including ``title``, must now be passed by keyword.
+  - The ``image_path`` key in the ``images`` dictionaries passed to
+    :meth:`.Subreddit.submit_gallery` has been replaced by ``image_media``, which takes
+    a :class:`.PostMedia` instance. All arguments, including ``title`` and ``images``,
+    must now be passed by keyword.
+  - The ``path`` argument to :class:`.InlineMedia` (:class:`.InlineGif`,
+    :class:`.InlineImage`, and :class:`.InlineVideo`) has been replaced by ``media``,
+    which takes a :class:`.PostMedia` instance.
+
+- An unknown media type now raises :class:`.ClientException` when uploading media,
+  instead of falling back to JPEG.
+- Media uploads to Reddit's S3 buckets now respect the configured ``timeout`` and raise
+  ``prawcore.RequestException`` on transport errors, consistent with all other requests,
+  instead of having no timeout and raising raw ``requests`` exceptions.
 
 **Fixed**
 

--- a/docs/code_overview/other.rst
+++ b/docs/code_overview/other.rst
@@ -36,6 +36,17 @@ them bound to an attribute of one of the PRAW models.
 
 .. toctree::
     :maxdepth: 2
+    :caption: Media
+
+    other/emojimedia
+    other/media
+    other/postmedia
+    other/stylesheetasset
+    other/stylesheetimage
+    other/widgetmedia
+
+.. toctree::
+    :maxdepth: 2
     :caption: ModNotes
 
     other/base_mod_notes

--- a/docs/code_overview/other/emojimedia.rst
+++ b/docs/code_overview/other/emojimedia.rst
@@ -1,0 +1,6 @@
+############
+ EmojiMedia
+############
+
+.. autoclass:: praw.models.EmojiMedia
+    :inherited-members:

--- a/docs/code_overview/other/media.rst
+++ b/docs/code_overview/other/media.rst
@@ -1,0 +1,6 @@
+#######
+ Media
+#######
+
+.. autoclass:: praw.models.Media
+    :inherited-members:

--- a/docs/code_overview/other/postmedia.rst
+++ b/docs/code_overview/other/postmedia.rst
@@ -1,0 +1,6 @@
+###########
+ PostMedia
+###########
+
+.. autoclass:: praw.models.PostMedia
+    :inherited-members:

--- a/docs/code_overview/other/stylesheetasset.rst
+++ b/docs/code_overview/other/stylesheetasset.rst
@@ -1,0 +1,6 @@
+#################
+ StylesheetAsset
+#################
+
+.. autoclass:: praw.models.StylesheetAsset
+    :inherited-members:

--- a/docs/code_overview/other/stylesheetimage.rst
+++ b/docs/code_overview/other/stylesheetimage.rst
@@ -1,0 +1,6 @@
+#################
+ StylesheetImage
+#################
+
+.. autoclass:: praw.models.StylesheetImage
+    :inherited-members:

--- a/docs/code_overview/other/widgetmedia.rst
+++ b/docs/code_overview/other/widgetmedia.rst
@@ -1,0 +1,6 @@
+#############
+ WidgetMedia
+#############
+
+.. autoclass:: praw.models.WidgetMedia
+    :inherited-members:

--- a/praw/models/__init__.py
+++ b/praw/models/__init__.py
@@ -11,6 +11,7 @@ from praw.models.list.trophy import TrophyList
 from praw.models.listing.domain import DomainListing
 from praw.models.listing.generator import ListingGenerator
 from praw.models.listing.listing import Listing, ModeratorListing, ModmailConversationsListing
+from praw.models.media import EmojiMedia, Media, PostMedia, StylesheetAsset, StylesheetImage, WidgetMedia
 from praw.models.mod_action import ModAction
 from praw.models.mod_note import ModNote
 from praw.models.mod_notes import RedditModNotes, RedditorModNotes, SubredditModNotes

--- a/praw/models/media.py
+++ b/praw/models/media.py
@@ -1,0 +1,263 @@
+"""Provide classes for uploading media to Reddit."""
+
+from __future__ import annotations
+
+import sys
+from functools import cached_property
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, ClassVar
+
+from defusedxml import ElementTree
+from prawcore.exceptions import ServerError
+
+from praw.const import API_PATH, JPEG_HEADER
+from praw.exceptions import ClientException, RedditAPIException, TooLargeMediaException
+
+if sys.version_info >= (3, 13):  # pragma: no cover
+    from mimetypes import guess_file_type
+else:  # pragma: no cover
+    from mimetypes import guess_type as guess_file_type
+
+if TYPE_CHECKING:
+    from requests import Response
+
+    import praw
+    from praw import models
+
+
+class Media:
+    """Base class representing media that can be uploaded to Reddit.
+
+    Use one of the subclasses, e.g., :class:`.EmojiMedia` or :class:`.PostMedia`,
+    depending on what the media is being uploaded for.
+
+    """
+
+    LEASE_API_PATH: ClassVar[str]
+    LEASE_RESPONSE_KEY: ClassVar[str] = "s3UploadLease"
+
+    def __eq__(self, other: object) -> bool:
+        """Return whether the other instance equals the current."""
+        return type(other) is type(self) and self.name == other.name and self._data == other._data
+
+    def __hash__(self) -> int:
+        """Return the hash of the current instance."""
+        return hash((self.__class__.__name__, self.name, self._data))
+
+    def __init__(self, fp: str | bytes, /, name: str | None = None) -> None:
+        """Initialize a :class:`.Media` instance.
+
+        :param fp: The path to a media file as a string, or the content of a media file
+            as a :class:`bytes` object.
+        :param name: The name of the media file, e.g., ``"picture.png"``. The name is
+            used to infer the media's MIME type. When ``fp`` is a path the name is
+            derived from it, otherwise this parameter is required.
+
+        """
+        if isinstance(fp, bytes):
+            if not name:
+                msg = "'name' is required when 'fp' is a bytes object."
+                raise ValueError(msg)
+            data = fp
+        else:
+            path = Path(fp)
+            name = name or path.name
+            data = path.read_bytes()
+        self._data = data
+        self.name = name
+
+    def __repr__(self) -> str:
+        """Return a string representation of the instance."""
+        return f"<{self.__class__.__name__} name={self.name!r}>"
+
+    def _build_lease_data(self, **additional_data: str) -> dict[str, str]:
+        return {"filepath": self.name, "mimetype": self._mime_type, **additional_data}
+
+    def _lease_and_post(self, lease_url: str, reddit: praw.Reddit, /, **additional_lease_data: str) -> tuple[dict[str, Any], dict[str, str], str]:
+        lease_data = self._build_lease_data(**additional_lease_data)
+        lease_response, upload_data, upload_url = self._obtain_lease(lease_data, lease_url, reddit)
+        response = self._post_to_s3(reddit, upload_data, upload_url)
+        if not response.ok:
+            self._raise_upload_error(response)
+        return lease_response, upload_data, upload_url
+
+    @cached_property
+    def _mime_type(self) -> str:
+        mime_type, _ = guess_file_type(self.name)
+        if mime_type is None:
+            msg = f"Unable to determine the MIME type of {self.name!r}."
+            raise ClientException(msg)
+        return mime_type
+
+    def _obtain_lease(self, lease_data: dict[str, str], lease_url: str, reddit: praw.Reddit, /) -> tuple[dict[str, Any], dict[str, str], str]:
+        lease_response = reddit.post(lease_url, data=lease_data)
+        upload_lease = lease_response[self.LEASE_RESPONSE_KEY]
+        upload_data = {item["name"]: item["value"] for item in upload_lease["fields"]}
+        upload_url = f"https:{upload_lease['action']}"
+        return lease_response, upload_data, upload_url
+
+    def _post_to_s3(self, reddit: praw.Reddit, upload_data: dict[str, str], upload_url: str, /) -> Response:
+        return reddit._core._requestor.request(
+            "POST", upload_url, data=upload_data, files={"file": (self.name, self._data)}
+        )
+
+    @staticmethod
+    def _raise_upload_error(response: Response, /) -> None:
+        raise ServerError(response=response)
+
+    def _upload(self, subreddit: models.Subreddit, /, **additional_lease_data: str) -> str:
+        """Upload the media to Reddit.
+
+        :param subreddit: The subreddit the media is associated with.
+        :param additional_lease_data: Additional data to include in the upload lease
+            request.
+
+        :returns: The URL of the uploaded media.
+
+        """
+        lease_url = self.LEASE_API_PATH.format(subreddit=subreddit)
+        _, upload_data, upload_url = self._lease_and_post(lease_url, subreddit._reddit, **additional_lease_data)
+        return f"{upload_url}/{upload_data['key']}"
+
+
+class EmojiMedia(Media):
+    """Media to be uploaded as a subreddit emoji.
+
+    See :meth:`.SubredditEmoji.add`.
+
+    """
+
+    LEASE_API_PATH = API_PATH["emoji_lease"]
+
+    def _upload(self, subreddit: models.Subreddit, /, **additional_lease_data: str) -> str:
+        """Upload the media to Reddit.
+
+        :param subreddit: The subreddit the emoji is associated with.
+        :param additional_lease_data: Additional data to include in the upload lease
+            request.
+
+        :returns: The S3 key of the uploaded media.
+
+        """
+        lease_url = self.LEASE_API_PATH.format(subreddit=subreddit)
+        _, upload_data, _ = self._lease_and_post(lease_url, subreddit._reddit, **additional_lease_data)
+        return upload_data["key"]
+
+
+class PostMedia(Media):
+    """Media to be uploaded as part of a submission.
+
+    See :meth:`.Subreddit.submit_image`, :meth:`.Subreddit.submit_gallery`,
+    :meth:`.Subreddit.submit_video`, and :class:`.InlineMedia`.
+
+    """
+
+    LEASE_API_PATH = API_PATH["media_asset"]
+    LEASE_RESPONSE_KEY = "args"
+
+    @staticmethod
+    def _parse_xml_response(response: Response, /) -> None:
+        """Parse the XML from a response and raise any errors found."""
+        root = ElementTree.fromstring(response.text)
+        tags = [element.tag for element in root]
+        if tags[:4] == ["Code", "Message", "ProposedSize", "MaxSizeAllowed"]:
+            # Returned if media is too big
+            *_, actual, maximum_size = (element.text for element in root[:4])
+            raise TooLargeMediaException(actual=int(actual), maximum_size=int(maximum_size))
+
+    @staticmethod
+    def _raise_upload_error(response: Response, /) -> None:
+        PostMedia._parse_xml_response(response)
+        Media._raise_upload_error(response)
+
+    def _upload(self, reddit: praw.Reddit, /, *, expected_mime_prefix: str | None = None, upload_type: str = "link") -> str:
+        """Upload the media to Reddit (undocumented endpoint).
+
+        Unlike the other :class:`.Media` subclasses, post media is not associated with a
+        subreddit when uploaded, so this method takes a :class:`.Reddit` instance.
+
+        :param reddit: The :class:`.Reddit` instance to upload with.
+        :param expected_mime_prefix: If provided, enforce that the media has a MIME type
+            that starts with the provided prefix.
+        :param upload_type: One of ``"link"``, ``"gallery"``, or ``"selfpost"``
+            (default: ``"link"``).
+
+        :returns: The URL of the uploaded media when ``upload_type`` is ``"link"``,
+            otherwise the media's asset ID.
+
+        """
+        if expected_mime_prefix is not None and self._mime_type.partition("/")[0] != expected_mime_prefix:
+            msg = f"Expected a mimetype starting with {expected_mime_prefix!r} but got mimetype {self._mime_type!r} (from file name {self.name!r})."
+            raise ClientException(msg)
+        lease_response, upload_data, upload_url = self._lease_and_post(self.LEASE_API_PATH, reddit)
+        if upload_type == "link":
+            return f"{upload_url}/{upload_data['key']}"
+        return lease_response["asset"]["asset_id"]
+
+
+class StylesheetAsset(Media):
+    """Media to be uploaded as a subreddit style asset, e.g., a banner.
+
+    See :meth:`.SubredditStylesheet.upload_banner`.
+
+    """
+
+    LEASE_API_PATH = API_PATH["style_asset_lease"]
+
+    def _upload(self, subreddit: models.Subreddit, /, *, image_type: str) -> str:
+        """Upload the media to Reddit.
+
+        :param subreddit: The subreddit the style asset is associated with.
+        :param image_type: The type of style asset, e.g., ``"bannerBackgroundImage"``.
+
+        :returns: The URL of the uploaded media.
+
+        """
+        return super()._upload(subreddit, imagetype=image_type)
+
+
+class StylesheetImage(Media):
+    """Media to be uploaded as a subreddit stylesheet image.
+
+    See :meth:`.SubredditStylesheet.upload`.
+
+    """
+
+    UPLOAD_API_PATH = API_PATH["upload_image"]
+
+    @cached_property
+    def _image_type(self) -> str:
+        return "jpg" if self._data.startswith(JPEG_HEADER) else "png"
+
+    def _upload(self, subreddit: models.Subreddit, /, **additional_data: str) -> dict[str, Any]:
+        """Upload the media to Reddit.
+
+        :param subreddit: The subreddit the stylesheet image is associated with.
+        :param additional_data: Additional data to include in the upload request.
+
+        :returns: A dictionary containing a link to the uploaded image under the key
+            ``img_src``.
+
+        """
+        data = {"img_type": self._image_type, **additional_data}
+        url = self.UPLOAD_API_PATH.format(subreddit=subreddit)
+        response = subreddit._reddit.post(url, data=data, files={"file": (self.name, self._data)})
+        if response["errors"]:
+            error_type = response["errors"][0]
+            error_value = response.get("errors_values", [""])[0]
+            assert error_type in {
+                "BAD_CSS_NAME",
+                "IMAGE_ERROR",
+            }, "Please file a bug with PRAW."
+            raise RedditAPIException([[error_type, error_value, None]])
+        return response
+
+
+class WidgetMedia(Media):
+    """Media to be uploaded for use in a subreddit widget.
+
+    See :meth:`.SubredditWidgetsModeration.upload_image`.
+
+    """
+
+    LEASE_API_PATH = API_PATH["widget_lease"]

--- a/praw/models/reddit/emoji.py
+++ b/praw/models/reddit/emoji.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from praw.const import API_PATH
@@ -181,7 +180,7 @@ class SubredditEmoji:
     def add(
         self,
         *,
-        image_path: str,
+        emoji_media: models.EmojiMedia,
         mod_flair_only: bool | None = None,
         name: str,
         post_flair_allowed: bool | None = None,
@@ -189,7 +188,7 @@ class SubredditEmoji:
     ) -> Emoji:
         """Add an emoji to this subreddit.
 
-        :param image_path: A path to a jpeg or png image.
+        :param emoji_media: The :class:`.EmojiMedia` to be uploaded as an emoji.
         :param mod_flair_only: When provided, indicate whether the emoji is restricted
             to mod use only (default: ``None``).
         :param name: The name of the emoji.
@@ -204,32 +203,19 @@ class SubredditEmoji:
 
         .. code-block:: python
 
-            reddit.subreddit("test").emoji.add(name="emoji", image_path="emoji.png")
+            from praw.models import EmojiMedia
+
+            emoji_media = EmojiMedia("emoji.png")
+            reddit.subreddit("test").emoji.add(emoji_media=emoji_media, name="emoji")
 
         """
-        file = Path(image_path)
-        data = {
-            "filepath": file.name,
-            "mimetype": "image/jpeg",
-        }
-        if image_path.lower().endswith(".png"):
-            data["mimetype"] = "image/png"
-        url = API_PATH["emoji_lease"].format(subreddit=self.subreddit)
-
-        # until we learn otherwise, assume this request always succeeds
-        upload_lease = self._reddit.post(url, data=data)["s3UploadLease"]
-        upload_data = {item["name"]: item["value"] for item in upload_lease["fields"]}
-        upload_url = f"https:{upload_lease['action']}"
-
-        with file.open("rb") as image:
-            response = self._reddit._core._requestor._http.post(upload_url, data=upload_data, files={"file": image})
-        response.raise_for_status()
+        s3_key = emoji_media._upload(self.subreddit)
 
         data = {
             "mod_flair_only": mod_flair_only,
             "name": name,
             "post_flair_allowed": post_flair_allowed,
-            "s3_key": upload_data["key"],
+            "s3_key": s3_key,
             "user_flair_allowed": user_flair_allowed,
         }
         url = API_PATH["emoji_upload"].format(subreddit=self.subreddit)

--- a/praw/models/reddit/inline_media.py
+++ b/praw/models/reddit/inline_media.py
@@ -2,6 +2,11 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from praw import models
+
 
 class InlineMedia:
     """Provides a way to embed media in self posts."""
@@ -10,22 +15,22 @@ class InlineMedia:
 
     def __eq__(self, other: InlineMedia) -> bool:
         """Return whether the other instance equals the current."""
-        return all(getattr(self, attr) == getattr(other, attr) for attr in ["TYPE", "path", "caption", "media_id"])
+        return all(getattr(self, attr) == getattr(other, attr) for attr in ["TYPE", "media", "caption", "media_id"])
 
     def __hash__(self) -> int:
         """Return the hash of the current instance."""
         return hash(self.__class__.__name__) ^ hash(
-            tuple(getattr(self, attr) for attr in ["TYPE", "path", "caption", "media_id"])
+            tuple(getattr(self, attr) for attr in ["TYPE", "media", "caption", "media_id"])
         )
 
-    def __init__(self, *, caption: str | None = None, path: str) -> None:
+    def __init__(self, *, caption: str | None = None, media: models.PostMedia) -> None:
         """Initialize an :class:`.InlineMedia` instance.
 
         :param caption: An optional caption to add to the image (default: ``None``).
-        :param path: The path to a media file.
+        :param media: The :class:`.PostMedia` to embed.
 
         """
-        self.path = path
+        self.media = media
         self.caption = caption
         self.media_id = None
 

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -12,22 +12,18 @@ from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin
 
 import websocket
-from defusedxml import ElementTree
 from prawcore import Redirect
-from prawcore.exceptions import ServerError
-from requests.exceptions import HTTPError
 
-from praw.const import API_PATH, JPEG_HEADER
+from praw.const import API_PATH
 from praw.exceptions import (
-    ClientException,
     InvalidFlairTemplateID,
     MediaPostFailed,
     RedditAPIException,
-    TooLargeMediaException,
     WebSocketException,
 )
 from praw.models.listing.generator import ListingGenerator
 from praw.models.listing.mixins import SubredditListingMixin
+from praw.models.media import PostMedia
 from praw.models.reddit.base import RedditBase
 from praw.models.reddit.emoji import SubredditEmoji
 from praw.models.reddit.mixins import FullnameMixin, MessageableMixin
@@ -41,8 +37,6 @@ from praw.util import cachedproperty
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
-
-    from requests import Response
 
     import praw
     from praw import models
@@ -1509,43 +1503,6 @@ class SubredditStylesheet:
         url = API_PATH["structured_styles"].format(subreddit=self.subreddit)
         self.subreddit._reddit.patch(url, data=style_data)
 
-    def _upload_image(self, *, data: dict[str, str | Any], image_path: str) -> dict[str, Any]:
-        with Path(image_path).open("rb") as image:
-            header = image.read(len(JPEG_HEADER))
-            image.seek(0)
-            data["img_type"] = "jpg" if header == JPEG_HEADER else "png"
-            url = API_PATH["upload_image"].format(subreddit=self.subreddit)
-            response = self.subreddit._reddit.post(url, data=data, files={"file": image})
-            if response["errors"]:
-                error_type = response["errors"][0]
-                error_value = response.get("errors_values", [""])[0]
-                assert error_type in {
-                    "BAD_CSS_NAME",
-                    "IMAGE_ERROR",
-                }, "Please file a bug with PRAW."
-                raise RedditAPIException([[error_type, error_value, None]])
-            return response
-
-    def _upload_style_asset(self, *, image_path: str, image_type: str) -> str:
-        file = Path(image_path)
-        data = {"imagetype": image_type, "filepath": file.name}
-        data["mimetype"] = "image/jpeg"
-        if image_path.lower().endswith(".png"):
-            data["mimetype"] = "image/png"
-        url = API_PATH["style_asset_lease"].format(subreddit=self.subreddit)
-
-        upload_lease = self.subreddit._reddit.post(url, data=data)["s3UploadLease"]
-        upload_data = {item["name"]: item["value"] for item in upload_lease["fields"]}
-        upload_url = f"https:{upload_lease['action']}"
-
-        with file.open("rb") as image:
-            response = self.subreddit._reddit._core._requestor._http.post(
-                upload_url, data=upload_data, files={"file": image}
-            )
-        response.raise_for_status()
-
-        return f"{upload_url}/{upload_data['key']}"
-
     def delete_banner(self) -> None:
         """Remove the current :class:`.Subreddit` (redesign) banner image.
 
@@ -1687,10 +1644,10 @@ class SubredditStylesheet:
         url = API_PATH["subreddit_stylesheet"].format(subreddit=self.subreddit)
         self.subreddit._reddit.post(url, data=data)
 
-    def upload(self, *, image_path: str, name: str) -> dict[str, str]:
+    def upload(self, *, image_media: models.StylesheetImage, name: str) -> dict[str, str]:
         """Upload an image to the :class:`.Subreddit`.
 
-        :param image_path: A path to a jpeg or png image.
+        :param image_media: The :class:`.StylesheetImage` to upload.
         :param name: The name to use for the image. If an image already exists with the
             same name, it will be replaced.
 
@@ -1707,15 +1664,19 @@ class SubredditStylesheet:
 
         .. code-block:: python
 
-            reddit.subreddit("test").stylesheet.upload(name="smile", image_path="img.png")
+            from praw.models import StylesheetImage
+
+            reddit.subreddit("test").stylesheet.upload(
+                image_media=StylesheetImage("img.png"), name="smile"
+            )
 
         """
-        return self._upload_image(data={"name": name, "upload_type": "img"}, image_path=image_path)
+        return image_media._upload(self.subreddit, name=name, upload_type="img")
 
-    def upload_banner(self, image_path: str) -> None:
+    def upload_banner(self, image_media: models.StylesheetAsset, /) -> None:
         """Upload an image for the :class:`.Subreddit`'s (redesign) banner image.
 
-        :param image_path: A path to a jpeg or png image.
+        :param image_media: The :class:`.StylesheetAsset` to upload.
 
         :raises: ``prawcore.TooLarge`` if the overall request body is too large.
         :raises: :class:`.RedditAPIException` if there are other issues with the
@@ -1727,22 +1688,25 @@ class SubredditStylesheet:
 
         .. code-block:: python
 
-            reddit.subreddit("test").stylesheet.upload_banner("banner.png")
+            from praw.models import StylesheetAsset
+
+            reddit.subreddit("test").stylesheet.upload_banner(StylesheetAsset("banner.png"))
 
         """
         image_type = "bannerBackgroundImage"
-        image_url = self._upload_style_asset(image_path=image_path, image_type=image_type)
+        image_url = image_media._upload(self.subreddit, image_type=image_type)
         self._update_structured_styles({image_type: image_url})
 
     def upload_banner_additional_image(
         self,
-        image_path: str,
+        image_media: models.StylesheetAsset,
+        /,
         *,
         align: str | None = None,
     ) -> None:
         """Upload an image for the :class:`.Subreddit`'s (redesign) additional image.
 
-        :param image_path: A path to a jpeg or png image.
+        :param image_media: The :class:`.StylesheetAsset` to upload.
         :param align: Either ``"left"``, ``"centered"``, or ``"right"``. (default:
             ``"left"``).
 
@@ -1756,8 +1720,10 @@ class SubredditStylesheet:
 
         .. code-block:: python
 
+            from praw.models import StylesheetAsset
+
             subreddit = reddit.subreddit("test")
-            subreddit.stylesheet.upload_banner_additional_image("banner.png")
+            subreddit.stylesheet.upload_banner_additional_image(StylesheetAsset("banner.png"))
 
         """
         alignment = {}
@@ -1768,16 +1734,16 @@ class SubredditStylesheet:
             alignment["bannerPositionedImagePosition"] = align
 
         image_type = "bannerPositionedImage"
-        image_url = self._upload_style_asset(image_path=image_path, image_type=image_type)
+        image_url = image_media._upload(self.subreddit, image_type=image_type)
         style_data = {image_type: image_url}
         if alignment:
             style_data.update(alignment)
         self._update_structured_styles(style_data)
 
-    def upload_banner_hover_image(self, image_path: str) -> None:
+    def upload_banner_hover_image(self, image_media: models.StylesheetAsset, /) -> None:
         """Upload an image for the :class:`.Subreddit`'s (redesign) additional image.
 
-        :param image_path: A path to a jpeg or png image.
+        :param image_media: The :class:`.StylesheetAsset` to upload.
 
         Fails if the :class:`.Subreddit` does not have an additional image defined.
 
@@ -1791,18 +1757,20 @@ class SubredditStylesheet:
 
         .. code-block:: python
 
+            from praw.models import StylesheetAsset
+
             subreddit = reddit.subreddit("test")
-            subreddit.stylesheet.upload_banner_hover_image("banner.png")
+            subreddit.stylesheet.upload_banner_hover_image(StylesheetAsset("banner.png"))
 
         """
         image_type = "secondaryBannerPositionedImage"
-        image_url = self._upload_style_asset(image_path=image_path, image_type=image_type)
+        image_url = image_media._upload(self.subreddit, image_type=image_type)
         self._update_structured_styles({image_type: image_url})
 
-    def upload_header(self, image_path: str) -> dict[str, str]:
+    def upload_header(self, image_media: models.StylesheetImage, /) -> dict[str, str]:
         """Upload an image to be used as the :class:`.Subreddit`'s header image.
 
-        :param image_path: A path to a jpeg or png image.
+        :param image_media: The :class:`.StylesheetImage` to upload.
 
         :returns: A dictionary containing a link to the uploaded image under the key
             ``img_src``.
@@ -1817,22 +1785,26 @@ class SubredditStylesheet:
 
         .. code-block:: python
 
-            reddit.subreddit("test").stylesheet.upload_header("header.png")
+            from praw.models import StylesheetImage
+
+            reddit.subreddit("test").stylesheet.upload_header(StylesheetImage("header.png"))
 
         """
-        return self._upload_image(data={"upload_type": "header"}, image_path=image_path)
+        return image_media._upload(self.subreddit, upload_type="header")
 
-    def upload_mobile_banner(self, image_path: str) -> None:
+    def upload_mobile_banner(self, image_media: models.StylesheetAsset, /) -> None:
         """Upload an image for the :class:`.Subreddit`'s (redesign) mobile banner.
 
-        :param image_path: A path to a JPEG or PNG image.
+        :param image_media: The :class:`.StylesheetAsset` to upload.
 
         For example:
 
         .. code-block:: python
 
+            from praw.models import StylesheetAsset
+
             subreddit = reddit.subreddit("test")
-            subreddit.stylesheet.upload_mobile_banner("banner.png")
+            subreddit.stylesheet.upload_mobile_banner(StylesheetAsset("banner.png"))
 
         Fails if the :class:`.Subreddit` does not have an additional image defined.
 
@@ -1844,13 +1816,13 @@ class SubredditStylesheet:
 
         """
         image_type = "mobileBannerImage"
-        image_url = self._upload_style_asset(image_path=image_path, image_type=image_type)
+        image_url = image_media._upload(self.subreddit, image_type=image_type)
         self._update_structured_styles({image_type: image_url})
 
-    def upload_mobile_header(self, image_path: str) -> dict[str, str]:
+    def upload_mobile_header(self, image_media: models.StylesheetImage, /) -> dict[str, str]:
         """Upload an image to be used as the :class:`.Subreddit`'s mobile header.
 
-        :param image_path: A path to a jpeg or png image.
+        :param image_media: The :class:`.StylesheetImage` to upload.
 
         :returns: A dictionary containing a link to the uploaded image under the key
             ``img_src``.
@@ -1865,15 +1837,17 @@ class SubredditStylesheet:
 
         .. code-block:: python
 
-            reddit.subreddit("test").stylesheet.upload_mobile_header("header.png")
+            from praw.models import StylesheetImage
+
+            reddit.subreddit("test").stylesheet.upload_mobile_header(StylesheetImage("header.png"))
 
         """
-        return self._upload_image(data={"upload_type": "banner"}, image_path=image_path)
+        return image_media._upload(self.subreddit, upload_type="banner")
 
-    def upload_mobile_icon(self, image_path: str) -> dict[str, str]:
+    def upload_mobile_icon(self, image_media: models.StylesheetImage, /) -> dict[str, str]:
         """Upload an image to be used as the :class:`.Subreddit`'s mobile icon.
 
-        :param image_path: A path to a jpeg or png image.
+        :param image_media: The :class:`.StylesheetImage` to upload.
 
         :returns: A dictionary containing a link to the uploaded image under the key
             ``img_src``.
@@ -1888,10 +1862,12 @@ class SubredditStylesheet:
 
         .. code-block:: python
 
-            reddit.subreddit("test").stylesheet.upload_mobile_icon("icon.png")
+            from praw.models import StylesheetImage
+
+            reddit.subreddit("test").stylesheet.upload_mobile_icon(StylesheetImage("icon.png"))
 
         """
-        return self._upload_image(data={"upload_type": "icon"}, image_path=image_path)
+        return image_media._upload(self.subreddit, upload_type="icon")
 
 
 class SubredditWiki:
@@ -2420,17 +2396,6 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
         _reddit.post(API_PATH["site_admin"], data=model)
 
     @staticmethod
-    def _parse_xml_response(response: Response) -> None:
-        """Parse the XML from a response and raise any errors found."""
-        xml = response.text
-        root = ElementTree.fromstring(xml)
-        tags = [element.tag for element in root]
-        if tags[:4] == ["Code", "Message", "ProposedSize", "MaxSizeAllowed"]:
-            # Returned if image is too big
-            _code, _message, actual, maximum_size = (element.text for element in root[:4])
-            raise TooLargeMediaException(actual=int(actual), maximum_size=int(maximum_size))
-
-    @staticmethod
     def _subreddit_list(
         *,
         other_subreddits: list[str | models.Subreddit],
@@ -2441,15 +2406,11 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
         return str(subreddit)
 
     @staticmethod
-    def _validate_gallery(images: list[dict[str, str]]) -> None:
+    def _validate_gallery(images: list[dict[str, str | PostMedia]]) -> None:
         for image in images:
-            image_path = image.get("image_path", "")
-            if image_path:
-                if not Path(image_path).is_file():
-                    msg = f"{image_path!r} is not a valid image path."
-                    raise TypeError(msg)
-            else:
-                msg = "'image_path' is required."
+            image_media = image.get("image_media")
+            if not isinstance(image_media, PostMedia):
+                msg = "'image_media' is required and must be a PostMedia instance."
                 raise TypeError(msg)
             if not len(image.get("caption", "")) <= Subreddit.MAX_CAPTION_LENGTH:
                 msg = "Caption must be 180 characters or less."
@@ -2457,9 +2418,9 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
 
     @staticmethod
     def _validate_inline_media(inline_media: models.InlineMedia) -> None:
-        if not Path(inline_media.path).is_file():
-            msg = f"{inline_media.path!r} is not a valid file path."
-            raise ValueError(msg)
+        if not isinstance(inline_media.media, PostMedia):
+            msg = "'media' must be a PostMedia instance."
+            raise TypeError(msg)
 
     @cachedproperty
     def banned(self) -> models.reddit.subreddit.SubredditRelationship:
@@ -2823,10 +2784,6 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
     def _fetch_info(self) -> tuple[str, dict[str, RedditBase], None]:
         return "subreddit_about", {"subreddit": self}, None
 
-    def _read_and_post_media(self, file: Path, upload_url: str, upload_data: dict[str, Any]) -> Response:
-        with file.open("rb") as media:
-            return self._reddit._core._requestor._http.post(upload_url, data=upload_data, files={"file": media})
-
     def _submit_media(
         self, *, data: dict[Any, Any], timeout: int, without_websockets: bool
     ) -> models.Submission | None:
@@ -2873,70 +2830,8 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
 
         """
         self._validate_inline_media(inline_media)
-        inline_media.media_id = self._upload_media(media_path=inline_media.path, upload_type="selfpost")
+        inline_media.media_id = inline_media.media._upload(self._reddit, upload_type="selfpost")
         return inline_media
-
-    def _upload_media(
-        self,
-        *,
-        expected_mime_prefix: str | None = None,
-        media_path: str | None,
-        upload_type: str = "link",
-    ) -> str:
-        """Upload media and return its URL and a websocket (Undocumented endpoint).
-
-        :param expected_mime_prefix: If provided, enforce that the media has a mime type
-            that starts with the provided prefix.
-        :param media_path: The path to the media file to upload. Default is the PRAW
-            logo.
-        :param upload_type: One of ``"link"``, ``"gallery"'', or ``"selfpost"``
-            (default: ``"link"``).
-
-        :returns: The link to the uploaded media.
-
-        """
-        if media_path is None:
-            # if we're uploading without a media path, assume we're uploading a PRAW logo
-            # this default is commonly used when ``video_poster_url`` is not provided in ``submit_video``
-            module_path = Path(__file__).absolute()
-            logo_path = module_path.parent.parent.parent / "images" / "PRAW logo.png"
-            file = Path(logo_path)
-        else:
-            file = Path(media_path)
-
-        file_name = file.name.lower()
-        file_extension = file_name.rpartition(".")[2]
-        mime_type = {
-            "png": "image/png",
-            "mov": "video/quicktime",
-            "mp4": "video/mp4",
-            "jpg": "image/jpeg",
-            "jpeg": "image/jpeg",
-            "gif": "image/gif",
-        }.get(file_extension, "image/jpeg")  # default to JPEG
-        if expected_mime_prefix is not None and mime_type.partition("/")[0] != expected_mime_prefix:
-            msg = f"Expected a mimetype starting with {expected_mime_prefix!r} but got mimetype {mime_type!r} (from file extension {file_extension!r})."
-            raise ClientException(msg)
-        img_data = {"filepath": file_name, "mimetype": mime_type}
-
-        url = API_PATH["media_asset"]
-        # until we learn otherwise, assume this request always succeeds
-        upload_response = self._reddit.post(url, data=img_data)
-        upload_lease = upload_response["args"]
-        upload_url = f"https:{upload_lease['action']}"
-        upload_data = {item["name"]: item["value"] for item in upload_lease["fields"]}
-
-        response = self._read_and_post_media(file, upload_url, upload_data)
-        if not response.ok:
-            self._parse_xml_response(response)
-        try:
-            response.raise_for_status()
-        except HTTPError as err:
-            raise ServerError(response=err.response) from None
-
-        if upload_type == "link":
-            return f"{upload_url}/{upload_data['key']}"
-        return upload_response["asset"]["asset_id"]
 
     def post_requirements(self) -> dict[str, str | int | bool]:
         """Get the post requirements for a subreddit.
@@ -3102,11 +2997,11 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
 
         .. code-block:: python
 
-            from praw.models import InlineGif, InlineImage, InlineVideo
+            from praw.models import InlineGif, InlineImage, InlineVideo, PostMedia
 
-            gif = InlineGif(path="path/to/image.gif", caption="optional caption")
-            image = InlineImage(path="path/to/image.jpg", caption="optional caption")
-            video = InlineVideo(path="path/to/video.mp4", caption="optional caption")
+            gif = InlineGif(caption="optional caption", media=PostMedia("path/to/image.gif"))
+            image = InlineImage(caption="optional caption", media=PostMedia("path/to/image.jpg"))
+            video = InlineVideo(caption="optional caption", media=PostMedia("path/to/video.mp4"))
             selftext = "Text with a gif {gif1} an image {image1} and a video {video1} inline"
             media = {"gif1": gif, "image1": image, "video1": video}
             reddit.subreddit("test").submit("title", inline_media=media, selftext=selftext)
@@ -3200,24 +3095,24 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
 
     def submit_gallery(
         self,
-        title: str,
-        images: list[dict[str, str]],
         *,
         collection_id: str | None = None,
         discussion_type: str | None = None,
         flair_id: str | None = None,
         flair_text: str | None = None,
+        images: list[dict[str, str | PostMedia]],
         nsfw: bool = False,
         selftext: str | None = None,
         send_replies: bool = True,
         spoiler: bool = False,
+        title: str,
     ) -> models.Submission:
         """Add an image gallery submission to the subreddit.
 
         :param title: The title of the submission.
         :param images: The images to post in dict with the following structure:
-            ``{"image_path": "path", "caption": "caption", "outbound_url": "url"}``,
-            only ``image_path`` is required.
+            ``{"image_media": PostMedia("path"), "caption": "caption", "outbound_url":
+            "url"}``, only ``image_media`` is required.
         :param collection_id: The UUID of a :class:`.Collection` to add the
             newly-submitted post to.
         :param discussion_type: Set to ``"CHAT"`` to enable live discussion instead of
@@ -3236,30 +3131,32 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
 
         :returns: A :class:`.Submission` object for the newly created submission.
 
-        :raises: :class:`.ClientException` if ``image_path`` in ``images`` refers to a
+        :raises: :class:`.ClientException` if ``image_media`` in ``images`` refers to a
             file that is not an image.
 
         For example, to submit an image gallery to r/test do:
 
         .. code-block:: python
 
+            from praw.models import PostMedia
+
             title = "My favorite pictures"
-            image = "/path/to/image.png"
-            image2 = "/path/to/image2.png"
-            image3 = "/path/to/image3.png"
+            image = PostMedia("/path/to/image.png")
+            image2 = PostMedia("/path/to/image2.png")
+            image3 = PostMedia("/path/to/image3.png")
             images = [
-                {"image_path": image},
+                {"image_media": image},
                 {
-                    "image_path": image2,
+                    "image_media": image2,
                     "caption": "Image caption 2",
                 },
                 {
-                    "image_path": image3,
+                    "image_media": image3,
                     "caption": "Image caption 3",
                     "outbound_url": "https://example.com/link3",
                 },
             ]
-            reddit.subreddit("test").submit_gallery(title, images)
+            reddit.subreddit("test").submit_gallery(images=images, title=title)
 
         .. seealso::
 
@@ -3294,9 +3191,9 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
             data["items"].append({
                 "caption": image.get("caption", ""),
                 "outbound_url": image.get("outbound_url", ""),
-                "media_id": self._upload_media(
+                "media_id": image["image_media"]._upload(
+                    self._reddit,
                     expected_mime_prefix="image",
-                    media_path=image["image_path"],
                     upload_type="gallery",
                 ),
             })
@@ -3307,19 +3204,19 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
 
     def submit_image(
         self,
-        title: str,
-        image_path: str,
         *,
         collection_id: str | None = None,
         discussion_type: str | None = None,
         flair_id: str | None = None,
         flair_text: str | None = None,
+        image_media: models.PostMedia,
         nsfw: bool = False,
         resubmit: bool = True,
         selftext: str | None = None,
         send_replies: bool = True,
         spoiler: bool = False,
         timeout: int = 10,
+        title: str,
         without_websockets: bool = False,
     ) -> models.Submission | None:
         """Add an image submission to the subreddit.
@@ -3332,7 +3229,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
         :param flair_text: If the template's ``flair_text_editable`` value is ``True``,
             this value will set a custom text (default: ``None``). ``flair_id`` is
             required when ``flair_text`` is provided.
-        :param image_path: The path to an image, to upload and post.
+        :param image_media: The :class:`.PostMedia` image to upload and post.
         :param nsfw: Whether the submission should be marked NSFW (default: ``False``).
         :param resubmit: When ``False``, an error will occur if the URL has already been
             submitted (default: ``True``).
@@ -3352,7 +3249,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
         :returns: A :class:`.Submission` object for the newly created submission, unless
             ``without_websockets`` is ``True``.
 
-        :raises: :class:`.ClientException` if ``image_path`` refers to a file that is
+        :raises: :class:`.ClientException` if ``image_media`` refers to a file that is
             not an image.
 
         .. note::
@@ -3372,9 +3269,11 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
 
         .. code-block:: python
 
+            from praw.models import PostMedia
+
             title = "My favorite picture"
-            image = "/path/to/image.png"
-            reddit.subreddit("test").submit_image(title, image)
+            image = PostMedia("/path/to/image.png")
+            reddit.subreddit("test").submit_image(image_media=image, title=title)
 
         .. seealso::
 
@@ -3404,7 +3303,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
             if value is not None:
                 data[key] = value
 
-        image_url = self._upload_media(expected_mime_prefix="image", media_path=image_path)
+        image_url = image_media._upload(self._reddit, expected_mime_prefix="image")
         data.update(kind="image", url=image_url)
         return self._submit_media(data=data, timeout=timeout, without_websockets=without_websockets)
 
@@ -3493,8 +3392,6 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
 
     def submit_video(
         self,
-        title: str,
-        video_path: str,
         *,
         collection_id: str | None = None,
         discussion_type: str | None = None,
@@ -3505,15 +3402,17 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
         selftext: str | None = None,
         send_replies: bool = True,
         spoiler: bool = False,
-        thumbnail_path: str | None = None,
+        thumbnail_media: models.PostMedia | None = None,
         timeout: int = 10,
+        title: str,
+        video_media: models.PostMedia,
         videogif: bool = False,
         without_websockets: bool = False,
     ) -> models.Submission | None:
         """Add a video or videogif submission to the subreddit.
 
         :param title: The title of the submission.
-        :param video_path: The path to a video, to upload and post.
+        :param video_media: The :class:`.PostMedia` video to upload and post.
         :param collection_id: The UUID of a :class:`.Collection` to add the
             newly-submitted post to.
         :param discussion_type: Set to ``"CHAT"`` to enable live discussion instead of
@@ -3531,9 +3430,9 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
             author when comments are made to the submission (default: ``True``).
         :param spoiler: Whether the submission should be marked as a spoiler (default:
             ``False``).
-        :param thumbnail_path: The path to an image, to be uploaded and used as the
-            thumbnail for this video. If not provided, the PRAW logo will be used as the
-            thumbnail.
+        :param thumbnail_media: The :class:`.PostMedia` image to be uploaded and used as
+            the thumbnail for this video. If not provided, the PRAW logo will be used as
+            the thumbnail.
         :param timeout: Specifies a particular timeout, in seconds. Use to avoid
             "Websocket error" exceptions (default: ``10``).
         :param videogif: If ``True``, the video is uploaded as a videogif, which is
@@ -3545,7 +3444,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
         :returns: A :class:`.Submission` object for the newly created submission, unless
             ``without_websockets`` is ``True``.
 
-        :raises: :class:`.ClientException` if ``video_path`` refers to a file that is
+        :raises: :class:`.ClientException` if ``video_media`` refers to a file that is
             not a video.
 
         .. note::
@@ -3565,9 +3464,11 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
 
         .. code-block:: python
 
+            from praw.models import PostMedia
+
             title = "My favorite movie"
-            video = "/path/to/video.mp4"
-            reddit.subreddit("test").submit_video(title, video)
+            video = PostMedia("/path/to/video.mp4")
+            reddit.subreddit("test").submit_video(title=title, video_media=video)
 
         .. seealso::
 
@@ -3597,12 +3498,15 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
             if value is not None:
                 data[key] = value
 
-        video_url = self._upload_media(expected_mime_prefix="video", media_path=video_path)
+        if thumbnail_media is None:
+            # if we're uploading without a thumbnail, use the PRAW logo
+            logo_path = Path(__file__).absolute().parent.parent.parent / "images" / "PRAW logo.png"
+            thumbnail_media = PostMedia(str(logo_path))
+        video_url = video_media._upload(self._reddit, expected_mime_prefix="video")
         data.update(
             kind="videogif" if videogif else "video",
             url=video_url,
-            # if thumbnail_path is None, it uploads the PRAW logo
-            video_poster_url=self._upload_media(media_path=thumbnail_path),
+            video_poster_url=thumbnail_media._upload(self._reddit),
         )
         return self._submit_media(data=data, timeout=timeout, without_websockets=without_websockets)
 

--- a/praw/models/reddit/widgets.py
+++ b/praw/models/reddit/widgets.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from json import JSONEncoder, dumps
-from pathlib import Path
 from typing import TYPE_CHECKING, Any, TypeVar
 
 from praw.const import API_PATH
@@ -1794,10 +1793,10 @@ class SubredditWidgetsModeration:
         path = API_PATH["widget_order"].format(subreddit=self._subreddit, section=section)
         self._reddit.patch(path, data={"json": dumps(order), "section": section})
 
-    def upload_image(self, file_path: str) -> str:
+    def upload_image(self, image_media: models.WidgetMedia, /) -> str:
         """Upload an image to Reddit and get the URL.
 
-        :param file_path: The path to the local file.
+        :param image_media: The :class:`.WidgetMedia` to upload.
 
         :returns: The URL of the uploaded image as a ``str``.
 
@@ -1809,8 +1808,10 @@ class SubredditWidgetsModeration:
 
         .. code-block:: python
 
+            from praw.models import WidgetMedia
+
             my_sub = reddit.subreddit("test")
-            image_url = my_sub.widgets.mod.upload_image("/path/to/image.jpg")
+            image_url = my_sub.widgets.mod.upload_image(WidgetMedia("/path/to/image.jpg"))
             image_data = [{"width": 300, "height": 300, "url": image_url, "linkUrl": ""}]
             styles = {"backgroundColor": "#FFFF66", "headerColor": "#3333EE"}
             my_sub.widgets.mod.add_image_widget(
@@ -1818,22 +1819,4 @@ class SubredditWidgetsModeration:
             )
 
         """
-        file = Path(file_path)
-        img_data = {
-            "filepath": file.name,
-            "mimetype": "image/jpeg",
-        }
-        if file_path.lower().endswith(".png"):
-            img_data["mimetype"] = "image/png"
-
-        url = API_PATH["widget_lease"].format(subreddit=self._subreddit)
-        # until we learn otherwise, assume this request always succeeds
-        upload_lease = self._reddit.post(url, data=img_data)["s3UploadLease"]
-        upload_data = {item["name"]: item["value"] for item in upload_lease["fields"]}
-        upload_url = f"https:{upload_lease['action']}"
-
-        with file.open("rb") as image:
-            response = self._reddit._core._requestor._http.post(upload_url, data=upload_data, files={"file": image})
-        response.raise_for_status()
-
-        return f"{upload_url}/{upload_data['key']}"
+        return image_media._upload(self._subreddit)

--- a/tests/integration/models/reddit/test_emoji.py
+++ b/tests/integration/models/reddit/test_emoji.py
@@ -2,6 +2,7 @@ import pytest
 
 from praw.exceptions import ClientException
 from praw.models import Emoji
+from praw.models.media import EmojiMedia
 
 from ... import IntegrationTest
 
@@ -60,8 +61,21 @@ class TestSubredditEmoji(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         for extension in ["jpg", "png"]:
             emoji = subreddit.emoji.add(
+                emoji_media=EmojiMedia(f"tests/integration/files/test.{extension}"),
                 name=f"test_{extension}",
-                image_path=f"tests/integration/files/test.{extension}",
+            )
+            assert isinstance(emoji, Emoji)
+
+    @pytest.mark.cassette_name("TestSubredditEmoji.test_add")
+    def test_add__bytes(self, reddit):
+        reddit.read_only = False
+        subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
+        for extension in ["jpg", "png"]:
+            with open(f"tests/integration/files/test.{extension}", "rb") as file:
+                media_bytes = file.read()
+            emoji = subreddit.emoji.add(
+                emoji_media=EmojiMedia(media_bytes, name=f"test.{extension}"),
+                name=f"test_{extension}",
             )
             assert isinstance(emoji, Emoji)
 
@@ -70,9 +84,9 @@ class TestSubredditEmoji(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         for extension in ["jpg", "png"]:
             emoji = subreddit.emoji.add(
-                name=f"test_{extension}",
-                image_path=f"tests/integration/files/test.{extension}",
+                emoji_media=EmojiMedia(f"tests/integration/files/test.{extension}"),
                 mod_flair_only=True,
+                name=f"test_{extension}",
                 post_flair_allowed=True,
                 user_flair_allowed=False,
             )

--- a/tests/integration/models/reddit/test_submission.py
+++ b/tests/integration/models/reddit/test_submission.py
@@ -1,7 +1,14 @@
 import pytest
 
 from praw.exceptions import ClientException, RedditAPIException
-from praw.models import Comment, InlineGif, InlineImage, InlineVideo, Submission
+from praw.models import (
+    Comment,
+    InlineGif,
+    InlineImage,
+    InlineVideo,
+    PostMedia,
+    Submission,
+)
 
 from ... import IntegrationTest
 
@@ -9,9 +16,13 @@ from ... import IntegrationTest
 class TestSubmission(IntegrationTest):
     @staticmethod
     def _inline_media(image_path):
-        gif = InlineGif(caption="optional caption", path=image_path("test.gif"))
-        image = InlineImage(caption="optional caption", path=image_path("test.png"))
-        video = InlineVideo(caption="optional caption", path=image_path("test.mp4"))
+        gif = InlineGif(caption="optional caption", media=PostMedia(image_path("test.gif")))
+        image = InlineImage(
+            caption="optional caption", media=PostMedia(image_path("test.png"))
+        )
+        video = InlineVideo(
+            caption="optional caption", media=PostMedia(image_path("test.mp4"))
+        )
         return {"gif1": gif, "image1": image, "video1": video}
 
     @staticmethod

--- a/tests/integration/models/reddit/test_subreddit.py
+++ b/tests/integration/models/reddit/test_subreddit.py
@@ -28,8 +28,11 @@ from praw.models import (
     ModmailAction,
     ModmailConversation,
     ModmailMessage,
+    PostMedia,
     Redditor,
     Stylesheet,
+    StylesheetAsset,
+    StylesheetImage,
     Submission,
     Subreddit,
     SubredditMessage,
@@ -1023,7 +1026,7 @@ class TestSubredditStylesheet(IntegrationTest):
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         response = subreddit.stylesheet.upload(
-            name="praw", image_path=image_path("white-square.png")
+            image_media=StylesheetImage(image_path("white-square.png")), name="praw"
         )
         assert response["img_src"].endswith(".png")
 
@@ -1032,7 +1035,7 @@ class TestSubredditStylesheet(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         with pytest.raises(RedditAPIException) as excinfo:
             subreddit.stylesheet.upload(
-                name="praw", image_path=image_path("invalid.jpg")
+                image_media=StylesheetImage(image_path("invalid.jpg")), name="praw"
             )
         assert excinfo.value.items[0].error_type == "IMAGE_ERROR"
 
@@ -1041,7 +1044,7 @@ class TestSubredditStylesheet(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         with pytest.raises(RedditAPIException) as excinfo:
             subreddit.stylesheet.upload(
-                name="praw.png", image_path=image_path("white-square.png")
+                image_media=StylesheetImage(image_path("white-square.png")), name="praw.png"
             )
         assert excinfo.value.items[0].error_type == "BAD_CSS_NAME"
 
@@ -1050,7 +1053,9 @@ class TestSubredditStylesheet(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         for method in ["upload_header", "upload_mobile_header", "upload_mobile_icon"]:
             with pytest.raises(RedditAPIException) as excinfo:
-                getattr(subreddit.stylesheet, method)(image_path("invalid.jpg"))
+                getattr(subreddit.stylesheet, method)(
+                    StylesheetImage(image_path("invalid.jpg"))
+                )
             assert excinfo.value.items[0].error_type == "IMAGE_ERROR"
 
     def test_upload__others_too_large(self, image_path, reddit):
@@ -1058,96 +1063,114 @@ class TestSubredditStylesheet(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         for method in ["upload_header", "upload_mobile_header", "upload_mobile_icon"]:
             with pytest.raises(TooLarge):
-                getattr(subreddit.stylesheet, method)(image_path("too_large.jpg"))
+                getattr(subreddit.stylesheet, method)(
+                    StylesheetImage(image_path("too_large.jpg"))
+                )
 
     def test_upload__too_large(self, image_path, reddit):
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         with pytest.raises(TooLarge):
             subreddit.stylesheet.upload(
-                name="praw", image_path=image_path("too_large.jpg")
+                image_media=StylesheetImage(image_path("too_large.jpg")), name="praw"
             )
 
     def test_upload_banner__jpg(self, image_path, reddit):
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
-        subreddit.stylesheet.upload_banner(image_path("white-square.jpg"))
+        subreddit.stylesheet.upload_banner(StylesheetAsset(image_path("white-square.jpg")))
 
     def test_upload_banner__png(self, image_path, reddit):
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
-        subreddit.stylesheet.upload_banner(image_path("white-square.png"))
+        subreddit.stylesheet.upload_banner(StylesheetAsset(image_path("white-square.png")))
 
     def test_upload_banner_additional_image__align(self, image_path, reddit):
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         for alignment in ("left", "centered", "right"):
             subreddit.stylesheet.upload_banner_additional_image(
-                image_path("white-square.png"), align=alignment
+                StylesheetAsset(image_path("white-square.png")), align=alignment
             )
 
     def test_upload_banner_additional_image__jpg(self, image_path, reddit):
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         subreddit.stylesheet.upload_banner_additional_image(
-            image_path("white-square.jpg")
+            StylesheetAsset(image_path("white-square.jpg"))
         )
 
     def test_upload_banner_additional_image__png(self, image_path, reddit):
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         subreddit.stylesheet.upload_banner_additional_image(
-            image_path("white-square.png")
+            StylesheetAsset(image_path("white-square.png"))
         )
 
     def test_upload_banner_hover_image__jpg(self, image_path, reddit):
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         subreddit.stylesheet.upload_banner_additional_image(
-            image_path("white-square.png")
+            StylesheetAsset(image_path("white-square.png"))
         )
-        subreddit.stylesheet.upload_banner_hover_image(image_path("white-square.jpg"))
+        subreddit.stylesheet.upload_banner_hover_image(
+            StylesheetAsset(image_path("white-square.jpg"))
+        )
 
     def test_upload_banner_hover_image__png(self, image_path, reddit):
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         subreddit.stylesheet.upload_banner_additional_image(
-            image_path("white-square.jpg")
+            StylesheetAsset(image_path("white-square.jpg"))
         )
-        subreddit.stylesheet.upload_banner_hover_image(image_path("white-square.png"))
+        subreddit.stylesheet.upload_banner_hover_image(
+            StylesheetAsset(image_path("white-square.png"))
+        )
 
     def test_upload_header__jpg(self, image_path, reddit):
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
-        response = subreddit.stylesheet.upload_header(image_path("white-square.jpg"))
+        response = subreddit.stylesheet.upload_header(
+            StylesheetImage(image_path("white-square.jpg"))
+        )
         assert response["img_src"].endswith(".jpg")
 
     def test_upload_header__png(self, image_path, reddit):
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
-        response = subreddit.stylesheet.upload_header(image_path("white-square.png"))
+        response = subreddit.stylesheet.upload_header(
+            StylesheetImage(image_path("white-square.png"))
+        )
         assert response["img_src"].endswith(".png")
 
     def test_upload_mobile_banner__jpg(self, image_path, reddit):
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
-        subreddit.stylesheet.upload_mobile_banner(image_path("white-square.jpg"))
+        subreddit.stylesheet.upload_mobile_banner(
+            StylesheetAsset(image_path("white-square.jpg"))
+        )
 
     def test_upload_mobile_banner__png(self, image_path, reddit):
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
-        subreddit.stylesheet.upload_mobile_banner(image_path("white-square.png"))
+        subreddit.stylesheet.upload_mobile_banner(
+            StylesheetAsset(image_path("white-square.png"))
+        )
 
     def test_upload_mobile_header(self, image_path, reddit):
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
-        response = subreddit.stylesheet.upload_mobile_header(image_path("header.jpg"))
+        response = subreddit.stylesheet.upload_mobile_header(
+            StylesheetImage(image_path("header.jpg"))
+        )
         assert response["img_src"].endswith(".jpg")
 
     def test_upload_mobile_icon(self, image_path, reddit):
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
-        response = subreddit.stylesheet.upload_mobile_icon(image_path("icon.jpg"))
+        response = subreddit.stylesheet.upload_mobile_icon(
+            StylesheetImage(image_path("icon.jpg"))
+        )
         assert response["img_src"].endswith(".jpg")
 
 
@@ -1379,9 +1402,13 @@ class TestSubreddit(IntegrationTest):
     def test_submit__selftext_inline_media(self, image_path, reddit):
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
-        gif = InlineGif(caption="optional caption", path=image_path("test.gif"))
-        image = InlineImage(caption="optional caption", path=image_path("test.png"))
-        video = InlineVideo(caption="optional caption", path=image_path("test.mp4"))
+        gif = InlineGif(caption="optional caption", media=PostMedia(image_path("test.gif")))
+        image = InlineImage(
+            caption="optional caption", media=PostMedia(image_path("test.png"))
+        )
+        video = InlineVideo(
+            caption="optional caption", media=PostMedia(image_path("test.mp4"))
+        )
         selftext = (
             "Text with a gif {gif1} an image {image1} and a video {video1} inline"
         )
@@ -1437,20 +1464,20 @@ class TestSubreddit(IntegrationTest):
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         images = [
-            {"image_path": image_path("test.png")},
-            {"image_path": image_path("test.jpg"), "caption": "test.jpg"},
+            {"image_media": PostMedia(image_path("test.png"))},
+            {"image_media": PostMedia(image_path("test.jpg")), "caption": "test.jpg"},
             {
-                "image_path": image_path("test.gif"),
+                "image_media": PostMedia(image_path("test.gif")),
                 "outbound_url": "https://example.com",
             },
             {
-                "image_path": image_path("test.png"),
+                "image_media": PostMedia(image_path("test.png")),
                 "caption": "test.png",
                 "outbound_url": "https://example.com",
             },
         ]
 
-        submission = subreddit.submit_gallery("Test Title", images)
+        submission = subreddit.submit_gallery(images=images, title="Test Title")
         assert submission.author == pytest.placeholders.username
         assert submission.is_gallery
         assert submission.title == "Test Title"
@@ -1458,7 +1485,7 @@ class TestSubreddit(IntegrationTest):
         assert isinstance(submission.gallery_data["items"], list)
         for i, item in enumerate(items):
             test_data = images[i]
-            test_data.pop("image_path")
+            test_data.pop("image_media")
             item.pop("id")
             item.pop("media_id")
             assert item == test_data
@@ -1467,21 +1494,21 @@ class TestSubreddit(IntegrationTest):
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         images = [
-            {"image_path": image_path("test.png")},
-            {"image_path": image_path("test.jpg"), "caption": "test.jpg"},
+            {"image_media": PostMedia(image_path("test.png"))},
+            {"image_media": PostMedia(image_path("test.jpg")), "caption": "test.jpg"},
             {
-                "image_path": image_path("test.gif"),
+                "image_media": PostMedia(image_path("test.gif")),
                 "outbound_url": "https://example.com",
             },
             {
-                "image_path": image_path("test.png"),
+                "image_media": PostMedia(image_path("test.png")),
                 "caption": "test.png",
                 "outbound_url": "https://example.com",
             },
         ]
 
         with pytest.raises(RedditAPIException):
-            subreddit.submit_gallery("Test Title", images)
+            subreddit.submit_gallery(images=images, title="Test Title")
 
     def test_submit_gallery__flair(self, image_path, reddit):
         flair_id = "6fc213da-cae7-11ea-9274-0e2407099e45"
@@ -1490,20 +1517,23 @@ class TestSubreddit(IntegrationTest):
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         images = [
-            {"image_path": image_path("test.png")},
-            {"image_path": image_path("test.jpg"), "caption": "test.jpg"},
+            {"image_media": PostMedia(image_path("test.png"))},
+            {"image_media": PostMedia(image_path("test.jpg")), "caption": "test.jpg"},
             {
-                "image_path": image_path("test.gif"),
+                "image_media": PostMedia(image_path("test.gif")),
                 "outbound_url": "https://example.com",
             },
             {
-                "image_path": image_path("test.png"),
+                "image_media": PostMedia(image_path("test.png")),
                 "caption": "test.png",
                 "outbound_url": "https://example.com",
             },
         ]
         submission = subreddit.submit_gallery(
-            "Test Title", images, flair_id=flair_id, flair_text=flair_text
+            flair_id=flair_id,
+            flair_text=flair_text,
+            images=images,
+            title="Test Title",
         )
         assert submission.link_flair_css_class == flair_class
         assert submission.link_flair_text == flair_text
@@ -1518,24 +1548,24 @@ class TestSubreddit(IntegrationTest):
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         images = [
-            {"image_path": image_path("test.png")},
+            {"image_media": PostMedia(image_path("test.png"))},
             {
-                "image_path": image_path("test.jpg"),
+                "image_media": PostMedia(image_path("test.jpg")),
                 "caption": "A JPG image.",
             },
             {
-                "image_path": image_path("test.gif"),
+                "image_media": PostMedia(image_path("test.gif")),
                 "outbound_url": "https://example.com",
             },
             {
-                "image_path": image_path("test.png"),
+                "image_media": PostMedia(image_path("test.png")),
                 "caption": "A PNG image.",
                 "outbound_url": "https://example.com",
             },
         ]
         selftext = "Testing **PRAW** gallery submission *with markdown selftext*."
         title = "Testing PRAW Gallery with Selftext"
-        submission = subreddit.submit_gallery(title, images, selftext=selftext)
+        submission = subreddit.submit_gallery(images=images, selftext=selftext, title=title)
         assert submission.author == pytest.placeholders.username
         assert submission.is_gallery
         assert submission.title == title
@@ -1544,7 +1574,7 @@ class TestSubreddit(IntegrationTest):
         assert isinstance(submission.gallery_data["items"], list)
         for i, item in enumerate(items):
             test_data = images[i]
-            test_data.pop("image_path")
+            test_data.pop("image_media")
             item.pop("id")
             item.pop("media_id")
             assert item == test_data
@@ -1560,7 +1590,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         for i, file_name in enumerate(("test.png", "test.jpg", "test.gif")):
             image = image_path(file_name)
-            submission = subreddit.submit_image(f"Test Title {i}", image)
+            submission = subreddit.submit_image(image_media=PostMedia(image), title=f"Test Title {i}")
             assert submission.author == pytest.placeholders.username
             assert submission.is_reddit_media_domain
             assert submission.title == f"Test Title {i}"
@@ -1575,7 +1605,7 @@ class TestSubreddit(IntegrationTest):
         for file_name in ("test.png", "test.jpg"):
             image = image_path(file_name)
             with pytest.raises(ClientException):
-                subreddit.submit_image("Test Title", image)
+                subreddit.submit_image(image_media=PostMedia(image), title="Test Title")
 
     @mock.patch(
         "websocket.create_connection",
@@ -1589,7 +1619,10 @@ class TestSubreddit(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         image = image_path("test.jpg")
         submission = subreddit.submit_image(
-            "Test Title", image, flair_id=flair_id, flair_text=flair_text
+            flair_id=flair_id,
+            flair_text=flair_text,
+            image_media=PostMedia(image),
+            title="Test Title",
         )
         assert submission.link_flair_css_class == flair_class
         assert submission.link_flair_text == flair_text
@@ -1608,9 +1641,9 @@ class TestSubreddit(IntegrationTest):
             "<HostId>iYEVOuRfbLiKwMgHt2ewqQRIm0NWL79uiC2rPLj9P0PwW55MhjY2/O8d9JdKTf1iwzLjwWMnGQ=</HostId>"
             "</Error>"
         )
-        _post = reddit._core._requestor._http.post
+        _request = reddit._core._requestor._http.request
 
-        def patch_request(url, *args, **kwargs):
+        def patch_request(method, url, *args, **kwargs):
             """Patch requests to return mock data on specific url."""
             if "https://reddit-uploaded-media.s3-accelerate.amazonaws.com" in url:
                 response = requests.Response()
@@ -1618,16 +1651,16 @@ class TestSubreddit(IntegrationTest):
                 response.encoding = "utf-8"
                 response.status_code = 400
                 return response
-            return _post(url, *args, **kwargs)
+            return _request(method, url, *args, **kwargs)
 
-        reddit._core._requestor._http.post = patch_request
+        reddit._core._requestor._http.request = patch_request
         fake_png = PNG_HEADER + b"\x1a" * 10  # Normally 1024 ** 2 * 20 (20 MB)
         with open(tmp_path.joinpath("fake_img.png"), "wb") as tempfile:
             tempfile.write(fake_png)
         subreddit = reddit.subreddit("test")
         with pytest.raises(TooLargeMediaException):
-            subreddit.submit_image("test", tempfile.name)
-        reddit._core._requestor._http.post = _post
+            subreddit.submit_image(image_media=PostMedia(tempfile.name), title="test")
+        reddit._core._requestor._http.request = _request
 
     @mock.patch(
         "websocket.create_connection",
@@ -1641,7 +1674,7 @@ class TestSubreddit(IntegrationTest):
         image = image_path("test.png")
         selftext = "Testing **PRAW** image submission *with markdown selftext*."
         title = "Testing PRAW image submission with selftext"
-        submission = subreddit.submit_image(title, image, selftext=selftext)
+        submission = subreddit.submit_image(image_media=PostMedia(image), selftext=selftext, title=title)
         assert submission.selftext == selftext
         assert submission.is_reddit_media_domain
         assert submission.title == title
@@ -1655,7 +1688,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         image = image_path("test.jpg")
         with pytest.raises(WebSocketException):
-            subreddit.submit_image("Test Title", image)
+            subreddit.submit_image(image_media=PostMedia(image), title="Test Title")
 
     @mock.patch(
         "websocket.create_connection",
@@ -1670,7 +1703,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         image = image_path("test.jpg")
         with pytest.raises(WebSocketException):
-            subreddit.submit_image("Test Title", image)
+            subreddit.submit_image(image_media=PostMedia(image), title="Test Title")
 
     @mock.patch(
         "websocket.create_connection",
@@ -1686,7 +1719,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         image = image_path("test.jpg")
         with pytest.raises(WebSocketException):
-            subreddit.submit_image("Test Title", image)
+            subreddit.submit_image(image_media=PostMedia(image), title="Test Title")
 
     @mock.patch(
         "websocket.create_connection",
@@ -1702,7 +1735,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         image = image_path("test.jpg")
         with pytest.raises(WebSocketException):
-            subreddit.submit_image("Test Title", image)
+            subreddit.submit_image(image_media=PostMedia(image), title="Test Title")
 
     @mock.patch(
         "websocket.create_connection",
@@ -1718,7 +1751,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         image = image_path("test.jpg")
         with pytest.raises(WebSocketException):
-            subreddit.submit_image("Test Title", image)
+            subreddit.submit_image(image_media=PostMedia(image), title="Test Title")
 
     def test_submit_image__without_websockets(self, image_path, reddit):
         reddit.read_only = False
@@ -1726,7 +1759,9 @@ class TestSubreddit(IntegrationTest):
         for file_name in ("test.png", "test.jpg", "test.gif"):
             image = image_path(file_name)
             submission = subreddit.submit_image(
-                "Test Title", image, without_websockets=True
+                image_media=PostMedia(image),
+                title="Test Title",
+                without_websockets=True,
             )
             assert submission is None
 
@@ -1738,7 +1773,7 @@ class TestSubreddit(IntegrationTest):
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         image = image_path("test.jpg")
-        submission = subreddit.submit_image("Test Title", image, discussion_type="CHAT")
+        submission = subreddit.submit_image(discussion_type="CHAT", image_media=PostMedia(image), title="Test Title")
         assert submission.discussion_type == "CHAT"
 
     def test_submit_image_verify_invalid(self, image_path, reddit):
@@ -1750,7 +1785,9 @@ class TestSubreddit(IntegrationTest):
             (RedditAPIException, BadRequest)
         ):  # waiting for prawcore fix
             subreddit.submit_image(
-                "gdfgfdgdgdgfgfdgdfgfdgfdg", image, without_websockets=True
+                image_media=PostMedia(image),
+                title="gdfgfdgdgdgfgfdgdfgfdgfdg",
+                without_websockets=True,
             )
 
     def test_submit_live_chat(self, reddit):
@@ -1814,7 +1851,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         for i, file_name in enumerate(("test.mov", "test.mp4")):
             video = image_path(file_name)
-            submission = subreddit.submit_video(f"Test Title {i}", video)
+            submission = subreddit.submit_video(title=f"Test Title {i}", video_media=PostMedia(video))
             assert submission.author == pytest.placeholders.username
             assert submission.is_video
             assert submission.title == f"Test Title {i}"
@@ -1829,7 +1866,7 @@ class TestSubreddit(IntegrationTest):
         for file_name in ("test.mov", "test.mp4"):
             video = image_path(file_name)
             with pytest.raises(ClientException):
-                subreddit.submit_video("Test Title", video)
+                subreddit.submit_video(title="Test Title", video_media=PostMedia(video))
 
     @mock.patch(
         "websocket.create_connection",
@@ -1843,7 +1880,10 @@ class TestSubreddit(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         video = image_path("test.mov")
         submission = subreddit.submit_video(
-            "Test Title", video, flair_id=flair_id, flair_text=flair_text
+            flair_id=flair_id,
+            flair_text=flair_text,
+            title="Test Title",
+            video_media=PostMedia(video),
         )
         assert submission.link_flair_css_class == flair_class
         assert submission.link_flair_text == flair_text
@@ -1861,7 +1901,7 @@ class TestSubreddit(IntegrationTest):
             title = f"Test Title {i}"
             selftext = f"Testing **PRAW** video submission *with markdown selftext*."
             video = image_path(file_name)
-            submission = subreddit.submit_video(title, video, selftext=selftext)
+            submission = subreddit.submit_video(selftext=selftext, title=title, video_media=PostMedia(video))
             assert submission.author == pytest.placeholders.username
             assert submission.is_video
             assert submission.title == title
@@ -1883,7 +1923,9 @@ class TestSubreddit(IntegrationTest):
             video = image_path(video_name)
             thumb = image_path(thumb_name)
             submission = subreddit.submit_video(
-                "Test Title", video, thumbnail_path=thumb
+                thumbnail_media=PostMedia(thumb),
+                title="Test Title",
+                video_media=PostMedia(video),
             )
             assert submission.author == pytest.placeholders.username
             assert submission.is_video
@@ -1898,7 +1940,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         video = image_path("test.mov")
         with pytest.raises(WebSocketException):
-            subreddit.submit_video("Test Title", video)
+            subreddit.submit_video(title="Test Title", video_media=PostMedia(video))
 
     @mock.patch(
         "websocket.create_connection",
@@ -1913,7 +1955,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         video = image_path("test.mov")
         with pytest.raises(WebSocketException):
-            subreddit.submit_video("Test Title", video)
+            subreddit.submit_video(title="Test Title", video_media=PostMedia(video))
 
     @mock.patch(
         "websocket.create_connection",
@@ -1929,7 +1971,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         video = image_path("test.mov")
         with pytest.raises(WebSocketException):
-            subreddit.submit_video("Test Title", video)
+            subreddit.submit_video(title="Test Title", video_media=PostMedia(video))
 
     @mock.patch(
         "websocket.create_connection",
@@ -1945,7 +1987,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         video = image_path("test.mov")
         with pytest.raises(WebSocketException):
-            subreddit.submit_video("Test Title", video)
+            subreddit.submit_video(title="Test Title", video_media=PostMedia(video))
 
     @mock.patch(
         "websocket.create_connection",
@@ -1961,7 +2003,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         video = image_path("test.mov")
         with pytest.raises(WebSocketException):
-            subreddit.submit_video("Test Title", video)
+            subreddit.submit_video(title="Test Title", video_media=PostMedia(video))
 
     @mock.patch(
         "websocket.create_connection",
@@ -1974,7 +2016,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         for file_name in ("test.mov", "test.mp4"):
             video = image_path(file_name)
-            submission = subreddit.submit_video("Test Title", video, videogif=True)
+            submission = subreddit.submit_video(title="Test Title", video_media=PostMedia(video), videogif=True)
             assert submission.author == pytest.placeholders.username
             assert submission.is_video
             assert submission.title == "Test Title"
@@ -1985,7 +2027,9 @@ class TestSubreddit(IntegrationTest):
         for file_name in ("test.mov", "test.mp4"):
             video = image_path(file_name)
             submission = subreddit.submit_video(
-                "Test Title", video, without_websockets=True
+                title="Test Title",
+                video_media=PostMedia(video),
+                without_websockets=True,
             )
             assert submission is None
 
@@ -1997,7 +2041,7 @@ class TestSubreddit(IntegrationTest):
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         video = image_path("test.mov")
-        submission = subreddit.submit_video("Test Title", video, discussion_type="CHAT")
+        submission = subreddit.submit_video(discussion_type="CHAT", title="Test Title", video_media=PostMedia(video))
         assert submission.discussion_type == "CHAT"
 
     def test_submit_video_verify_invalid(self, image_path, reddit):
@@ -2009,7 +2053,9 @@ class TestSubreddit(IntegrationTest):
             (RedditAPIException, BadRequest)
         ):  # waiting for prawcore fix
             subreddit.submit_video(
-                "gdfgfdgdgdgfgfdgdfgfdgfdg", video, without_websockets=True
+                title="gdfgfdgdgdgfgfdgdfgfdgfdg",
+                video_media=PostMedia(video),
+                without_websockets=True,
             )
 
     def test_subscribe(self, reddit):

--- a/tests/integration/models/reddit/test_widgets.py
+++ b/tests/integration/models/reddit/test_widgets.py
@@ -23,6 +23,7 @@ from praw.models import (
     Subreddit,
     TextArea,
     Widget,
+    WidgetMedia,
 )
 
 from ... import IntegrationTest
@@ -62,7 +63,7 @@ class TestButtonWidget(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         widgets = subreddit.widgets
         styles = {"headerColor": "#123456", "backgroundColor": "#bb0e00"}
-        my_image = widgets.mod.upload_image(image_path("test.png"))
+        my_image = widgets.mod.upload_image(WidgetMedia(image_path("test.png")))
         buttons = [
             {
                 "kind": "text",
@@ -314,7 +315,7 @@ class TestCustomWidget(IntegrationTest):
                 "width": 0,
                 "height": 0,
                 "name": "a",
-                "url": widgets.mod.upload_image(image_path("test.png")),
+                "url": widgets.mod.upload_image(WidgetMedia(image_path("test.png"))),
             }
         ]
 
@@ -436,7 +437,7 @@ class TestImageWidget(IntegrationTest):
                 "width": 0,
                 "height": 0,
                 "linkUrl": "",
-                "url": widgets.mod.upload_image(img_path),
+                "url": widgets.mod.upload_image(WidgetMedia(img_path)),
             }
             for img_path in image_paths
         ]
@@ -832,7 +833,7 @@ class TestSubredditWidgetsModeration(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         widgets = subreddit.widgets
         for image in ("test.jpg", "test.png"):
-            image_url = widgets.mod.upload_image(image_path(image))
+            image_url = widgets.mod.upload_image(WidgetMedia(image_path(image)))
             assert image_url
 
 

--- a/tests/integration/models/reddit/test_wikipage.py
+++ b/tests/integration/models/reddit/test_wikipage.py
@@ -4,7 +4,7 @@ import pytest
 from prawcore import Forbidden, NotFound
 
 from praw.exceptions import RedditAPIException
-from praw.models import Redditor, WikiPage
+from praw.models import Redditor, StylesheetImage, WikiPage
 
 from ... import IntegrationTest
 
@@ -43,8 +43,8 @@ class TestWikiPageModeration(IntegrationTest):
 
         reddit.read_only = False
         subreddit.stylesheet.upload(
+            image_media=StylesheetImage("tests/integration/files/icon.jpg"),
             name="css-revert-fail",
-            image_path="tests/integration/files/icon.jpg",
         )
         page.edit(content="div {background: url(%%css-revert-fail%%)}")
         revision_id = next(page.revisions(limit=1))["id"]

--- a/tests/unit/models/reddit/test_inline_media.py
+++ b/tests/unit/models/reddit/test_inline_media.py
@@ -1,17 +1,17 @@
 import pickle
 
-from praw.models import InlineGif, InlineImage, InlineMedia, InlineVideo
+from praw.models import InlineGif, InlineImage, InlineMedia, InlineVideo, PostMedia
 
 from ... import UnitTest
 
 
 class TestInlineMedia(UnitTest):
     def test_equality(self):
-        media1 = InlineMedia(path="path1", caption="caption1")
+        media1 = InlineMedia(caption="caption1", media=PostMedia(b"data1", name="name1"))
         media1.media_id = "media_id1"
-        media2 = InlineMedia(path="path1", caption="caption1")
+        media2 = InlineMedia(caption="caption1", media=PostMedia(b"data1", name="name1"))
         media2.media_id = "media_id1"
-        media3 = InlineMedia(path="path2", caption="caption2")
+        media3 = InlineMedia(caption="caption2", media=PostMedia(b"data2", name="name2"))
         media3.media_id = "media_id2"
         assert media1 == media1
         assert media2 == media2
@@ -21,11 +21,11 @@ class TestInlineMedia(UnitTest):
         assert media1 != media3
 
     def test_hash(self):
-        media1 = InlineMedia(path="path1", caption="caption1")
+        media1 = InlineMedia(caption="caption1", media=PostMedia(b"data1", name="name1"))
         media1.media_id = "media_id1"
-        media2 = InlineMedia(path="path1", caption="caption1")
+        media2 = InlineMedia(caption="caption1", media=PostMedia(b"data1", name="name1"))
         media2.media_id = "media_id1"
-        media3 = InlineMedia(path="path2", caption="caption2")
+        media3 = InlineMedia(caption="caption2", media=PostMedia(b"data2", name="name2"))
         media3.media_id = "media_id2"
         assert hash(media1) == hash(media1)
         assert hash(media2) == hash(media2)
@@ -35,17 +35,17 @@ class TestInlineMedia(UnitTest):
         assert hash(media1) != hash(media3)
 
     def test_pickle(self):
-        media = InlineMedia(path="path1", caption="caption1")
+        media = InlineMedia(caption="caption1", media=PostMedia(b"data1", name="name1"))
         for level in range(pickle.HIGHEST_PROTOCOL + 1):
             other = pickle.loads(pickle.dumps(media, protocol=level))
             assert media == other
 
     def test_repr(self):
-        media = InlineMedia(path="path1", caption="caption1")
-        no_caption = InlineMedia(path="path1")
-        gif = InlineGif(path="gif_path1", caption="gif_caption1")
-        image = InlineImage(path="image_path1", caption="image_caption1")
-        video = InlineVideo(path="video_path1", caption="video_caption1")
+        media = InlineMedia(caption="caption1", media=PostMedia(b"data1", name="name1"))
+        no_caption = InlineMedia(media=PostMedia(b"data1", name="name1"))
+        gif = InlineGif(caption="gif_caption1", media=PostMedia(b"gif_data1", name="gif_name1"))
+        image = InlineImage(caption="image_caption1", media=PostMedia(b"image_data1", name="image_name1"))
+        video = InlineVideo(caption="video_caption1", media=PostMedia(b"video_data1", name="video_name1"))
         assert repr(media) == "<InlineMedia caption='caption1'>"
         assert repr(no_caption) == "<InlineMedia caption=None>"
         assert repr(gif) == "<InlineGif caption='gif_caption1'>"
@@ -53,11 +53,11 @@ class TestInlineMedia(UnitTest):
         assert repr(video) == "<InlineVideo caption='video_caption1'>"
 
     def test_str(self):
-        media = InlineMedia(path="path1", caption="caption1")
-        no_caption = InlineMedia(path="path1")
-        gif = InlineGif(path="gif_path1", caption="gif_caption1")
-        image = InlineImage(path="image_path1", caption="image_caption1")
-        video = InlineVideo(path="video_path1", caption="video_caption1")
+        media = InlineMedia(caption="caption1", media=PostMedia(b"data1", name="name1"))
+        no_caption = InlineMedia(media=PostMedia(b"data1", name="name1"))
+        gif = InlineGif(caption="gif_caption1", media=PostMedia(b"gif_data1", name="gif_name1"))
+        image = InlineImage(caption="image_caption1", media=PostMedia(b"image_data1", name="image_name1"))
+        video = InlineVideo(caption="video_caption1", media=PostMedia(b"video_data1", name="video_name1"))
         media.media_id = "media_media_id"
         no_caption.media_id = "media_media_id_no_caption"
         gif.media_id = "gif_media_id"

--- a/tests/unit/models/reddit/test_subreddit.py
+++ b/tests/unit/models/reddit/test_subreddit.py
@@ -5,7 +5,7 @@ from unittest import mock
 import pytest
 
 from praw.exceptions import ClientException, MediaPostFailed
-from praw.models import InlineGif, InlineImage, InlineVideo, Subreddit, WikiPage
+from praw.models import InlineGif, InlineImage, InlineVideo, PostMedia, StylesheetAsset, Subreddit, WikiPage
 from praw.models.reddit.subreddit import SubredditFlairTemplates
 
 from ... import UnitTest
@@ -55,22 +55,22 @@ class TestSubreddit(UnitTest):
 
     @mock.patch("websocket.create_connection")
     @mock.patch(
-        "praw.models.Subreddit._upload_media",
-        return_value=("fake_media_url", "fake_websocket_url"),
+        "praw.models.PostMedia._upload",
+        return_value="fake_media_url",
     )
     @mock.patch(
         "praw.Reddit.post", return_value={"json": {"data": {"websocket_url": ""}}}
     )
     def test_invalid_media(
-        self, _mock_post, _mock_upload_media, connection_mock, reddit
+        self, _mock_post, _mock_upload, connection_mock, reddit
     ):
         connection_mock().recv.return_value = json.dumps(
             {"payload": {}, "type": "failed"}
         )
         with pytest.raises(MediaPostFailed):
-            reddit.subreddit("test").submit_image("Test", "dummy path")
+            reddit.subreddit("test").submit_image(image_media=PostMedia(b"", name="dummy.png"), title="Test")
 
-    @mock.patch("praw.models.Subreddit._read_and_post_media")
+    @mock.patch("praw.models.PostMedia._post_to_s3")
     @mock.patch("websocket.create_connection")
     @mock.patch(
         "praw.Reddit.post",
@@ -81,19 +81,14 @@ class TestSubreddit(UnitTest):
     )
     def test_media_upload_500(self, _mock_post, connection_mock, mock_method, reddit):
         from prawcore.exceptions import ServerError
-        from requests.exceptions import HTTPError
-
-        http_response = mock.Mock()
-        http_response.status_code = 500
 
         response = mock.Mock()
-        response.ok = True
-        response.raise_for_status = mock.Mock(
-            side_effect=HTTPError(response=http_response)
-        )
+        response.ok = False
+        response.status_code = 500
+        response.text = "<Error/>"
         mock_method.return_value = response
         with pytest.raises(ServerError):
-            reddit.subreddit("test").submit_image("Test", "/dev/null")
+            reddit.subreddit("test").submit_image(image_media=PostMedia(b"", name="test.png"), title="Test")
 
     def test_notes_delete__invalid_args(self, reddit):
         with pytest.raises(TypeError) as excinfo:
@@ -137,9 +132,9 @@ class TestSubreddit(UnitTest):
         # but `inline_media` is not supported for link post selftext
         message = "As of 2025-05-07, `inline_media` is not supported for link post selftext. Only Markdown text can be added to non-self posts."
         subreddit = Subreddit(reddit, display_name="name")
-        gif = InlineGif(caption="optional caption", path="test.gif")
-        image = InlineImage(caption="optional caption", path="test.png")
-        video = InlineVideo(caption="optional caption", path="test.mp4")
+        gif = InlineGif(caption="optional caption", media=PostMedia(b"", name="test.gif"))
+        image = InlineImage(caption="optional caption", media=PostMedia(b"", name="test.png"))
+        video = InlineVideo(caption="optional caption", media=PostMedia(b"", name="test.mp4"))
         selftext = "Text with {gif1}, {image1}, and {video1} inline"
         media = {"gif1": gif, "image1": image, "video1": video}
         with pytest.raises(TypeError) as excinfo:
@@ -149,24 +144,20 @@ class TestSubreddit(UnitTest):
                              selftext=selftext)
         assert str(excinfo.value) == message
 
-    def test_submit_gallery__invalid_path(self, reddit):
-        message = "'invalid_image_path' is not a valid image path."
+    def test_submit_gallery__invalid_image_media(self, reddit):
+        message = "'image_media' is required and must be a PostMedia instance."
         subreddit = Subreddit(reddit, display_name="name")
 
         with pytest.raises(TypeError) as excinfo:
-            subreddit.submit_gallery(
-                "Cool title", [{"image_path": "invalid_image_path"}]
-            )
+            subreddit.submit_gallery(images=[{"image_media": "a string is not PostMedia"}], title="Cool title")
         assert str(excinfo.value) == message
 
-    def test_submit_gallery__missing_path(self, reddit):
-        message = "'image_path' is required."
+    def test_submit_gallery__missing_image_media(self, reddit):
+        message = "'image_media' is required and must be a PostMedia instance."
         subreddit = Subreddit(reddit, display_name="name")
 
         with pytest.raises(TypeError) as excinfo:
-            subreddit.submit_gallery(
-                "Cool title", [{"caption": "caption"}, {"caption": "caption2"}]
-            )
+            subreddit.submit_gallery(images=[{"caption": "caption"}, {"caption": "caption2"}], title="Cool title")
         assert str(excinfo.value) == message
 
     def test_submit_gallery__too_long_caption(self, reddit):
@@ -179,41 +170,42 @@ class TestSubreddit(UnitTest):
         )
         with pytest.raises(TypeError) as excinfo:
             subreddit.submit_gallery(
-                "Cool title", [{"image_path": __file__, "caption": caption}]
+                images=[{"image_media": PostMedia(b"", name="test.png"), "caption": caption}],
+                title="Cool title",
             )
         assert str(excinfo.value) == message
 
     def test_submit_image__bad_filetype(self, image_path, reddit):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         for file_name in ("test.mov", "test.mp4"):
-            image = image_path(file_name)
+            image = PostMedia(image_path(file_name))
             with pytest.raises(ClientException):
-                subreddit.submit_image("Test Title", image)
+                subreddit.submit_image(image_media=image, title="Test Title")
 
-    def test_submit_inline_media__invalid_path(self, reddit):
-        message = "'invalid_image_path' is not a valid file path."
+    def test_submit_inline_media__invalid_media(self, reddit):
+        message = "'media' must be a PostMedia instance."
         subreddit = Subreddit(reddit, display_name="name")
-        gif = InlineGif(caption="optional caption", path="invalid_image_path")
-        image = InlineImage(caption="optional caption", path="invalid_image_path")
-        video = InlineVideo(caption="optional caption", path="invalid_image_path")
+        gif = InlineGif(caption="optional caption", media="not_post_media")
+        image = InlineImage(caption="optional caption", media="not_post_media")
+        video = InlineVideo(caption="optional caption", media="not_post_media")
         selftext = "Text with {gif1}, {image1}, and {video1} inline"
         media = {"gif1": gif, "image1": image, "video1": video}
-        with pytest.raises(ValueError) as excinfo:
+        with pytest.raises(TypeError) as excinfo:
             subreddit.submit("title", inline_media=media, selftext=selftext)
         assert str(excinfo.value) == message
 
     def test_submit_video__bad_filetype(self, image_path, reddit):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         for file_name in ("test.jpg", "test.png", "test.gif"):
-            video = image_path(file_name)
+            video = PostMedia(image_path(file_name))
             with pytest.raises(ClientException):
-                subreddit.submit_video("Test Title", video)
+                subreddit.submit_video(title="Test Title", video_media=video)
 
     def test_upload_banner_additional_image(self, reddit):
         subreddit = Subreddit(reddit, display_name="name")
         with pytest.raises(ValueError):
             subreddit.stylesheet.upload_banner_additional_image(
-                "dummy_path", align="asdf"
+                StylesheetAsset(b"", name="dummy.png"), align="asdf"
             )
 
 

--- a/tests/unit/models/test_media.py
+++ b/tests/unit/models/test_media.py
@@ -1,0 +1,111 @@
+import pickle
+from pathlib import Path
+
+import pytest
+
+from praw.exceptions import ClientException
+from praw.models import EmojiMedia, PostMedia, StylesheetAsset, StylesheetImage, WidgetMedia
+from praw.models.media import Media
+
+from .. import UnitTest
+
+
+class TestMedia(UnitTest):
+    def test_equality(self):
+        media1 = PostMedia(b"data1", name="name1")
+        media2 = PostMedia(b"data1", name="name1")
+        media3 = PostMedia(b"data2", name="name1")
+        media4 = PostMedia(b"data1", name="name2")
+        media5 = EmojiMedia(b"data1", name="name1")
+        assert media1 == media1
+        assert media1 == media2
+        assert media1 != media3
+        assert media1 != media4
+        assert media1 != media5
+
+    def test_hash(self):
+        media1 = PostMedia(b"data1", name="name1")
+        media2 = PostMedia(b"data1", name="name1")
+        media3 = PostMedia(b"data2", name="name2")
+        assert hash(media1) == hash(media2)
+        assert hash(media1) != hash(media3)
+
+    def test_init__bytes(self):
+        media = PostMedia(b"data", name="image.png")
+        assert media.name == "image.png"
+        assert media._data == b"data"
+
+    def test_init__name_derived_from_path(self, image_path):
+        path = image_path("test.png")
+        media = PostMedia(path)
+        assert media.name == "test.png"
+        assert media._data == Path(path).read_bytes()
+
+    def test_init__name_overrides_path(self, image_path):
+        media = PostMedia(image_path("test.png"), name="other.png")
+        assert media.name == "other.png"
+
+    def test_init__name_required_for_bytes(self):
+        message = "'name' is required when 'fp' is a bytes object."
+        with pytest.raises(ValueError) as excinfo:
+            PostMedia(b"data")
+        assert str(excinfo.value) == message
+
+    def test_init__nonexistent_path(self):
+        with pytest.raises(FileNotFoundError):
+            PostMedia("nonexistent_path.png")
+
+    def test_mime_type(self):
+        for name, mime_type in [
+            ("test.gif", "image/gif"),
+            ("test.jpeg", "image/jpeg"),
+            ("test.jpg", "image/jpeg"),
+            ("test.mov", "video/quicktime"),
+            ("test.mp4", "video/mp4"),
+            ("test.png", "image/png"),
+        ]:
+            assert Media(b"data", name=name)._mime_type == mime_type
+
+    def test_mime_type__unknown(self):
+        media = Media(b"data", name="unknown.invalid_extension")
+        message = "Unable to determine the MIME type of 'unknown.invalid_extension'."
+        with pytest.raises(ClientException) as excinfo:
+            media._mime_type
+        assert str(excinfo.value) == message
+
+    def test_pickle(self):
+        media = PostMedia(b"data", name="image.png")
+        for level in range(pickle.HIGHEST_PROTOCOL + 1):
+            other = pickle.loads(pickle.dumps(media, protocol=level))
+            assert media == other
+
+    def test_repr(self):
+        assert repr(PostMedia(b"data", name="image.png")) == "<PostMedia name='image.png'>"
+        assert repr(WidgetMedia(b"data", name="image.jpg")) == "<WidgetMedia name='image.jpg'>"
+
+
+class TestPostMedia(UnitTest):
+    def test_upload__expected_mime_prefix(self, reddit):
+        media = PostMedia(b"data", name="test.png")
+        message = "Expected a mimetype starting with 'video' but got mimetype 'image/png' (from file name 'test.png')."
+        with pytest.raises(ClientException) as excinfo:
+            media._upload(reddit, expected_mime_prefix="video")
+        assert str(excinfo.value) == message
+
+
+class TestStylesheetImage(UnitTest):
+    def test_image_type(self):
+        jpeg = StylesheetImage(b"\xff\xd8\xff data", name="image.jpg")
+        assert jpeg._image_type == "jpg"
+        png = StylesheetImage(b"\x89PNG data", name="image.png")
+        assert png._image_type == "png"
+
+
+class TestStylesheetAsset(UnitTest):
+    def test_lease_data(self):
+        media = StylesheetAsset(b"data", name="image.png")
+        assert media._build_lease_data(imagetype="bannerBackgroundImage") == {
+            "filepath": "image.png",
+            "mimetype": "image/png",
+            "imagetype": "bannerBackgroundImage",
+        }


### PR DESCRIPTION
## Feature Summary and Justification

This completes the media upload consolidation and implements the design consensus that came out of #1891: media can now be uploaded from in-memory ``bytes`` without first being written to disk.

All media uploads now go through a new ``praw.models.media`` module with a ``Media`` base class and one subclass per upload flow:

- ``EmojiMedia`` — subreddit emojis (``SubredditEmoji.add``)
- ``PostMedia`` — image/gallery/video submissions and inline media
- ``StylesheetAsset`` — redesign style assets (banners, mobile banner)
- ``StylesheetImage`` — stylesheet images (``upload``, ``upload_header``, ``upload_mobile_header``, ``upload_mobile_icon``)
- ``WidgetMedia`` — widget images

Each is constructed from a path (``str``) or from ``bytes`` plus a required ``name=`` (used to infer the MIME type via the stdlib ``mimetypes`` module). Users only construct these objects and pass them to the existing PRAW methods; the upload machinery is internal.

```python
from praw.models import PostMedia

reddit.subreddit("test").submit_image(image_media=PostMedia("/path/to/image.png"), title="title")
reddit.subreddit("test").submit_image(image_media=PostMedia(image_bytes, name="image.png"), title="title")
```

## Design notes

- Per the #1891 discussion, there is no MIME sniffing inside PRAW — the type comes from the file name, and an unknown extension raises ``ClientException`` instead of silently defaulting to JPEG.
- The duplicated lease/S3-upload code in ``Subreddit._upload_media``, ``_read_and_post_media``, ``SubredditStylesheet._upload_image``/``_upload_style_asset``, ``SubredditEmoji.add``, and ``SubredditWidgetsModeration.upload_image`` is consolidated into the ``Media`` classes.
- The internal upload entry points take ``subreddit`` positionally for the subreddit-scoped flows (emoji, widgets, stylesheet); ``PostMedia`` takes a ``Reddit`` instance since the post media-asset endpoint is account-scoped.
- S3 uploads now go through ``prawcore``'s ``Requestor.request`` instead of the raw session, so they respect the configured ``timeout`` and raise ``prawcore.RequestException`` on transport errors like all other requests.
- ``Media`` instances support equality, hashing, and pickling (keeps ``InlineMedia`` picklable).

## Breaking changes (detailed in CHANGES.rst)

- Parameter renames across all upload methods: ``image_path``/``video_path``/``thumbnail_path``/``file_path``/``path`` → ``emoji_media``/``image_media``/``video_media``/``thumbnail_media``/``media``, taking ``Media`` instances.
- ``submit_image``, ``submit_video``, and ``submit_gallery`` arguments — including ``title`` and ``images`` — are now keyword-only.
- The single-argument stylesheet ``upload_*`` methods and ``SubredditWidgetsModeration.upload_image`` take their media argument positionally only.
- ``InlineMedia`` (``InlineGif``/``InlineImage``/``InlineVideo``) takes ``media=PostMedia(...)`` instead of ``path=...``.

New unit tests cover the media classes; all integration tests updated and passing against existing cassettes with 100% coverage.

Closes #1891
