### PR TITLE
Add PRAW 8 migration guide

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -14,6 +14,8 @@ praw follows `semantic versioning <https://semver.org/>`_.
 - Add support for Python 3.14.
 - Add support for optional Markdown-formatted ``selftext`` when submitting link, image,
   gallery, and video posts.
+- Add a :ref:`migration guide <praw8_migration>` covering all breaking changes in PRAW
+  8.
 - Add :class:`.Media` and its subclasses :class:`.EmojiMedia`, :class:`.PostMedia`,
   :class:`.StylesheetAsset`, :class:`.StylesheetImage`, and :class:`.WidgetMedia` to
   consolidate media uploads. Media can be constructed from a file path, or from

--- a/docs/_static/praw8_migration.css
+++ b/docs/_static/praw8_migration.css
@@ -1,0 +1,14 @@
+/* Tint the "old" code blocks in the PRAW 8 migration guide. */
+.code-old .highlight {
+    background-color: #fdecec;
+}
+
+body[data-theme="dark"] .code-old .highlight {
+    background-color: #3b2224;
+}
+
+@media (prefers-color-scheme: dark) {
+    body[data-theme="auto"] .code-old .highlight {
+        background-color: #3b2224;
+    }
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,8 @@ extensions = [
     "sphinx.ext.intersphinx",
     "sphinx_autodoc_typehints",
 ]
+html_css_files = ["praw8_migration.css"]
+html_static_path = ["_static"]
 html_theme = "furo"
 htmlhelp_basename = "PRAW"
 intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -62,6 +62,7 @@ application. See :ref:`oauth` for information on using **installed** application
     package_info/change_log
     package_info/contributing
     package_info/glossary
+    package_info/praw8_migration
     package_info/references
 
 .. toctree::

--- a/docs/package_info/praw8_migration.rst
+++ b/docs/package_info/praw8_migration.rst
@@ -1,0 +1,393 @@
+.. _praw8_migration:
+
+#####################
+ Migrating to PRAW 8
+#####################
+
+PRAW 8 completes the deprecation cycle started during the 7.x series. This guide covers
+every removed or changed item, with examples showing how to update your code.
+
+************************
+ Python Version Support
+************************
+
+PRAW 8 requires Python 3.10 or newer. Support for Python 3.8 and 3.9, both of which are
+end-of-life, has been dropped, and support for Python 3.13 and 3.14 has been added.
+
+***************
+ Media Uploads
+***************
+
+All methods that upload media now accept :class:`.Media` instances instead of file
+paths. The relevant subclass depends on what is being uploaded: :class:`.PostMedia` for
+submissions and inline media, :class:`.EmojiMedia` for emoji, :class:`.StylesheetImage`
+and :class:`.StylesheetAsset` for stylesheet images, and :class:`.WidgetMedia` for
+widget images.
+
+A :class:`.Media` instance can be constructed from a file path, or from ``bytes``
+content along with a ``name``, so media no longer has to be written to disk before
+uploading:
+
+.. code-block:: python
+
+    from praw.models import PostMedia
+
+    media_from_path = PostMedia("/path/to/image.png")
+    media_from_bytes = PostMedia(image_bytes, "image.png")
+
+Submitting an image
+===================
+
+All arguments to :meth:`.Subreddit.submit_image`, including ``title``, must now be
+passed by keyword.
+
+Old:
+
+.. code-block:: python
+    :class: code-old
+
+    reddit.subreddit("test").submit_image("My Title", "/path/to/image.png")
+
+New:
+
+.. code-block:: python
+
+    from praw.models import PostMedia
+
+    reddit.subreddit("test").submit_image(
+        image_media=PostMedia("/path/to/image.png"), title="My Title"
+    )
+
+Submitting a video
+==================
+
+All arguments to :meth:`.Subreddit.submit_video`, including ``title``, must now be
+passed by keyword.
+
+Old:
+
+.. code-block:: python
+    :class: code-old
+
+    reddit.subreddit("test").submit_video(
+        "My Title", "/path/to/video.mp4", thumbnail_path="/path/to/thumbnail.png"
+    )
+
+New:
+
+.. code-block:: python
+
+    from praw.models import PostMedia
+
+    reddit.subreddit("test").submit_video(
+        thumbnail_media=PostMedia("/path/to/thumbnail.png"),
+        title="My Title",
+        video_media=PostMedia("/path/to/video.mp4"),
+    )
+
+Submitting a gallery
+====================
+
+The ``image_path`` key in the ``images`` dictionaries passed to
+:meth:`.Subreddit.submit_gallery` has been replaced by ``image_media``. All arguments,
+including ``title`` and ``images``, must now be passed by keyword.
+
+Old:
+
+.. code-block:: python
+    :class: code-old
+
+    images = [
+        {"image_path": "/path/to/image.png"},
+        {"image_path": "/path/to/image2.png", "caption": "a caption"},
+    ]
+    reddit.subreddit("test").submit_gallery("My Title", images)
+
+New:
+
+.. code-block:: python
+
+    from praw.models import PostMedia
+
+    images = [
+        {"image_media": PostMedia("/path/to/image.png")},
+        {"image_media": PostMedia("/path/to/image2.png"), "caption": "a caption"},
+    ]
+    reddit.subreddit("test").submit_gallery(images=images, title="My Title")
+
+Inline media
+============
+
+The ``path`` argument to :class:`.InlineMedia` (:class:`.InlineGif`,
+:class:`.InlineImage`, and :class:`.InlineVideo`) has been replaced by ``media``, which
+takes a :class:`.PostMedia` instance.
+
+Old:
+
+.. code-block:: python
+    :class: code-old
+
+    from praw.models import InlineImage
+
+    image = InlineImage(caption="optional caption", path="/path/to/image.jpg")
+
+New:
+
+.. code-block:: python
+
+    from praw.models import InlineImage, PostMedia
+
+    image = InlineImage(caption="optional caption", media=PostMedia("/path/to/image.jpg"))
+
+Emoji
+=====
+
+The ``image_path`` argument to :meth:`.SubredditEmoji.add` has been replaced by
+``emoji_media``, which takes an :class:`.EmojiMedia` instance.
+
+Old:
+
+.. code-block:: python
+    :class: code-old
+
+    reddit.subreddit("test").emoji.add(image_path="emoji.png", name="emoji")
+
+New:
+
+.. code-block:: python
+
+    from praw.models import EmojiMedia
+
+    reddit.subreddit("test").emoji.add(emoji_media=EmojiMedia("emoji.png"), name="emoji")
+
+Stylesheet images
+=================
+
+The ``image_path`` arguments to the :class:`.SubredditStylesheet` ``upload_*`` methods
+have been replaced by ``image_media``. :meth:`.SubredditStylesheet.upload`,
+:meth:`.upload_header`, :meth:`.upload_mobile_header`, and :meth:`.upload_mobile_icon`
+take a :class:`.StylesheetImage` instance, while :meth:`.upload_banner`,
+:meth:`.upload_banner_additional_image`, :meth:`.upload_banner_hover_image`, and
+:meth:`.upload_mobile_banner` take a :class:`.StylesheetAsset` instance. Other than
+:meth:`.SubredditStylesheet.upload`, the ``image_media`` argument must be passed
+positionally.
+
+Old:
+
+.. code-block:: python
+    :class: code-old
+
+    stylesheet = reddit.subreddit("test").stylesheet
+    stylesheet.upload(image_path="img.png", name="smile")
+    stylesheet.upload_banner("banner.png")
+
+New:
+
+.. code-block:: python
+
+    from praw.models import StylesheetAsset, StylesheetImage
+
+    stylesheet = reddit.subreddit("test").stylesheet
+    stylesheet.upload(image_media=StylesheetImage("img.png"), name="smile")
+    stylesheet.upload_banner(StylesheetAsset("banner.png"))
+
+Widget images
+=============
+
+The ``file_path`` argument to :meth:`.SubredditWidgetsModeration.upload_image` has been
+replaced by ``image_media``, which takes a :class:`.WidgetMedia` instance and must be
+passed positionally.
+
+Old:
+
+.. code-block:: python
+    :class: code-old
+
+    image_url = reddit.subreddit("test").widgets.mod.upload_image("/path/to/image.jpg")
+
+New:
+
+.. code-block:: python
+
+    from praw.models import WidgetMedia
+
+    image_url = reddit.subreddit("test").widgets.mod.upload_image(
+        WidgetMedia("/path/to/image.jpg")
+    )
+
+Other media upload changes
+==========================
+
+- An unknown media type now raises :class:`.ClientException` when uploading media,
+  instead of falling back to JPEG.
+- Media uploads to Reddit's S3 buckets now respect the configured ``timeout`` and raise
+  ``prawcore.RequestException`` on transport errors, consistent with all other requests.
+  Code that caught raw ``requests`` exceptions around media uploads should catch
+  ``prawcore.RequestException`` instead.
+
+*********************************
+ ``user.me()`` in read-only mode
+*********************************
+
+Calling ``reddit.user.me()`` in :attr:`.read_only` mode previously returned ``None``
+with a deprecation warning. It now raises :class:`.ReadOnlyException`.
+
+Old:
+
+.. code-block:: python
+    :class: code-old
+
+    if reddit.user.me() is None:
+        print("Not authenticated")
+
+New:
+
+.. code-block:: python
+
+    from praw.exceptions import ReadOnlyException
+
+    try:
+        reddit.user.me()
+    except ReadOnlyException:
+        print("Not authenticated")
+
+***********************************************
+ ``Redditor.subreddit`` is a ``UserSubreddit``
+***********************************************
+
+The ``subreddit`` attribute of :class:`.Redditor` is a :class:`.UserSubreddit` instance.
+Its values are accessed as attributes; the ``dict`` interface has been removed.
+
+Old:
+
+.. code-block:: python
+    :class: code-old
+
+    title = redditor.subreddit["title"]
+
+New:
+
+.. code-block:: python
+
+    title = redditor.subreddit.title
+
+*********************************
+ Link submissions with body text
+*********************************
+
+The ``selftext`` and ``url`` arguments to :meth:`.Subreddit.submit` are no longer
+mutually exclusive. When ``url`` is provided, ``selftext`` is used as optional
+Markdown-formatted body text to accompany the link submission.
+:meth:`.Subreddit.submit_image`, :meth:`.Subreddit.submit_video`, and
+:meth:`.Subreddit.submit_gallery` also accept an optional ``selftext`` parameter.
+
+One exception: combining ``inline_media`` with ``selftext`` for a ``url`` submission
+raises an exception, because Reddit does not support inline media in body text for link
+submissions.
+
+******************************************
+ Arguments that must be passed by keyword
+******************************************
+
+The following arguments must now be passed by keyword:
+
+- The ``mark_read`` argument when calling ``subreddit.modmail`` to fetch a
+  :class:`.ModmailConversation`, e.g., ``reddit.subreddit("test").modmail("2gmz",
+  mark_read=True)``.
+- The ``is_link`` argument to :meth:`.SubredditFlairTemplates.flair_type`.
+- The ``data`` argument to ``Objector.objectify``.
+
+*********
+ Renamed
+*********
+
+- The ``reason_id`` argument to :class:`.RemovalReason` has been renamed to ``id``.
+- ``APIException`` has been removed; use :class:`.RedditAPIException`. See the `PRAW 7
+  migration documentation
+  <https://praw.readthedocs.io/en/v7.8.1/package_info/praw7_migration.html>`_ for
+  details on the exception container interface.
+- ``Subreddits.gold`` has been removed; use :meth:`.Subreddits.premium`.
+
+*************
+ Old modmail
+*************
+
+Reddit retired the old modmail system, so ``Subreddit.mod.inbox``,
+``Subreddit.mod.unread``, ``Subreddit.mod.stream.unread``, ``SubredditMessage.mute``,
+and ``SubredditMessage.unmute`` have been removed. Use the new modmail interface
+instead.
+
+Old:
+
+.. code-block:: python
+    :class: code-old
+
+    for message in reddit.subreddit("test").mod.unread():
+        print(message.subject)
+
+New:
+
+.. code-block:: python
+
+    for conversation in reddit.subreddit("test").modmail.conversations(state="new"):
+        print(conversation.subject)
+
+To stream conversations, use :meth:`.SubredditModerationStream.modmail_conversations`
+(``subreddit.mod.stream.modmail_conversations()``). Muting and unmuting users is
+available on :class:`.ModmailConversation` via :meth:`.ModmailConversation.mute` and
+:meth:`.ModmailConversation.unmute`.
+
+The ``after`` argument for :meth:`.conversations` has also been removed. To resume a
+listing from a known conversation, pass ``after`` through ``params``:
+
+.. code-block:: python
+
+    conversations = reddit.subreddit("test").modmail.conversations(params={"after": "2gmz"})
+
+****************
+ Token managers
+****************
+
+The ``token_manager`` keyword argument to :class:`.Reddit`, along with
+``BaseTokenManager``, ``FileTokenManager``, and ``SQLiteTokenManager``, has been
+removed. Refresh tokens no longer rotate, so a static ``refresh_token`` can be provided
+directly.
+
+Old:
+
+.. code-block:: python
+    :class: code-old
+
+    from praw.util.token_manager import FileTokenManager
+
+    reddit = praw.Reddit(..., token_manager=FileTokenManager("token.txt"))
+
+New:
+
+.. code-block:: python
+
+    reddit = praw.Reddit(..., refresh_token="...")
+
+See :ref:`refresh_token` for the complete guide to obtaining and using refresh tokens.
+
+*****************************
+ Removed without replacement
+*****************************
+
+The following were removed because Reddit no longer supports the underlying endpoints or
+features:
+
+- ``Reddit.random_subreddit``, ``Subreddit.random``, and ``Subreddit.random_rising`` —
+  Reddit removed the random subreddit and random submission endpoints.
+- ``Comment.award``, ``Submission.award``, and the ``gild`` aliases on
+  :class:`.Comment`, :class:`.Redditor`, and :class:`.Submission` — Reddit removed the
+  awards API.
+- ``Redditor.gilded``, ``Subreddit.gilded``, and ``Redditor.gildings`` — gilded listings
+  were removed along with the awards API.
+- ``Subreddits.search_by_topic`` — the endpoint has returned 404 since 2020.
+- ``Reddit.validate_on_submit`` — Reddit now always validates posts on submission, so
+  the setting no longer has any effect. Remove any assignments to it.
+- ``WebSocketException.original_exception``.
+- ``InboxableMixin.unblock_subreddit``.
+- The ``reset_timestamp`` key in the dictionary returned by :meth:`.limits` — the
+  remaining keys are ``remaining`` and ``used``.


### PR DESCRIPTION
Adds `docs/package_info/praw8_migration.rst` (modeled on the PRAW 7 migration guide) covering every removed or changed item in the Unreleased changelog, each with before/after examples:

- **Media uploads**: `PostMedia`/`EmojiMedia`/`StylesheetImage`/`StylesheetAsset`/`WidgetMedia` replacing path arguments across `submit_image`/`submit_video`/`submit_gallery`, inline media, emoji, stylesheet, and widget methods — including the bytes+name construction that avoids writing to disk, the keyword-only requirements, the unknown-media-type `ClientException`, and the S3 timeout/exception change
- **Behavior changes**: `user.me()` raising `ReadOnlyException` in read-only mode, `Redditor.subreddit` as `UserSubreddit` (attribute access), link submissions with `selftext` body text and the `inline_media` exception
- **Keyword-only arguments** and **renames** (`reason_id` → `id`, `APIException` → `RedditAPIException`, `gold` → `premium`)
- **Old modmail removal** with new-modmail equivalents (conversations, streaming, mute/unmute, `after` via `params`)
- **Token managers** → static `refresh_token`, linking to the refresh token tutorial
- **Removed without replacement** (random endpoints, awards/gilding, `search_by_topic`, `validate_on_submit`, etc.) with rationale

Linked from the index TOC (alphabetical position) and referenced from the changelog. Sphinx build is clean (all cross-references resolve) and docstrfmt passes.