### PR TITLE
Bump shared workflows to v1.3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     secrets:
       NETWORK_TEST_CLIENT_ID: ${{ secrets.NETWORK_TEST_CLIENT_ID }}
       NETWORK_TEST_CLIENT_SECRET: ${{ secrets.NETWORK_TEST_CLIENT_SECRET }}
-    uses: praw-dev/.github/.github/workflows/ci.yml@d00355f9d670fa915fd5cd4f0ac422061951f55a # v1.3.1
+    uses: praw-dev/.github/.github/workflows/ci.yml@1d4a4eb39290407d05b4c8fb0a7ec36fb9ff935d # v1.3.2
     with:
       min_python: "3.10"
       network_test: true

--- a/.github/workflows/pre-commit_autoupdate.yml
+++ b/.github/workflows/pre-commit_autoupdate.yml
@@ -4,7 +4,7 @@ jobs:
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-    uses: praw-dev/.github/.github/workflows/pre-commit_autoupdate.yml@d00355f9d670fa915fd5cd4f0ac422061951f55a # v1.3.1
+    uses: praw-dev/.github/.github/workflows/pre-commit_autoupdate.yml@1d4a4eb39290407d05b4c8fb0a7ec36fb9ff935d # v1.3.2
 name: Update pre-commit hooks
 on:
   schedule:

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -4,7 +4,7 @@ jobs:
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-    uses: praw-dev/.github/.github/workflows/prepare_release.yml@d00355f9d670fa915fd5cd4f0ac422061951f55a # v1.3.1
+    uses: praw-dev/.github/.github/workflows/prepare_release.yml@1d4a4eb39290407d05b4c8fb0a7ec36fb9ff935d # v1.3.2
     with:
       package: praw
       version: ${{ inputs.version }}

--- a/.github/workflows/set_active_docs.yml
+++ b/.github/workflows/set_active_docs.yml
@@ -3,7 +3,7 @@ jobs:
     name: Set Active Docs
     secrets:
       READTHEDOCS_TOKEN: ${{ secrets.READTHEDOCS_TOKEN }}
-    uses: praw-dev/.github/.github/workflows/set_active_docs.yml@d00355f9d670fa915fd5cd4f0ac422061951f55a # v1.3.1
+    uses: praw-dev/.github/.github/workflows/set_active_docs.yml@1d4a4eb39290407d05b4c8fb0a7ec36fb9ff935d # v1.3.2
 name: Set Active Docs
 on:
   release:

--- a/.github/workflows/stale_action.yml
+++ b/.github/workflows/stale_action.yml
@@ -1,7 +1,7 @@
 jobs:
   stale_action:
     name: Close stale issues and PRs
-    uses: praw-dev/.github/.github/workflows/stale_action.yml@d00355f9d670fa915fd5cd4f0ac422061951f55a # v1.3.1
+    uses: praw-dev/.github/.github/workflows/stale_action.yml@1d4a4eb39290407d05b4c8fb0a7ec36fb9ff935d # v1.3.2
 name: Close stale issues and PRs
 on:
   schedule:

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -1,7 +1,7 @@
 jobs:
   tag_release:
     name: Tag Release
-    uses: praw-dev/.github/.github/workflows/tag_release.yml@d00355f9d670fa915fd5cd4f0ac422061951f55a # v1.3.1
+    uses: praw-dev/.github/.github/workflows/tag_release.yml@1d4a4eb39290407d05b4c8fb0a7ec36fb9ff935d # v1.3.2
 name: Tag Release
 on:
   push:


### PR DESCRIPTION
v1.3.2 updates praw-release to v1.2.0, which folds prerelease changelog
sections into the final release section when bumping to a final version.
