### PR TITLE
Merge per-kind submit methods into Subreddit.submit

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,0 @@
-[report]
-exclude_lines =
-    if TYPE_CHECKING:
-    pragma: no cover

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,20 @@ praw follows `semantic versioning <https://semver.org/>`_.
  Unreleased
 ************
 
+**Changed**
+
+- ``Subreddit.submit_gallery``, ``Subreddit.submit_image``, ``Subreddit.submit_poll``,
+  and ``Subreddit.submit_video`` have been merged into :meth:`.Subreddit.submit`. The
+  kind of submission is selected with the ``gallery``, ``image``, ``poll``, ``url``, or
+  ``video`` keyword argument. At least one of those, or ``selftext``, must be provided,
+  and they are mutually exclusive, while ``selftext`` may accompany any of them as
+  optional Markdown-formatted body text. ``image`` takes a :class:`.PostMedia` instance;
+  ``gallery`` takes a list of :class:`.PostMedia` instances or ``dict``\ s with a
+  ``media`` key; ``video`` takes a :class:`.PostMedia` instance or a ``dict`` with a
+  ``media`` key and optional ``gif`` and ``thumbnail`` keys; and ``poll`` takes a
+  ``dict`` with ``duration`` and ``options`` keys. ``selftext`` is no longer required
+  for poll submissions.
+
 ***********************
  8.0.0rc1 (2026/06/08)
 ***********************
@@ -45,39 +59,24 @@ praw follows `semantic versioning <https://semver.org/>`_.
   body text to accompany the link submission. An exception is raised when trying to use
   ``inline_media`` with ``selftext`` for a ``url`` submission because Reddit does not
   support inline media in body text for link submissions.
-- :meth:`.Subreddit.submit_video`, :meth:`.Subreddit.submit_gallery`, and
-  :meth:`.Subreddit.submit_image` now accept an optional Markdown-formatted ``selftext``
+- ``Subreddit.submit_video``, ``Subreddit.submit_gallery``, and
+  ``Subreddit.submit_image`` now accept an optional Markdown-formatted ``selftext``
   parameter.
 - The ``reason_id`` argument to :class:`.RemovalReason` has been renamed to ``id``.
 - Media upload methods now accept :class:`.Media` instances instead of file paths:
 
   - The ``image_path`` argument to :meth:`.SubredditEmoji.add` has been replaced by
-    ``emoji_media``, which takes an :class:`.EmojiMedia` instance.
-  - The ``image_path`` arguments to :meth:`.SubredditStylesheet.upload`,
-    :meth:`.upload_header`, :meth:`.upload_mobile_header`, and
-    :meth:`.upload_mobile_icon` have been replaced by ``image_media``, which takes a
-    :class:`.StylesheetImage` instance.
-  - The ``image_path`` arguments to :meth:`.SubredditStylesheet.upload_banner`,
+    ``media``, which takes an :class:`.EmojiMedia` instance.
+  - The ``image_path`` arguments to the :class:`.SubredditStylesheet` ``upload_*``
+    methods have been replaced by ``media``, which must be passed positionally.
+    :meth:`.SubredditStylesheet.upload`, :meth:`.upload_header`,
+    :meth:`.upload_mobile_header`, and :meth:`.upload_mobile_icon` take a
+    :class:`.StylesheetImage` instance, while :meth:`.upload_banner`,
     :meth:`.upload_banner_additional_image`, :meth:`.upload_banner_hover_image`, and
-    :meth:`.upload_mobile_banner` have been replaced by ``image_media``, which takes a
-    :class:`.StylesheetAsset` instance.
-  - The ``image_media`` arguments to the :class:`.SubredditStylesheet` ``upload_*``
-    methods, other than :meth:`.SubredditStylesheet.upload`, must be passed
-    positionally.
+    :meth:`.upload_mobile_banner` take a :class:`.StylesheetAsset` instance.
   - The ``file_path`` argument to :meth:`.SubredditWidgetsModeration.upload_image` has
-    been replaced by ``image_media``, which takes a :class:`.WidgetMedia` instance and
-    must be passed positionally.
-  - The ``image_path`` argument to :meth:`.Subreddit.submit_image` has been replaced by
-    ``image_media``, which takes a :class:`.PostMedia` instance. All arguments,
-    including ``title``, must now be passed by keyword.
-  - The ``video_path`` and ``thumbnail_path`` arguments to
-    :meth:`.Subreddit.submit_video` have been replaced by ``video_media`` and
-    ``thumbnail_media``, which take :class:`.PostMedia` instances. All arguments,
-    including ``title``, must now be passed by keyword.
-  - The ``image_path`` key in the ``images`` dictionaries passed to
-    :meth:`.Subreddit.submit_gallery` has been replaced by ``image_media``, which takes
-    a :class:`.PostMedia` instance. All arguments, including ``title`` and ``images``,
-    must now be passed by keyword.
+    been replaced by ``media``, which takes a :class:`.WidgetMedia` instance and must be
+    passed positionally.
   - The ``path`` argument to :class:`.InlineMedia` (:class:`.InlineGif`,
     :class:`.InlineImage`, and :class:`.InlineVideo`) has been replaced by ``media``,
     which takes a :class:`.PostMedia` instance.
@@ -398,7 +397,7 @@ praw follows `semantic versioning <https://semver.org/>`_.
 **Added**
 
 - Add method :meth:`.Subreddits.premium` to reflect the naming change in Reddit's API.
-- Ability to submit image galleries with :meth:`~.Subreddit.submit_gallery`.
+- Ability to submit image galleries with ``Subreddit.submit_gallery``.
 - Ability to pass a gallery url to :meth:`.Reddit.submission`.
 - Ability to specify modmail mute duration.
 - Add method :meth:`.invited` to get invited moderators of a subreddit.
@@ -416,9 +415,9 @@ praw follows `semantic versioning <https://semver.org/>`_.
 - Drop support for Python 3.5, which is end-of-life on 2020-09-13.
 - :class:`.BoundedSet` will now utilize a Last-Recently-Used (LRU) storing mechanism,
   which will change the order in which elements are removed from the set.
-- Improved :meth:`~.Subreddit.submit_image` and :meth:`~.Subreddit.submit_video`
-  performance in slow network environments by removing a race condition when
-  establishing a websocket connection.
+- Improved ``Subreddit.submit_image`` and ``Subreddit.submit_video`` performance in slow
+  network environments by removing a race condition when establishing a websocket
+  connection.
 
 **Deprecated**
 
@@ -441,7 +440,7 @@ praw follows `semantic versioning <https://semver.org/>`_.
 
 - :class:`.Rule` to represent one rule of a subreddit.
 - :class:`.SubredditRules` to get and add rules.
-- Ability to submit polls with :meth:`~.Subreddit.submit_poll`.
+- Ability to submit polls with ``Subreddit.submit_poll``.
 - :class:`.PollData` and :class:`.PollOption`.
 - Ability to view poll data and poll options via the ``.poll_data`` attribute on poll
   submissions.
@@ -473,7 +472,7 @@ praw follows `semantic versioning <https://semver.org/>`_.
   subreddit settings and send unmodified ones in the update request.
 - Instances of ``BadRequest``\ s captured by PRAW that do not contain any detailed JSON
   data are re-raised as the original ``BadRequest``.
-- :meth:`~.Subreddit.submit_image` and :meth:`~.Subreddit.submit_video` will throw
+- ``Subreddit.submit_image`` and ``Subreddit.submit_video`` will throw
   :class:`.MediaPostFailed` when Reddit fails to post an image or video post.
 
 ********************
@@ -512,16 +511,16 @@ praw follows `semantic versioning <https://semver.org/>`_.
   generated by trying to sticky the same post multiple times.
 - A new method :meth:`.CommentModeration.show` will uncollapse a comment that was
   collapsed because of Crowd Control
-- Methods :meth:`~.Subreddit.submit_image` and :meth:`~.Subreddit.submit_video` will
-  throw :class:`.TooLargeMediaException` if the submitted media is rejected by Reddit
-  due to the size of the media.
+- Methods ``Subreddit.submit_image`` and ``Subreddit.submit_video`` will throw
+  :class:`.TooLargeMediaException` if the submitted media is rejected by Reddit due to
+  the size of the media.
 - Class :class:`.Reddit` has an attribute, ``validate_on_submit``, that can be set after
   class initialization that causes methods :meth:`~.Subreddit.submit`,
-  :meth:`~.Subreddit.submit_image`, :meth:`~.Subreddit.submit_video`, and
-  :meth:`.Submission.edit` to check that the submission matches a subreddit's post
-  validation rules. This attribute will be functionally useless once Reddit implements
-  their change. This attribute will be deprecated on the next release after Reddit's
-  change, and will be removed on the next major release after Reddit's change.
+  ``Subreddit.submit_image``, ``Subreddit.submit_video``, and :meth:`.Submission.edit`
+  to check that the submission matches a subreddit's post validation rules. This
+  attribute will be functionally useless once Reddit implements their change. This
+  attribute will be deprecated on the next release after Reddit's change, and will be
+  removed on the next major release after Reddit's change.
 
 .. warning::
 
@@ -535,8 +534,8 @@ praw follows `semantic versioning <https://semver.org/>`_.
   ``RedditAPIException.items``, which returns a list.
 - ``APIException`` is an alias to :class:`.RedditAPIException`.
 - Parameter ``discussion_type`` to methods :meth:`~.Subreddit.submit`,
-  :meth:`~.Subreddit.submit_image`, and :meth:`~.Subreddit.submit_video` to support
-  submitting as a live discussion (set to ``"CHAT"``).
+  ``Subreddit.submit_image``, and ``Subreddit.submit_video`` to support submitting as a
+  live discussion (set to ``"CHAT"``).
 - Instances of :class:`.Trophy` can be compared for equality with each other.
 - :class:`.Reddit` has a new configurable parameter, ``timeout``. This defaults to 16
   seconds. It controls how long PRAW will wait for a response before throwing an
@@ -592,8 +591,8 @@ praw follows `semantic versioning <https://semver.org/>`_.
 - :meth:`.set_original_content` supports marking a submission as original content.
 - :meth:`.unset_original_content` supports unmarking a submission as original content.
 - :meth:`.moderated` to get a list of a redditor's moderated subreddits.
-- Parameter ``without_websockets`` to :meth:`~.Subreddit.submit_image` and
-  :meth:`~.Subreddit.submit_video` to submit without using WebSockets.
+- Parameter ``without_websockets`` to ``Subreddit.submit_image`` and
+  ``Subreddit.submit_video`` to submit without using WebSockets.
 - :meth:`.Reddit.redditor` supports ``fullname`` param to fetch a :class:`.Redditor` by
   the fullname instead of name. :class:`.Redditor` constructor now also has ``fullname``
   param.
@@ -693,9 +692,8 @@ praw follows `semantic versioning <https://semver.org/>`_.
 **Added**
 
 - Collections (:class:`.Collection` and helper classes).
-- :meth:`~.Subreddit.submit`, :meth:`~.Subreddit.submit_image`, and
-  :meth:`~.Subreddit.submit_video` can be used to submit a post directly to a
-  collection.
+- :meth:`~.Subreddit.submit`, ``Subreddit.submit_image``, and ``Subreddit.submit_video``
+  can be used to submit a post directly to a collection.
 - ``praw.util.camel_to_snake`` and ``praw.util.snake_case_keys``.
 - Comments can now be locked and unlocked via ``comment.mod.lock()`` and
   ``comment.mod.unlock()``. See: (:meth:`~.ThingModerationMixin.lock` and
@@ -721,14 +719,13 @@ praw follows `semantic versioning <https://semver.org/>`_.
 - :meth:`.delete_banner`
 - :meth:`.delete_banner_additional_image`
 - :meth:`.delete_banner_hover_image`
-- :meth:`~.Subreddit.submit`, :meth:`~.Subreddit.submit_image`, and
-  :meth:`~.Subreddit.submit_video` support parameter ``nsfw`` to mark the submission
-  NSFW immediately upon posting.
-- :meth:`~.Subreddit.submit`, :meth:`~.Subreddit.submit_image`, and
-  :meth:`~.Subreddit.submit_video` support parameter ``spoiler`` to mark the submission
-  as a spoiler immediately upon posting.
-- :meth:`~.Subreddit.submit_image` and :meth:`~.Subreddit.submit_video` support
-  parameter ``timeout``. Default timeout has been raised from 2 seconds to 10 seconds.
+- :meth:`~.Subreddit.submit`, ``Subreddit.submit_image``, and ``Subreddit.submit_video``
+  support parameter ``nsfw`` to mark the submission NSFW immediately upon posting.
+- :meth:`~.Subreddit.submit`, ``Subreddit.submit_image``, and ``Subreddit.submit_video``
+  support parameter ``spoiler`` to mark the submission as a spoiler immediately upon
+  posting.
+- ``Subreddit.submit_image`` and ``Subreddit.submit_video`` support parameter
+  ``timeout``. Default timeout has been raised from 2 seconds to 10 seconds.
 - Added parameter ``function_kwargs`` to :func:`.stream_generator` to pass additional
   kwargs to ``function``.
 
@@ -774,9 +771,8 @@ praw follows `semantic versioning <https://semver.org/>`_.
 - Add method :meth:`~.SubredditWidgetsModeration.reorder` to reorder a subreddit's
   widgets.
 - Add :class:`.Redditors` (``reddit.redditors``) to provide :class:`.Redditor` listings.
-- Add :meth:`~.Subreddit.submit_image` for submitting native images to Reddit.
-- Add :meth:`~.Subreddit.submit_video` for submitting native videos and videogifs to
-  Reddit.
+- Add ``Subreddit.submit_image`` for submitting native images to Reddit.
+- Add ``Subreddit.submit_video`` for submitting native videos and videogifs to Reddit.
 
 **Changed**
 

--- a/docs/package_info/praw8_migration.rst
+++ b/docs/package_info/praw8_migration.rst
@@ -35,86 +35,6 @@ uploading:
     media_from_path = PostMedia("/path/to/image.png")
     media_from_bytes = PostMedia(image_bytes, "image.png")
 
-Submitting an image
-===================
-
-All arguments to :meth:`.Subreddit.submit_image`, including ``title``, must now be
-passed by keyword.
-
-Old:
-
-.. code-block:: python
-    :class: code-old
-
-    reddit.subreddit("test").submit_image("My Title", "/path/to/image.png")
-
-New:
-
-.. code-block:: python
-
-    from praw.models import PostMedia
-
-    reddit.subreddit("test").submit_image(
-        image_media=PostMedia("/path/to/image.png"), title="My Title"
-    )
-
-Submitting a video
-==================
-
-All arguments to :meth:`.Subreddit.submit_video`, including ``title``, must now be
-passed by keyword.
-
-Old:
-
-.. code-block:: python
-    :class: code-old
-
-    reddit.subreddit("test").submit_video(
-        "My Title", "/path/to/video.mp4", thumbnail_path="/path/to/thumbnail.png"
-    )
-
-New:
-
-.. code-block:: python
-
-    from praw.models import PostMedia
-
-    reddit.subreddit("test").submit_video(
-        thumbnail_media=PostMedia("/path/to/thumbnail.png"),
-        title="My Title",
-        video_media=PostMedia("/path/to/video.mp4"),
-    )
-
-Submitting a gallery
-====================
-
-The ``image_path`` key in the ``images`` dictionaries passed to
-:meth:`.Subreddit.submit_gallery` has been replaced by ``image_media``. All arguments,
-including ``title`` and ``images``, must now be passed by keyword.
-
-Old:
-
-.. code-block:: python
-    :class: code-old
-
-    images = [
-        {"image_path": "/path/to/image.png"},
-        {"image_path": "/path/to/image2.png", "caption": "a caption"},
-    ]
-    reddit.subreddit("test").submit_gallery("My Title", images)
-
-New:
-
-.. code-block:: python
-
-    from praw.models import PostMedia
-
-    images = [
-        {"image_media": PostMedia("/path/to/image.png")},
-        {"image_media": PostMedia("/path/to/image2.png"), "caption": "a caption"},
-    ]
-    reddit.subreddit("test").submit_gallery(images=images, title="My Title")
-
 Inline media
 ============
 
@@ -143,7 +63,7 @@ Emoji
 =====
 
 The ``image_path`` argument to :meth:`.SubredditEmoji.add` has been replaced by
-``emoji_media``, which takes an :class:`.EmojiMedia` instance.
+``media``, which takes an :class:`.EmojiMedia` instance.
 
 Old:
 
@@ -158,19 +78,18 @@ New:
 
     from praw.models import EmojiMedia
 
-    reddit.subreddit("test").emoji.add(emoji_media=EmojiMedia("emoji.png"), name="emoji")
+    reddit.subreddit("test").emoji.add(media=EmojiMedia("emoji.png"), name="emoji")
 
 Stylesheet images
 =================
 
 The ``image_path`` arguments to the :class:`.SubredditStylesheet` ``upload_*`` methods
-have been replaced by ``image_media``. :meth:`.SubredditStylesheet.upload`,
-:meth:`.upload_header`, :meth:`.upload_mobile_header`, and :meth:`.upload_mobile_icon`
-take a :class:`.StylesheetImage` instance, while :meth:`.upload_banner`,
+have been replaced by ``media``, which must be passed positionally.
+:meth:`.SubredditStylesheet.upload`, :meth:`.upload_header`,
+:meth:`.upload_mobile_header`, and :meth:`.upload_mobile_icon` take a
+:class:`.StylesheetImage` instance, while :meth:`.upload_banner`,
 :meth:`.upload_banner_additional_image`, :meth:`.upload_banner_hover_image`, and
-:meth:`.upload_mobile_banner` take a :class:`.StylesheetAsset` instance. Other than
-:meth:`.SubredditStylesheet.upload`, the ``image_media`` argument must be passed
-positionally.
+:meth:`.upload_mobile_banner` take a :class:`.StylesheetAsset` instance.
 
 Old:
 
@@ -188,15 +107,15 @@ New:
     from praw.models import StylesheetAsset, StylesheetImage
 
     stylesheet = reddit.subreddit("test").stylesheet
-    stylesheet.upload(image_media=StylesheetImage("img.png"), name="smile")
+    stylesheet.upload(StylesheetImage("img.png"), name="smile")
     stylesheet.upload_banner(StylesheetAsset("banner.png"))
 
 Widget images
 =============
 
 The ``file_path`` argument to :meth:`.SubredditWidgetsModeration.upload_image` has been
-replaced by ``image_media``, which takes a :class:`.WidgetMedia` instance and must be
-passed positionally.
+replaced by ``media``, which takes a :class:`.WidgetMedia` instance and must be passed
+positionally.
 
 Old:
 
@@ -224,6 +143,135 @@ Other media upload changes
   ``prawcore.RequestException`` on transport errors, consistent with all other requests.
   Code that caught raw ``requests`` exceptions around media uploads should catch
   ``prawcore.RequestException`` instead.
+
+***************************
+ Unified ``submit`` method
+***************************
+
+``Subreddit.submit_gallery``, ``Subreddit.submit_image``, ``Subreddit.submit_poll``, and
+``Subreddit.submit_video`` have been merged into :meth:`.Subreddit.submit`. The kind of
+submission is selected with the ``gallery``, ``image``, ``poll``, ``url``, or ``video``
+keyword argument. At least one of those, or ``selftext``, must be provided, and they are
+mutually exclusive, while ``selftext`` may accompany any of them as optional
+Markdown-formatted body text.
+
+Submitting an image
+===================
+
+Old:
+
+.. code-block:: python
+    :class: code-old
+
+    reddit.subreddit("test").submit_image("My Title", "/path/to/image.png")
+
+New:
+
+.. code-block:: python
+
+    from praw.models import PostMedia
+
+    reddit.subreddit("test").submit("My Title", image=PostMedia("/path/to/image.png"))
+
+Submitting a video
+==================
+
+Video-specific options, such as a custom thumbnail or submitting the video as a
+videogif, are provided by passing a ``dict`` instead of a bare :class:`.PostMedia`.
+
+Old:
+
+.. code-block:: python
+    :class: code-old
+
+    reddit.subreddit("test").submit_video(
+        "My Title", "/path/to/video.mp4", thumbnail_path="/path/to/thumbnail.png"
+    )
+
+New:
+
+.. code-block:: python
+
+    from praw.models import PostMedia
+
+    reddit.subreddit("test").submit(
+        "My Title",
+        video={
+            "media": PostMedia("/path/to/video.mp4"),
+            "thumbnail": PostMedia("/path/to/thumbnail.png"),
+        },
+    )
+
+The ``videogif`` argument is now the ``"gif"`` key of the ``video`` dict:
+
+Old:
+
+.. code-block:: python
+    :class: code-old
+
+    reddit.subreddit("test").submit_video("My Title", "/path/to/video.mp4", videogif=True)
+
+New:
+
+.. code-block:: python
+
+    from praw.models import PostMedia
+
+    reddit.subreddit("test").submit(
+        "My Title", video={"gif": True, "media": PostMedia("/path/to/video.mp4")}
+    )
+
+Submitting a gallery
+====================
+
+Gallery items are either a bare :class:`.PostMedia`, or a ``dict`` with a ``media`` key
+(replacing ``image_path``) when a ``caption`` or ``outbound_url`` is desired.
+
+Old:
+
+.. code-block:: python
+    :class: code-old
+
+    images = [
+        {"image_path": "/path/to/image.png"},
+        {"image_path": "/path/to/image2.png", "caption": "a caption"},
+    ]
+    reddit.subreddit("test").submit_gallery("My Title", images)
+
+New:
+
+.. code-block:: python
+
+    from praw.models import PostMedia
+
+    gallery = [
+        PostMedia("/path/to/image.png"),
+        {"caption": "a caption", "media": PostMedia("/path/to/image2.png")},
+    ]
+    reddit.subreddit("test").submit("My Title", gallery=gallery)
+
+Submitting a poll
+=================
+
+The ``options`` and ``duration`` arguments are now keys of the ``poll`` dict.
+``selftext`` is no longer required for polls.
+
+Old:
+
+.. code-block:: python
+    :class: code-old
+
+    reddit.subreddit("test").submit_poll(
+        "Do you like PRAW?", duration=3, options=["Yes", "No"], selftext=""
+    )
+
+New:
+
+.. code-block:: python
+
+    reddit.subreddit("test").submit(
+        "Do you like PRAW?", poll={"duration": 3, "options": ["Yes", "No"]}
+    )
 
 *********************************
  ``user.me()`` in read-only mode
@@ -277,9 +325,8 @@ New:
 
 The ``selftext`` and ``url`` arguments to :meth:`.Subreddit.submit` are no longer
 mutually exclusive. When ``url`` is provided, ``selftext`` is used as optional
-Markdown-formatted body text to accompany the link submission.
-:meth:`.Subreddit.submit_image`, :meth:`.Subreddit.submit_video`, and
-:meth:`.Subreddit.submit_gallery` also accept an optional ``selftext`` parameter.
+Markdown-formatted body text to accompany the link submission. The same applies to
+``gallery``, ``image``, ``poll``, and ``video`` submissions.
 
 One exception: combining ``inline_media`` with ``selftext`` for a ``url`` submission
 raises an exception, because Reddit does not support inline media in body text for link

--- a/praw/models/media.py
+++ b/praw/models/media.py
@@ -147,8 +147,7 @@ class EmojiMedia(Media):
 class PostMedia(Media):
     """Media to be uploaded as part of a submission.
 
-    See :meth:`.Subreddit.submit_image`, :meth:`.Subreddit.submit_gallery`,
-    :meth:`.Subreddit.submit_video`, and :class:`.InlineMedia`.
+    See :meth:`.Subreddit.submit` and :class:`.InlineMedia`.
 
     """
 

--- a/praw/models/reddit/draft.py
+++ b/praw/models/reddit/draft.py
@@ -184,12 +184,7 @@ class Draft(RedditBase):
 
         .. seealso::
 
-            - :meth:`~.Subreddit.submit` to submit url posts and selftexts
-            - :meth:`~.Subreddit.submit_gallery`. to submit more than one image in the
-              same post
-            - :meth:`~.Subreddit.submit_image` to submit images
-            - :meth:`~.Subreddit.submit_poll` to submit polls
-            - :meth:`~.Subreddit.submit_video` to submit videos and videogifs
+            :meth:`~.Subreddit.submit` to make a submission directly.
 
         """
         submit_kwargs["draft_id"] = self.id

--- a/praw/models/reddit/emoji.py
+++ b/praw/models/reddit/emoji.py
@@ -180,7 +180,7 @@ class SubredditEmoji:
     def add(
         self,
         *,
-        emoji_media: models.EmojiMedia,
+        media: models.EmojiMedia,
         mod_flair_only: bool | None = None,
         name: str,
         post_flair_allowed: bool | None = None,
@@ -188,7 +188,7 @@ class SubredditEmoji:
     ) -> Emoji:
         """Add an emoji to this subreddit.
 
-        :param emoji_media: The :class:`.EmojiMedia` to be uploaded as an emoji.
+        :param media: The :class:`.EmojiMedia` to be uploaded as an emoji.
         :param mod_flair_only: When provided, indicate whether the emoji is restricted
             to mod use only (default: ``None``).
         :param name: The name of the emoji.
@@ -205,11 +205,11 @@ class SubredditEmoji:
 
             from praw.models import EmojiMedia
 
-            emoji_media = EmojiMedia("emoji.png")
-            reddit.subreddit("test").emoji.add(emoji_media=emoji_media, name="emoji")
+            media = EmojiMedia("emoji.png")
+            reddit.subreddit("test").emoji.add(media=media, name="emoji")
 
         """
-        s3_key = emoji_media._upload(self.subreddit)
+        s3_key = media._upload(self.subreddit)
 
         data = {
             "mod_flair_only": mod_flair_only,

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -1644,10 +1644,10 @@ class SubredditStylesheet:
         url = API_PATH["subreddit_stylesheet"].format(subreddit=self.subreddit)
         self.subreddit._reddit.post(url, data=data)
 
-    def upload(self, *, image_media: models.StylesheetImage, name: str) -> dict[str, str]:
+    def upload(self, media: models.StylesheetImage, /, *, name: str) -> dict[str, str]:
         """Upload an image to the :class:`.Subreddit`.
 
-        :param image_media: The :class:`.StylesheetImage` to upload.
+        :param media: The :class:`.StylesheetImage` to upload.
         :param name: The name to use for the image. If an image already exists with the
             same name, it will be replaced.
 
@@ -1666,17 +1666,15 @@ class SubredditStylesheet:
 
             from praw.models import StylesheetImage
 
-            reddit.subreddit("test").stylesheet.upload(
-                image_media=StylesheetImage("img.png"), name="smile"
-            )
+            reddit.subreddit("test").stylesheet.upload(StylesheetImage("img.png"), name="smile")
 
         """
-        return image_media._upload(self.subreddit, name=name, upload_type="img")
+        return media._upload(self.subreddit, name=name, upload_type="img")
 
-    def upload_banner(self, image_media: models.StylesheetAsset, /) -> None:
+    def upload_banner(self, media: models.StylesheetAsset, /) -> None:
         """Upload an image for the :class:`.Subreddit`'s (redesign) banner image.
 
-        :param image_media: The :class:`.StylesheetAsset` to upload.
+        :param media: The :class:`.StylesheetAsset` to upload.
 
         :raises: ``prawcore.TooLarge`` if the overall request body is too large.
         :raises: :class:`.RedditAPIException` if there are other issues with the
@@ -1694,19 +1692,19 @@ class SubredditStylesheet:
 
         """
         image_type = "bannerBackgroundImage"
-        image_url = image_media._upload(self.subreddit, image_type=image_type)
+        image_url = media._upload(self.subreddit, image_type=image_type)
         self._update_structured_styles({image_type: image_url})
 
     def upload_banner_additional_image(
         self,
-        image_media: models.StylesheetAsset,
+        media: models.StylesheetAsset,
         /,
         *,
         align: str | None = None,
     ) -> None:
         """Upload an image for the :class:`.Subreddit`'s (redesign) additional image.
 
-        :param image_media: The :class:`.StylesheetAsset` to upload.
+        :param media: The :class:`.StylesheetAsset` to upload.
         :param align: Either ``"left"``, ``"centered"``, or ``"right"``. (default:
             ``"left"``).
 
@@ -1734,16 +1732,16 @@ class SubredditStylesheet:
             alignment["bannerPositionedImagePosition"] = align
 
         image_type = "bannerPositionedImage"
-        image_url = image_media._upload(self.subreddit, image_type=image_type)
+        image_url = media._upload(self.subreddit, image_type=image_type)
         style_data = {image_type: image_url}
         if alignment:
             style_data.update(alignment)
         self._update_structured_styles(style_data)
 
-    def upload_banner_hover_image(self, image_media: models.StylesheetAsset, /) -> None:
+    def upload_banner_hover_image(self, media: models.StylesheetAsset, /) -> None:
         """Upload an image for the :class:`.Subreddit`'s (redesign) additional image.
 
-        :param image_media: The :class:`.StylesheetAsset` to upload.
+        :param media: The :class:`.StylesheetAsset` to upload.
 
         Fails if the :class:`.Subreddit` does not have an additional image defined.
 
@@ -1764,13 +1762,13 @@ class SubredditStylesheet:
 
         """
         image_type = "secondaryBannerPositionedImage"
-        image_url = image_media._upload(self.subreddit, image_type=image_type)
+        image_url = media._upload(self.subreddit, image_type=image_type)
         self._update_structured_styles({image_type: image_url})
 
-    def upload_header(self, image_media: models.StylesheetImage, /) -> dict[str, str]:
+    def upload_header(self, media: models.StylesheetImage, /) -> dict[str, str]:
         """Upload an image to be used as the :class:`.Subreddit`'s header image.
 
-        :param image_media: The :class:`.StylesheetImage` to upload.
+        :param media: The :class:`.StylesheetImage` to upload.
 
         :returns: A dictionary containing a link to the uploaded image under the key
             ``img_src``.
@@ -1790,12 +1788,12 @@ class SubredditStylesheet:
             reddit.subreddit("test").stylesheet.upload_header(StylesheetImage("header.png"))
 
         """
-        return image_media._upload(self.subreddit, upload_type="header")
+        return media._upload(self.subreddit, upload_type="header")
 
-    def upload_mobile_banner(self, image_media: models.StylesheetAsset, /) -> None:
+    def upload_mobile_banner(self, media: models.StylesheetAsset, /) -> None:
         """Upload an image for the :class:`.Subreddit`'s (redesign) mobile banner.
 
-        :param image_media: The :class:`.StylesheetAsset` to upload.
+        :param media: The :class:`.StylesheetAsset` to upload.
 
         For example:
 
@@ -1816,13 +1814,13 @@ class SubredditStylesheet:
 
         """
         image_type = "mobileBannerImage"
-        image_url = image_media._upload(self.subreddit, image_type=image_type)
+        image_url = media._upload(self.subreddit, image_type=image_type)
         self._update_structured_styles({image_type: image_url})
 
-    def upload_mobile_header(self, image_media: models.StylesheetImage, /) -> dict[str, str]:
+    def upload_mobile_header(self, media: models.StylesheetImage, /) -> dict[str, str]:
         """Upload an image to be used as the :class:`.Subreddit`'s mobile header.
 
-        :param image_media: The :class:`.StylesheetImage` to upload.
+        :param media: The :class:`.StylesheetImage` to upload.
 
         :returns: A dictionary containing a link to the uploaded image under the key
             ``img_src``.
@@ -1842,12 +1840,12 @@ class SubredditStylesheet:
             reddit.subreddit("test").stylesheet.upload_mobile_header(StylesheetImage("header.png"))
 
         """
-        return image_media._upload(self.subreddit, upload_type="banner")
+        return media._upload(self.subreddit, upload_type="banner")
 
-    def upload_mobile_icon(self, image_media: models.StylesheetImage, /) -> dict[str, str]:
+    def upload_mobile_icon(self, media: models.StylesheetImage, /) -> dict[str, str]:
         """Upload an image to be used as the :class:`.Subreddit`'s mobile icon.
 
-        :param image_media: The :class:`.StylesheetImage` to upload.
+        :param media: The :class:`.StylesheetImage` to upload.
 
         :returns: A dictionary containing a link to the uploaded image under the key
             ``img_src``.
@@ -1867,7 +1865,7 @@ class SubredditStylesheet:
             reddit.subreddit("test").stylesheet.upload_mobile_icon(StylesheetImage("icon.png"))
 
         """
-        return image_media._upload(self.subreddit, upload_type="icon")
+        return media._upload(self.subreddit, upload_type="icon")
 
 
 class SubredditWiki:
@@ -2408,9 +2406,9 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
     @staticmethod
     def _validate_gallery(images: list[dict[str, str | PostMedia]]) -> None:
         for image in images:
-            image_media = image.get("image_media")
-            if not isinstance(image_media, PostMedia):
-                msg = "'image_media' is required and must be a PostMedia instance."
+            media = image.get("media")
+            if not isinstance(media, PostMedia):
+                msg = "'media' is required and must be a PostMedia instance."
                 raise TypeError(msg)
             if not len(image.get("caption", "")) <= Subreddit.MAX_CAPTION_LENGTH:
                 msg = "Caption must be 180 characters or less."
@@ -2943,14 +2941,20 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
         draft_id: str | None = None,
         flair_id: str | None = None,
         flair_text: str | None = None,
+        gallery: list[models.PostMedia | dict[str, str | models.PostMedia]] | None = None,
+        image: models.PostMedia | None = None,
         inline_media: dict[str, models.InlineMedia] | None = None,
         nsfw: bool = False,
+        poll: dict[str, int | list[str]] | None = None,
         resubmit: bool = True,
         selftext: str | None = None,
         send_replies: bool = True,
         spoiler: bool = False,
+        timeout: int = 10,
         url: str | None = None,
-    ) -> models.Submission:
+        video: models.PostMedia | dict[str, bool | models.PostMedia] | None = None,
+        without_websockets: bool = False,
+    ) -> models.Submission | None:
         r"""Add a submission to the :class:`.Subreddit`.
 
         :param title: The title of the submission.
@@ -2958,32 +2962,59 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
             newly-submitted post to.
         :param discussion_type: Set to ``"CHAT"`` to enable live discussion instead of
             traditional comments (default: ``None``).
-        :param draft_id: The ID of a draft to submit.
+        :param draft_id: The ID of a draft to submit. Only applies to text and link
+            submissions.
         :param flair_id: The flair template to select (default: ``None``).
         :param flair_text: If the template's ``flair_text_editable`` value is ``True``,
             this value will set a custom text (default: ``None``). ``flair_id`` is
             required when ``flair_text`` is provided.
+        :param gallery: A list of images to post as a gallery. Each item is either a
+            :class:`.PostMedia` or a ``dict`` with the structure ``{"media":
+            PostMedia("path"), "caption": "caption", "outbound_url": "url"}``, where
+            only ``media`` is required.
+        :param image: The :class:`.PostMedia` image to upload and post.
         :param inline_media: A dict of :class:`.InlineMedia` objects where the key is
-            the placeholder name in ``selftext``. Link post selftext does not support
-            inline media.
+            the placeholder name in ``selftext``. Only supported for text submissions.
         :param nsfw: Whether the submission should be marked NSFW (default: ``False``).
+        :param poll: A ``dict`` with the structure ``{"duration": 3, "options": ["Yes",
+            "No"]}``, where ``duration`` is the number of days the poll should accept
+            votes (between ``1`` and ``7``, inclusive) and ``options`` is a list of two
+            to six poll options as ``str``. Both keys are required.
         :param resubmit: When ``False``, an error will occur if the URL has already been
             submitted (default: ``True``).
-        :param selftext: The Markdown formatted content for a ``text`` submission or an
-            optional post body for ``link`` submissions. Use an empty string, ``""``, to
-            make a title-only submission.
+        :param selftext: The Markdown formatted content for a ``text`` submission or
+            optional Markdown-formatted body text for any other kind of submission. Use
+            an empty string, ``""``, to make a title-only submission.
         :param send_replies: When ``True``, messages will be sent to the submission
             author when comments are made to the submission (default: ``True``).
         :param spoiler: Whether the submission should be marked as a spoiler (default:
             ``False``).
+        :param timeout: Specifies a particular timeout, in seconds, for the WebSockets
+            connection used by ``image`` and ``video`` submissions. Use to avoid
+            "Websocket error" exceptions (default: ``10``).
         :param url: The URL for a ``link`` submission.
+        :param video: The video to upload and post. Either a :class:`.PostMedia` or a
+            ``dict`` with the structure ``{"media": PostMedia("path"), "gif": True,
+            "thumbnail": PostMedia("path")}``, where only ``media`` is required. Set
+            ``"gif"`` to ``True`` to submit the video as a videogif, which is
+            essentially a silent video (default: ``False``). When ``"thumbnail"`` is not
+            provided, the PRAW logo will be used as the thumbnail.
+        :param without_websockets: Set to ``True`` to disable use of WebSockets for
+            ``image`` and ``video`` submissions (see note below for an explanation). If
+            ``True``, this method doesn't return anything (default: ``False``).
 
-        :returns: A :class:`.Submission` object for the newly created submission.
+        :returns: A :class:`.Submission` object for the newly created submission, unless
+            ``without_websockets`` is ``True`` for an ``image`` or ``video`` submission.
 
-        Provide ``selftext`` alone for a ``text`` submission. ``selftext`` can accompany
-        a ``url`` for a ``link`` submission. ``selftext`` that accompanies a ``link``
-        submission is optional. ``selftext`` for ``link`` submissions does not support
-        ``inline_media``.
+        :raises: :class:`.ClientException` if ``image`` or a ``gallery`` item's
+            ``media`` refers to a file that is not an image, or if the ``video`` (or its
+            ``media``) refers to a file that is not a video.
+
+        At least one of ``gallery``, ``image``, ``poll``, ``selftext``, ``url``, or
+        ``video`` must be provided. ``gallery``, ``image``, ``poll``, ``url``, and
+        ``video`` are mutually exclusive, while ``selftext`` may accompany any of them
+        as optional Markdown-formatted body text. ``selftext`` that accompanies another
+        kind of submission does not support ``inline_media``.
 
         For example, to submit a URL to r/test do:
 
@@ -2993,7 +3024,70 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
             url = "https://praw.readthedocs.io"
             reddit.subreddit("test").submit(title, url=url)
 
-        For example, to submit a self post with inline media do:
+        To submit an image to r/test do:
+
+        .. code-block:: python
+
+            from praw.models import PostMedia
+
+            title = "My favorite picture"
+            image = PostMedia("/path/to/image.png")
+            reddit.subreddit("test").submit(title, image=image)
+
+        To submit an image gallery to r/test do:
+
+        .. code-block:: python
+
+            from praw.models import PostMedia
+
+            title = "My favorite pictures"
+            gallery = [
+                PostMedia("/path/to/image.png"),
+                {
+                    "media": PostMedia("/path/to/image2.png"),
+                    "caption": "Image caption 2",
+                },
+                {
+                    "media": PostMedia("/path/to/image3.png"),
+                    "caption": "Image caption 3",
+                    "outbound_url": "https://example.com/link3",
+                },
+            ]
+            reddit.subreddit("test").submit(title, gallery=gallery)
+
+        To submit a video to r/test do:
+
+        .. code-block:: python
+
+            from praw.models import PostMedia
+
+            title = "My favorite movie"
+            video = PostMedia("/path/to/video.mp4")
+            reddit.subreddit("test").submit(title, video=video)
+
+        To submit a videogif with a custom thumbnail instead, do:
+
+        .. code-block:: python
+
+            from praw.models import PostMedia
+
+            title = "My favorite gif"
+            video = {
+                "gif": True,
+                "media": PostMedia("/path/to/video.mp4"),
+                "thumbnail": PostMedia("/path/to/thumbnail.png"),
+            }
+            reddit.subreddit("test").submit(title, video=video)
+
+        To submit a poll to r/test do:
+
+        .. code-block:: python
+
+            title = "Do you like PRAW?"
+            poll = {"duration": 3, "options": ["Yes", "No"]}
+            reddit.subreddit("test").submit(title, poll=poll)
+
+        To submit a self post with inline media do:
 
         .. code-block:: python
 
@@ -3030,6 +3124,20 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
 
         .. note::
 
+            For ``image`` and ``video`` submissions, Reddit's API uses WebSockets to
+            respond with the link of the newly created post. If this fails, the method
+            will raise :class:`.WebSocketException`. Occasionally, the Reddit post will
+            still be created. More often, there is an error with the media file. If you
+            frequently get exceptions but successfully created posts, try setting the
+            ``timeout`` parameter to a value above 10.
+
+            To disable the use of WebSockets, set ``without_websockets=True``. This will
+            make the method return ``None``, though the post will still be created. You
+            may wish to do this if you are running your program in a restricted network
+            environment, or using a proxy that doesn't support WebSockets connections.
+
+        .. note::
+
             To submit a post to a subreddit with the ``"news"`` flair, you can get the
             flair id like this:
 
@@ -3039,476 +3147,135 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
                 template_id = next(x for x in choices if x["flair_text"] == "news")["flair_template_id"]
                 subreddit.submit("title", flair_id=template_id, url="https://www.news.com/")
 
-        .. seealso::
-
-            - :meth:`~.Subreddit.submit_gallery` to submit more than one image in the
-              same post
-            - :meth:`~.Subreddit.submit_image` to submit images
-            - :meth:`~.Subreddit.submit_poll` to submit polls
-            - :meth:`~.Subreddit.submit_video` to submit videos and videogifs
-
         """
-        # link posts can now include selftext (no longer exclusive)
+        provided = [
+            name
+            for name, value in (
+                ("gallery", gallery),
+                ("image", image),
+                ("poll", poll),
+                ("url", url),
+                ("video", video),
+            )
+            if value is not None
+        ]
+        if len(provided) > 1:
+            msg = f"Only one of 'gallery', 'image', 'poll', 'url', or 'video' can be provided ({', '.join(repr(name) for name in provided)} given)."
+            raise TypeError(msg)
+        kind = provided[0] if provided else None
         # test for empty string in selftext for title-only submissions
-        if not url and not (bool(selftext) or selftext == ""):  # noqa: PLC1901
-            msg = "Either 'selftext' and/or 'url' must be provided."
+        if kind is None and not (bool(selftext) or selftext == ""):  # noqa: PLC1901
+            msg = "At least one of 'gallery', 'image', 'poll', 'selftext', 'url', or 'video' must be provided."
+            raise TypeError(msg)
+        if inline_media and kind is not None:
+            msg = f"'inline_media' is only supported for text submissions. Only Markdown text can be used for the selftext of a {kind!r} submission."
             raise TypeError(msg)
 
         data = {
-            "sr": str(self),
-            "resubmit": bool(resubmit),
-            "sendreplies": bool(send_replies),
-            "title": title,
             "nsfw": bool(nsfw),
+            "sendreplies": bool(send_replies),
             "spoiler": bool(spoiler),
+            "sr": str(self),
+            "title": title,
             "validate_on_submit": True,
         }
         for key, value in (
-            ("flair_id", flair_id),
-            ("flair_text", flair_text),
             ("collection_id", collection_id),
             ("discussion_type", discussion_type),
-            ("draft_id", draft_id),
+            ("flair_id", flair_id),
+            ("flair_text", flair_text),
         ):
             if value is not None:
                 data[key] = value
+
+        if gallery is not None:
+            images = [{"media": item} if isinstance(item, PostMedia) else item for item in gallery]
+            self._validate_gallery(images)
+            data.update(api_type="json", items=[], show_error_list=True)
+            if selftext is not None:
+                data["text"] = selftext
+            for image_item in images:
+                data["items"].append({
+                    "caption": image_item.get("caption", ""),
+                    "outbound_url": image_item.get("outbound_url", ""),
+                    "media_id": image_item["media"]._upload(
+                        self._reddit,
+                        expected_mime_prefix="image",
+                        upload_type="gallery",
+                    ),
+                })
+            response = self._reddit.request(json=data, method="POST", path=API_PATH["submit_gallery_post"])["json"]
+            if response["errors"]:
+                raise RedditAPIException(response["errors"])
+            return self._reddit.submission(url=response["data"]["url"])
+
+        data["resubmit"] = bool(resubmit)
+
+        if poll is not None:
+            invalid_keys = poll.keys() - {"duration", "options"}
+            if invalid_keys:
+                msg = f"'poll' contains invalid keys: {', '.join(repr(key) for key in sorted(invalid_keys))}."
+                raise TypeError(msg)
+            missing_keys = {"duration", "options"} - poll.keys()
+            if missing_keys:
+                msg = f"'poll' is missing required keys: {', '.join(repr(key) for key in sorted(missing_keys))}."
+                raise TypeError(msg)
+            data.update(
+                duration=poll["duration"],
+                options=poll["options"],
+                text=selftext if selftext is not None else "",
+            )
+            return self._reddit.post(API_PATH["submit_poll_post"], json=data)
+
+        if image is not None:
+            if selftext is not None:
+                data["text"] = selftext
+            data.update(kind="image", url=image._upload(self._reddit, expected_mime_prefix="image"))
+            return self._submit_media(data=data, timeout=timeout, without_websockets=without_websockets)
+
+        if video is not None:
+            if isinstance(video, PostMedia):
+                video = {"media": video}
+            invalid_keys = video.keys() - {"gif", "media", "thumbnail"}
+            if invalid_keys:
+                msg = f"'video' contains invalid keys: {', '.join(repr(key) for key in sorted(invalid_keys))}."
+                raise TypeError(msg)
+            video_media = video.get("media")
+            if not isinstance(video_media, PostMedia):
+                msg = "'media' is required and must be a PostMedia instance."
+                raise TypeError(msg)
+            thumbnail_media = video.get("thumbnail")
+            if thumbnail_media is None:
+                # if we're uploading without a thumbnail, use the PRAW logo
+                logo_path = Path(__file__).absolute().parent.parent.parent / "images" / "PRAW logo.png"
+                thumbnail_media = PostMedia(str(logo_path))
+            if selftext is not None:
+                data["text"] = selftext
+            data.update(
+                kind="videogif" if video.get("gif") else "video",
+                url=video_media._upload(self._reddit, expected_mime_prefix="video"),
+                video_poster_url=thumbnail_media._upload(self._reddit),
+            )
+            return self._submit_media(data=data, timeout=timeout, without_websockets=without_websockets)
+
+        if draft_id is not None:
+            data["draft_id"] = draft_id
         if url is not None:
             data.update(kind="link", url=url)
-            if inline_media:
-                msg = "As of 2025-05-07, `inline_media` is not supported for link post selftext. Only Markdown text can be added to non-self posts."
-                raise TypeError(msg)
             # we can ignore an empty string for selftext here b/c body text is optional for link posts
             if selftext:
-                data.update(text=selftext)
-        elif selftext is not None:
+                data["text"] = selftext
+        else:
             data.update(kind="self")
             if inline_media:
                 body = selftext.format(**{
                     placeholder: self._upload_inline_media(media) for placeholder, media in inline_media.items()
                 })
-                converted = self._convert_to_fancypants(body)
-                data.update(richtext_json=dumps(converted))
+                data.update(richtext_json=dumps(self._convert_to_fancypants(body)))
             else:
                 data.update(text=selftext)
 
         return self._reddit.post(API_PATH["submit"], data=data)
-
-    def submit_gallery(
-        self,
-        *,
-        collection_id: str | None = None,
-        discussion_type: str | None = None,
-        flair_id: str | None = None,
-        flair_text: str | None = None,
-        images: list[dict[str, str | PostMedia]],
-        nsfw: bool = False,
-        selftext: str | None = None,
-        send_replies: bool = True,
-        spoiler: bool = False,
-        title: str,
-    ) -> models.Submission:
-        """Add an image gallery submission to the subreddit.
-
-        :param title: The title of the submission.
-        :param images: The images to post in dict with the following structure:
-            ``{"image_media": PostMedia("path"), "caption": "caption", "outbound_url":
-            "url"}``, only ``image_media`` is required.
-        :param collection_id: The UUID of a :class:`.Collection` to add the
-            newly-submitted post to.
-        :param discussion_type: Set to ``"CHAT"`` to enable live discussion instead of
-            traditional comments (default: ``None``).
-        :param flair_id: The flair template to select (default: ``None``).
-        :param flair_text: If the template's ``flair_text_editable`` value is ``True``,
-            this value will set a custom text (default: ``None``). ``flair_id`` is
-            required when ``flair_text`` is provided.
-        :param nsfw: Whether the submission should be marked NSFW (default: ``False``).
-        :param selftext: Optional Markdown-formatted post body content (default:
-            ``None``).
-        :param send_replies: When ``True``, messages will be sent to the submission
-            author when comments are made to the submission (default: ``True``).
-        :param spoiler: Whether the submission should be marked asa spoiler (default:
-            ``False``).
-
-        :returns: A :class:`.Submission` object for the newly created submission.
-
-        :raises: :class:`.ClientException` if ``image_media`` in ``images`` refers to a
-            file that is not an image.
-
-        For example, to submit an image gallery to r/test do:
-
-        .. code-block:: python
-
-            from praw.models import PostMedia
-
-            title = "My favorite pictures"
-            image = PostMedia("/path/to/image.png")
-            image2 = PostMedia("/path/to/image2.png")
-            image3 = PostMedia("/path/to/image3.png")
-            images = [
-                {"image_media": image},
-                {
-                    "image_media": image2,
-                    "caption": "Image caption 2",
-                },
-                {
-                    "image_media": image3,
-                    "caption": "Image caption 3",
-                    "outbound_url": "https://example.com/link3",
-                },
-            ]
-            reddit.subreddit("test").submit_gallery(images=images, title=title)
-
-        .. seealso::
-
-            - :meth:`~.Subreddit.submit` to submit url posts and selftexts
-            - :meth:`~.Subreddit.submit_image` to submit single images
-            - :meth:`~.Subreddit.submit_poll` to submit polls
-            - :meth:`~.Subreddit.submit_video` to submit videos and videogifs
-
-        """
-        self._validate_gallery(images)
-        data = {
-            "api_type": "json",
-            "items": [],
-            "nsfw": bool(nsfw),
-            "sendreplies": bool(send_replies),
-            "show_error_list": True,
-            "spoiler": bool(spoiler),
-            "sr": str(self),
-            "title": title,
-            "validate_on_submit": True,
-        }
-        for key, value in (
-            ("flair_id", flair_id),
-            ("flair_text", flair_text),
-            ("collection_id", collection_id),
-            ("discussion_type", discussion_type),
-            ("text", selftext),
-        ):
-            if value is not None:
-                data[key] = value
-        for image in images:
-            data["items"].append({
-                "caption": image.get("caption", ""),
-                "outbound_url": image.get("outbound_url", ""),
-                "media_id": image["image_media"]._upload(
-                    self._reddit,
-                    expected_mime_prefix="image",
-                    upload_type="gallery",
-                ),
-            })
-        response = self._reddit.request(json=data, method="POST", path=API_PATH["submit_gallery_post"])["json"]
-        if response["errors"]:
-            raise RedditAPIException(response["errors"])
-        return self._reddit.submission(url=response["data"]["url"])
-
-    def submit_image(
-        self,
-        *,
-        collection_id: str | None = None,
-        discussion_type: str | None = None,
-        flair_id: str | None = None,
-        flair_text: str | None = None,
-        image_media: models.PostMedia,
-        nsfw: bool = False,
-        resubmit: bool = True,
-        selftext: str | None = None,
-        send_replies: bool = True,
-        spoiler: bool = False,
-        timeout: int = 10,
-        title: str,
-        without_websockets: bool = False,
-    ) -> models.Submission | None:
-        """Add an image submission to the subreddit.
-
-        :param collection_id: The UUID of a :class:`.Collection` to add the
-            newly-submitted post to.
-        :param discussion_type: Set to ``"CHAT"`` to enable live discussion instead of
-            traditional comments (default: ``None``).
-        :param flair_id: The flair template to select (default: ``None``).
-        :param flair_text: If the template's ``flair_text_editable`` value is ``True``,
-            this value will set a custom text (default: ``None``). ``flair_id`` is
-            required when ``flair_text`` is provided.
-        :param image_media: The :class:`.PostMedia` image to upload and post.
-        :param nsfw: Whether the submission should be marked NSFW (default: ``False``).
-        :param resubmit: When ``False``, an error will occur if the URL has already been
-            submitted (default: ``True``).
-        :param selftext: Optional Markdown-formatted post body content (default:
-            ``None``).
-        :param send_replies: When ``True``, messages will be sent to the submission
-            author when comments are made to the submission (default: ``True``).
-        :param spoiler: Whether the submission should be marked as a spoiler (default:
-            ``False``).
-        :param timeout: Specifies a particular timeout, in seconds. Use to avoid
-            "Websocket error" exceptions (default: ``10``).
-        :param title: The title of the submission.
-        :param without_websockets: Set to ``True`` to disable use of WebSockets (see
-            note below for an explanation). If ``True``, this method doesn't return
-            anything (default: ``False``).
-
-        :returns: A :class:`.Submission` object for the newly created submission, unless
-            ``without_websockets`` is ``True``.
-
-        :raises: :class:`.ClientException` if ``image_media`` refers to a file that is
-            not an image.
-
-        .. note::
-
-            Reddit's API uses WebSockets to respond with the link of the newly created
-            post. If this fails, the method will raise :class:`.WebSocketException`.
-            Occasionally, the Reddit post will still be created. More often, there is an
-            error with the image file. If you frequently get exceptions but successfully
-            created posts, try setting the ``timeout`` parameter to a value above 10.
-
-            To disable the use of WebSockets, set ``without_websockets=True``. This will
-            make the method return ``None``, though the post will still be created. You
-            may wish to do this if you are running your program in a restricted network
-            environment, or using a proxy that doesn't support WebSockets connections.
-
-        For example, to submit an image to r/test do:
-
-        .. code-block:: python
-
-            from praw.models import PostMedia
-
-            title = "My favorite picture"
-            image = PostMedia("/path/to/image.png")
-            reddit.subreddit("test").submit_image(image_media=image, title=title)
-
-        .. seealso::
-
-            - :meth:`~.Subreddit.submit` to submit url posts and selftexts
-            - :meth:`~.Subreddit.submit_gallery` to submit more than one image in the
-              same post
-            - :meth:`~.Subreddit.submit_poll` to submit polls
-            - :meth:`~.Subreddit.submit_video` to submit videos and videogifs
-
-        """
-        data = {
-            "sr": str(self),
-            "resubmit": bool(resubmit),
-            "sendreplies": bool(send_replies),
-            "title": title,
-            "nsfw": bool(nsfw),
-            "spoiler": bool(spoiler),
-            "validate_on_submit": True,
-        }
-        for key, value in (
-            ("flair_id", flair_id),
-            ("flair_text", flair_text),
-            ("collection_id", collection_id),
-            ("discussion_type", discussion_type),
-            ("text", selftext),
-        ):
-            if value is not None:
-                data[key] = value
-
-        image_url = image_media._upload(self._reddit, expected_mime_prefix="image")
-        data.update(kind="image", url=image_url)
-        return self._submit_media(data=data, timeout=timeout, without_websockets=without_websockets)
-
-    def submit_poll(
-        self,
-        title: str,
-        *,
-        collection_id: str | None = None,
-        discussion_type: str | None = None,
-        duration: int,
-        flair_id: str | None = None,
-        flair_text: str | None = None,
-        nsfw: bool = False,
-        options: list[str],
-        resubmit: bool = True,
-        selftext: str,
-        send_replies: bool = True,
-        spoiler: bool = False,
-    ) -> models.Submission:
-        """Add a poll submission to the subreddit.
-
-        :param title: The title of the submission.
-        :param collection_id: The UUID of a :class:`.Collection` to add the
-            newly-submitted post to.
-        :param discussion_type: Set to ``"CHAT"`` to enable live discussion instead of
-            traditional comments (default: ``None``).
-        :param duration: The number of days the poll should accept votes, as an ``int``.
-            Valid values are between ``1`` and ``7``, inclusive.
-        :param flair_id: The flair template to select (default: ``None``).
-        :param flair_text: If the template's ``flair_text_editable`` value is ``True``,
-            this value will set a custom text (default: ``None``). ``flair_id`` is
-            required when ``flair_text`` is provided.
-        :param nsfw: Whether the submission should be marked NSFW (default: ``False``).
-        :param options: A list of two to six poll options as ``str``.
-        :param resubmit: When ``False``, an error will occur if the URL has already been
-            submitted (default: ``True``).
-        :param selftext: The Markdown formatted content for the submission. Use an empty
-            string, ``""``, to make a submission with no text contents.
-        :param send_replies: When ``True``, messages will be sent to the submission
-            author when comments are made to the submission (default: ``True``).
-        :param spoiler: Whether the submission should be marked as a spoiler (default:
-            ``False``).
-
-        :returns: A :class:`.Submission` object for the newly created submission.
-
-        For example, to submit a poll to r/test do:
-
-        .. code-block:: python
-
-            title = "Do you like PRAW?"
-            reddit.subreddit("test").submit_poll(
-                title, selftext="", options=["Yes", "No"], duration=3
-            )
-
-        .. seealso::
-
-            - :meth:`~.Subreddit.submit` to submit url posts and selftexts
-            - :meth:`~.Subreddit.submit_gallery` to submit more than one image in the
-              same post
-            - :meth:`~.Subreddit.submit_image` to submit single images
-            - :meth:`~.Subreddit.submit_video` to submit videos and videogifs
-
-        """
-        data = {
-            "sr": str(self),
-            "text": selftext,
-            "options": options,
-            "duration": duration,
-            "resubmit": bool(resubmit),
-            "sendreplies": bool(send_replies),
-            "title": title,
-            "nsfw": bool(nsfw),
-            "spoiler": bool(spoiler),
-            "validate_on_submit": True,
-        }
-        for key, value in (
-            ("flair_id", flair_id),
-            ("flair_text", flair_text),
-            ("collection_id", collection_id),
-            ("discussion_type", discussion_type),
-        ):
-            if value is not None:
-                data[key] = value
-
-        return self._reddit.post(API_PATH["submit_poll_post"], json=data)
-
-    def submit_video(
-        self,
-        *,
-        collection_id: str | None = None,
-        discussion_type: str | None = None,
-        flair_id: str | None = None,
-        flair_text: str | None = None,
-        nsfw: bool = False,
-        resubmit: bool = True,
-        selftext: str | None = None,
-        send_replies: bool = True,
-        spoiler: bool = False,
-        thumbnail_media: models.PostMedia | None = None,
-        timeout: int = 10,
-        title: str,
-        video_media: models.PostMedia,
-        videogif: bool = False,
-        without_websockets: bool = False,
-    ) -> models.Submission | None:
-        """Add a video or videogif submission to the subreddit.
-
-        :param title: The title of the submission.
-        :param video_media: The :class:`.PostMedia` video to upload and post.
-        :param collection_id: The UUID of a :class:`.Collection` to add the
-            newly-submitted post to.
-        :param discussion_type: Set to ``"CHAT"`` to enable live discussion instead of
-            traditional comments (default: ``None``).
-        :param flair_id: The flair template to select (default: ``None``).
-        :param flair_text: If the template's ``flair_text_editable`` value is ``True``,
-            this value will set a custom text (default: ``None``). ``flair_id`` is
-            required when ``flair_text`` is provided.
-        :param nsfw: Whether the submission should be marked NSFW (default: ``False``).
-        :param resubmit: When ``False``, an error will occur if the URL has already been
-            submitted (default: ``True``).
-        :param selftext: Optional Markdown-formatted post body content (default:
-            ``None``).
-        :param send_replies: When ``True``, messages will be sent to the submission
-            author when comments are made to the submission (default: ``True``).
-        :param spoiler: Whether the submission should be marked as a spoiler (default:
-            ``False``).
-        :param thumbnail_media: The :class:`.PostMedia` image to be uploaded and used as
-            the thumbnail for this video. If not provided, the PRAW logo will be used as
-            the thumbnail.
-        :param timeout: Specifies a particular timeout, in seconds. Use to avoid
-            "Websocket error" exceptions (default: ``10``).
-        :param videogif: If ``True``, the video is uploaded as a videogif, which is
-            essentially a silent video (default: ``False``).
-        :param without_websockets: Set to ``True`` to disable use of WebSockets (see
-            note below for an explanation). If ``True``, this method doesn't return
-            anything (default: ``False``).
-
-        :returns: A :class:`.Submission` object for the newly created submission, unless
-            ``without_websockets`` is ``True``.
-
-        :raises: :class:`.ClientException` if ``video_media`` refers to a file that is
-            not a video.
-
-        .. note::
-
-            Reddit's API uses WebSockets to respond with the link of the newly created
-            post. If this fails, the method will raise :class:`.WebSocketException`.
-            Occasionally, the Reddit post will still be created. More often, there is an
-            error with the image file. If you frequently get exceptions but successfully
-            created posts, try setting the ``timeout`` parameter to a value above 10.
-
-            To disable the use of WebSockets, set ``without_websockets=True``. This will
-            make the method return ``None``, though the post will still be created. You
-            may wish to do this if you are running your program in a restricted network
-            environment, or using a proxy that doesn't support WebSockets connections.
-
-        For example, to submit a video to r/test do:
-
-        .. code-block:: python
-
-            from praw.models import PostMedia
-
-            title = "My favorite movie"
-            video = PostMedia("/path/to/video.mp4")
-            reddit.subreddit("test").submit_video(title=title, video_media=video)
-
-        .. seealso::
-
-            - :meth:`~.Subreddit.submit` to submit url posts and selftexts
-            - :meth:`~.Subreddit.submit_image` to submit images
-            - :meth:`~.Subreddit.submit_gallery` to submit more than one image in the
-              same post
-            - :meth:`~.Subreddit.submit_poll` to submit polls
-
-        """
-        data = {
-            "sr": str(self),
-            "resubmit": bool(resubmit),
-            "sendreplies": bool(send_replies),
-            "title": title,
-            "nsfw": bool(nsfw),
-            "spoiler": bool(spoiler),
-            "validate_on_submit": True,
-        }
-        for key, value in (
-            ("flair_id", flair_id),
-            ("flair_text", flair_text),
-            ("collection_id", collection_id),
-            ("discussion_type", discussion_type),
-            ("text", selftext),
-        ):
-            if value is not None:
-                data[key] = value
-
-        if thumbnail_media is None:
-            # if we're uploading without a thumbnail, use the PRAW logo
-            logo_path = Path(__file__).absolute().parent.parent.parent / "images" / "PRAW logo.png"
-            thumbnail_media = PostMedia(str(logo_path))
-        video_url = video_media._upload(self._reddit, expected_mime_prefix="video")
-        data.update(
-            kind="videogif" if videogif else "video",
-            url=video_url,
-            video_poster_url=thumbnail_media._upload(self._reddit),
-        )
-        return self._submit_media(data=data, timeout=timeout, without_websockets=without_websockets)
 
     def subscribe(self, *, other_subreddits: list[models.Subreddit] | None = None) -> None:
         """Subscribe to the subreddit.

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -8,7 +8,7 @@ from csv import writer
 from io import StringIO
 from json import dumps, loads
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, overload
 from urllib.parse import urljoin
 
 import websocket
@@ -2931,6 +2931,119 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBa
         except Redirect as redirect:
             path = redirect.path
         return self._submission_class(self._reddit, url=urljoin(self._reddit.config.reddit_url, path))
+
+    @overload
+    def submit(
+        self,
+        title: str,
+        *,
+        collection_id: str | None = ...,
+        discussion_type: str | None = ...,
+        draft_id: str | None = ...,
+        flair_id: str | None = ...,
+        flair_text: str | None = ...,
+        inline_media: dict[str, models.InlineMedia] | None = ...,
+        nsfw: bool = ...,
+        resubmit: bool = ...,
+        selftext: str,
+        send_replies: bool = ...,
+        spoiler: bool = ...,
+    ) -> models.Submission:
+        ...
+
+    @overload
+    def submit(
+        self,
+        title: str,
+        *,
+        collection_id: str | None = ...,
+        discussion_type: str | None = ...,
+        draft_id: str | None = ...,
+        flair_id: str | None = ...,
+        flair_text: str | None = ...,
+        nsfw: bool = ...,
+        resubmit: bool = ...,
+        selftext: str | None = ...,
+        send_replies: bool = ...,
+        spoiler: bool = ...,
+        url: str,
+    ) -> models.Submission:
+        ...
+
+    @overload
+    def submit(
+        self,
+        title: str,
+        *,
+        collection_id: str | None = ...,
+        discussion_type: str | None = ...,
+        flair_id: str | None = ...,
+        flair_text: str | None = ...,
+        image: models.PostMedia,
+        nsfw: bool = ...,
+        resubmit: bool = ...,
+        selftext: str | None = ...,
+        send_replies: bool = ...,
+        spoiler: bool = ...,
+        timeout: int = ...,
+        without_websockets: bool = ...,
+    ) -> models.Submission | None:
+        ...
+
+    @overload
+    def submit(
+        self,
+        title: str,
+        *,
+        collection_id: str | None = ...,
+        discussion_type: str | None = ...,
+        flair_id: str | None = ...,
+        flair_text: str | None = ...,
+        gallery: list[models.PostMedia | dict[str, str | models.PostMedia]],
+        nsfw: bool = ...,
+        selftext: str | None = ...,
+        send_replies: bool = ...,
+        spoiler: bool = ...,
+    ) -> models.Submission:
+        ...
+
+    @overload
+    def submit(
+        self,
+        title: str,
+        *,
+        collection_id: str | None = ...,
+        discussion_type: str | None = ...,
+        flair_id: str | None = ...,
+        flair_text: str | None = ...,
+        nsfw: bool = ...,
+        poll: dict[str, int | list[str]],
+        resubmit: bool = ...,
+        selftext: str | None = ...,
+        send_replies: bool = ...,
+        spoiler: bool = ...,
+    ) -> models.Submission:
+        ...
+
+    @overload
+    def submit(
+        self,
+        title: str,
+        *,
+        collection_id: str | None = ...,
+        discussion_type: str | None = ...,
+        flair_id: str | None = ...,
+        flair_text: str | None = ...,
+        nsfw: bool = ...,
+        resubmit: bool = ...,
+        selftext: str | None = ...,
+        send_replies: bool = ...,
+        spoiler: bool = ...,
+        timeout: int = ...,
+        video: models.PostMedia | dict[str, bool | models.PostMedia],
+        without_websockets: bool = ...,
+    ) -> models.Submission | None:
+        ...
 
     def submit(
         self,

--- a/praw/models/reddit/widgets.py
+++ b/praw/models/reddit/widgets.py
@@ -1793,10 +1793,10 @@ class SubredditWidgetsModeration:
         path = API_PATH["widget_order"].format(subreddit=self._subreddit, section=section)
         self._reddit.patch(path, data={"json": dumps(order), "section": section})
 
-    def upload_image(self, image_media: models.WidgetMedia, /) -> str:
+    def upload_image(self, media: models.WidgetMedia, /) -> str:
         """Upload an image to Reddit and get the URL.
 
-        :param image_media: The :class:`.WidgetMedia` to upload.
+        :param media: The :class:`.WidgetMedia` to upload.
 
         :returns: The URL of the uploaded image as a ``str``.
 
@@ -1819,4 +1819,4 @@ class SubredditWidgetsModeration:
             )
 
         """
-        return image_media._upload(self._subreddit)
+        return media._upload(self._subreddit)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,14 @@ requires-python = ">=3.10"
 "Issue Tracker" = "https://github.com/praw-dev/praw/issues"
 "Source Code" = "https://github.com/praw-dev/praw"
 
+[tool.coverage.report]
+exclude_lines = [
+  "@overload",
+  "if TYPE_CHECKING:",
+  "pragma: no cover"
+]
+fail_under = 100
+
 [tool.docstrfmt]
 extend_exclude = ['./docs/examples/']
 
@@ -186,7 +194,7 @@ runner = "uv-venv-lock-runner"
 [tool.tox.env_run_base]
 commands = [
   ["coverage", "run", "--source", "praw", "--module", "pytest", "{posargs}"],
-  ["coverage", "report", "-m", "--fail-under=100"]
+  ["coverage", "report", "-m"]
 ]
 dependency_groups = ["test"]
 description = "Run test under {base_python}"

--- a/tests/integration/models/reddit/test_emoji.py
+++ b/tests/integration/models/reddit/test_emoji.py
@@ -61,7 +61,7 @@ class TestSubredditEmoji(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         for extension in ["jpg", "png"]:
             emoji = subreddit.emoji.add(
-                emoji_media=EmojiMedia(f"tests/integration/files/test.{extension}"),
+                media=EmojiMedia(f"tests/integration/files/test.{extension}"),
                 name=f"test_{extension}",
             )
             assert isinstance(emoji, Emoji)
@@ -74,7 +74,7 @@ class TestSubredditEmoji(IntegrationTest):
             with open(f"tests/integration/files/test.{extension}", "rb") as file:
                 media_bytes = file.read()
             emoji = subreddit.emoji.add(
-                emoji_media=EmojiMedia(media_bytes, name=f"test.{extension}"),
+                media=EmojiMedia(media_bytes, name=f"test.{extension}"),
                 name=f"test_{extension}",
             )
             assert isinstance(emoji, Emoji)
@@ -84,7 +84,7 @@ class TestSubredditEmoji(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         for extension in ["jpg", "png"]:
             emoji = subreddit.emoji.add(
-                emoji_media=EmojiMedia(f"tests/integration/files/test.{extension}"),
+                media=EmojiMedia(f"tests/integration/files/test.{extension}"),
                 mod_flair_only=True,
                 name=f"test_{extension}",
                 post_flair_allowed=True,

--- a/tests/integration/models/reddit/test_subreddit.py
+++ b/tests/integration/models/reddit/test_subreddit.py
@@ -1026,7 +1026,7 @@ class TestSubredditStylesheet(IntegrationTest):
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         response = subreddit.stylesheet.upload(
-            image_media=StylesheetImage(image_path("white-square.png")), name="praw"
+            StylesheetImage(image_path("white-square.png")), name="praw"
         )
         assert response["img_src"].endswith(".png")
 
@@ -1035,7 +1035,7 @@ class TestSubredditStylesheet(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         with pytest.raises(RedditAPIException) as excinfo:
             subreddit.stylesheet.upload(
-                image_media=StylesheetImage(image_path("invalid.jpg")), name="praw"
+                StylesheetImage(image_path("invalid.jpg")), name="praw"
             )
         assert excinfo.value.items[0].error_type == "IMAGE_ERROR"
 
@@ -1044,7 +1044,7 @@ class TestSubredditStylesheet(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         with pytest.raises(RedditAPIException) as excinfo:
             subreddit.stylesheet.upload(
-                image_media=StylesheetImage(image_path("white-square.png")), name="praw.png"
+                StylesheetImage(image_path("white-square.png")), name="praw.png"
             )
         assert excinfo.value.items[0].error_type == "BAD_CSS_NAME"
 
@@ -1072,7 +1072,7 @@ class TestSubredditStylesheet(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         with pytest.raises(TooLarge):
             subreddit.stylesheet.upload(
-                image_media=StylesheetImage(image_path("too_large.jpg")), name="praw"
+                StylesheetImage(image_path("too_large.jpg")), name="praw"
             )
 
     def test_upload_banner__jpg(self, image_path, reddit):
@@ -1464,20 +1464,20 @@ class TestSubreddit(IntegrationTest):
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         images = [
-            {"image_media": PostMedia(image_path("test.png"))},
-            {"image_media": PostMedia(image_path("test.jpg")), "caption": "test.jpg"},
+            {"media": PostMedia(image_path("test.png"))},
+            {"media": PostMedia(image_path("test.jpg")), "caption": "test.jpg"},
             {
-                "image_media": PostMedia(image_path("test.gif")),
+                "media": PostMedia(image_path("test.gif")),
                 "outbound_url": "https://example.com",
             },
             {
-                "image_media": PostMedia(image_path("test.png")),
+                "media": PostMedia(image_path("test.png")),
                 "caption": "test.png",
                 "outbound_url": "https://example.com",
             },
         ]
 
-        submission = subreddit.submit_gallery(images=images, title="Test Title")
+        submission = subreddit.submit("Test Title", gallery=images)
         assert submission.author == pytest.placeholders.username
         assert submission.is_gallery
         assert submission.title == "Test Title"
@@ -1485,7 +1485,7 @@ class TestSubreddit(IntegrationTest):
         assert isinstance(submission.gallery_data["items"], list)
         for i, item in enumerate(items):
             test_data = images[i]
-            test_data.pop("image_media")
+            test_data.pop("media")
             item.pop("id")
             item.pop("media_id")
             assert item == test_data
@@ -1494,21 +1494,21 @@ class TestSubreddit(IntegrationTest):
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         images = [
-            {"image_media": PostMedia(image_path("test.png"))},
-            {"image_media": PostMedia(image_path("test.jpg")), "caption": "test.jpg"},
+            {"media": PostMedia(image_path("test.png"))},
+            {"media": PostMedia(image_path("test.jpg")), "caption": "test.jpg"},
             {
-                "image_media": PostMedia(image_path("test.gif")),
+                "media": PostMedia(image_path("test.gif")),
                 "outbound_url": "https://example.com",
             },
             {
-                "image_media": PostMedia(image_path("test.png")),
+                "media": PostMedia(image_path("test.png")),
                 "caption": "test.png",
                 "outbound_url": "https://example.com",
             },
         ]
 
         with pytest.raises(RedditAPIException):
-            subreddit.submit_gallery(images=images, title="Test Title")
+            subreddit.submit("Test Title", gallery=images)
 
     def test_submit_gallery__flair(self, image_path, reddit):
         flair_id = "6fc213da-cae7-11ea-9274-0e2407099e45"
@@ -1517,23 +1517,23 @@ class TestSubreddit(IntegrationTest):
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         images = [
-            {"image_media": PostMedia(image_path("test.png"))},
-            {"image_media": PostMedia(image_path("test.jpg")), "caption": "test.jpg"},
+            {"media": PostMedia(image_path("test.png"))},
+            {"media": PostMedia(image_path("test.jpg")), "caption": "test.jpg"},
             {
-                "image_media": PostMedia(image_path("test.gif")),
+                "media": PostMedia(image_path("test.gif")),
                 "outbound_url": "https://example.com",
             },
             {
-                "image_media": PostMedia(image_path("test.png")),
+                "media": PostMedia(image_path("test.png")),
                 "caption": "test.png",
                 "outbound_url": "https://example.com",
             },
         ]
-        submission = subreddit.submit_gallery(
+        submission = subreddit.submit(
+            "Test Title",
             flair_id=flair_id,
             flair_text=flair_text,
-            images=images,
-            title="Test Title",
+            gallery=images,
         )
         assert submission.link_flair_css_class == flair_class
         assert submission.link_flair_text == flair_text
@@ -1548,24 +1548,24 @@ class TestSubreddit(IntegrationTest):
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         images = [
-            {"image_media": PostMedia(image_path("test.png"))},
+            {"media": PostMedia(image_path("test.png"))},
             {
-                "image_media": PostMedia(image_path("test.jpg")),
+                "media": PostMedia(image_path("test.jpg")),
                 "caption": "A JPG image.",
             },
             {
-                "image_media": PostMedia(image_path("test.gif")),
+                "media": PostMedia(image_path("test.gif")),
                 "outbound_url": "https://example.com",
             },
             {
-                "image_media": PostMedia(image_path("test.png")),
+                "media": PostMedia(image_path("test.png")),
                 "caption": "A PNG image.",
                 "outbound_url": "https://example.com",
             },
         ]
         selftext = "Testing **PRAW** gallery submission *with markdown selftext*."
         title = "Testing PRAW Gallery with Selftext"
-        submission = subreddit.submit_gallery(images=images, selftext=selftext, title=title)
+        submission = subreddit.submit(title, gallery=images, selftext=selftext)
         assert submission.author == pytest.placeholders.username
         assert submission.is_gallery
         assert submission.title == title
@@ -1574,7 +1574,7 @@ class TestSubreddit(IntegrationTest):
         assert isinstance(submission.gallery_data["items"], list)
         for i, item in enumerate(items):
             test_data = images[i]
-            test_data.pop("image_media")
+            test_data.pop("media")
             item.pop("id")
             item.pop("media_id")
             assert item == test_data
@@ -1590,7 +1590,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         for i, file_name in enumerate(("test.png", "test.jpg", "test.gif")):
             image = image_path(file_name)
-            submission = subreddit.submit_image(image_media=PostMedia(image), title=f"Test Title {i}")
+            submission = subreddit.submit(f"Test Title {i}", image=PostMedia(image))
             assert submission.author == pytest.placeholders.username
             assert submission.is_reddit_media_domain
             assert submission.title == f"Test Title {i}"
@@ -1605,7 +1605,7 @@ class TestSubreddit(IntegrationTest):
         for file_name in ("test.png", "test.jpg"):
             image = image_path(file_name)
             with pytest.raises(ClientException):
-                subreddit.submit_image(image_media=PostMedia(image), title="Test Title")
+                subreddit.submit("Test Title", image=PostMedia(image))
 
     @mock.patch(
         "websocket.create_connection",
@@ -1618,11 +1618,11 @@ class TestSubreddit(IntegrationTest):
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         image = image_path("test.jpg")
-        submission = subreddit.submit_image(
+        submission = subreddit.submit(
+            "Test Title",
             flair_id=flair_id,
             flair_text=flair_text,
-            image_media=PostMedia(image),
-            title="Test Title",
+            image=PostMedia(image),
         )
         assert submission.link_flair_css_class == flair_class
         assert submission.link_flair_text == flair_text
@@ -1659,7 +1659,7 @@ class TestSubreddit(IntegrationTest):
             tempfile.write(fake_png)
         subreddit = reddit.subreddit("test")
         with pytest.raises(TooLargeMediaException):
-            subreddit.submit_image(image_media=PostMedia(tempfile.name), title="test")
+            subreddit.submit("test", image=PostMedia(tempfile.name))
         reddit._core._requestor._http.request = _request
 
     @mock.patch(
@@ -1674,7 +1674,7 @@ class TestSubreddit(IntegrationTest):
         image = image_path("test.png")
         selftext = "Testing **PRAW** image submission *with markdown selftext*."
         title = "Testing PRAW image submission with selftext"
-        submission = subreddit.submit_image(image_media=PostMedia(image), selftext=selftext, title=title)
+        submission = subreddit.submit(title, image=PostMedia(image), selftext=selftext)
         assert submission.selftext == selftext
         assert submission.is_reddit_media_domain
         assert submission.title == title
@@ -1688,7 +1688,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         image = image_path("test.jpg")
         with pytest.raises(WebSocketException):
-            subreddit.submit_image(image_media=PostMedia(image), title="Test Title")
+            subreddit.submit("Test Title", image=PostMedia(image))
 
     @mock.patch(
         "websocket.create_connection",
@@ -1703,7 +1703,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         image = image_path("test.jpg")
         with pytest.raises(WebSocketException):
-            subreddit.submit_image(image_media=PostMedia(image), title="Test Title")
+            subreddit.submit("Test Title", image=PostMedia(image))
 
     @mock.patch(
         "websocket.create_connection",
@@ -1719,7 +1719,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         image = image_path("test.jpg")
         with pytest.raises(WebSocketException):
-            subreddit.submit_image(image_media=PostMedia(image), title="Test Title")
+            subreddit.submit("Test Title", image=PostMedia(image))
 
     @mock.patch(
         "websocket.create_connection",
@@ -1735,7 +1735,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         image = image_path("test.jpg")
         with pytest.raises(WebSocketException):
-            subreddit.submit_image(image_media=PostMedia(image), title="Test Title")
+            subreddit.submit("Test Title", image=PostMedia(image))
 
     @mock.patch(
         "websocket.create_connection",
@@ -1751,16 +1751,16 @@ class TestSubreddit(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         image = image_path("test.jpg")
         with pytest.raises(WebSocketException):
-            subreddit.submit_image(image_media=PostMedia(image), title="Test Title")
+            subreddit.submit("Test Title", image=PostMedia(image))
 
     def test_submit_image__without_websockets(self, image_path, reddit):
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         for file_name in ("test.png", "test.jpg", "test.gif"):
             image = image_path(file_name)
-            submission = subreddit.submit_image(
-                image_media=PostMedia(image),
-                title="Test Title",
+            submission = subreddit.submit(
+                "Test Title",
+                image=PostMedia(image),
                 without_websockets=True,
             )
             assert submission is None
@@ -1773,7 +1773,7 @@ class TestSubreddit(IntegrationTest):
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         image = image_path("test.jpg")
-        submission = subreddit.submit_image(discussion_type="CHAT", image_media=PostMedia(image), title="Test Title")
+        submission = subreddit.submit("Test Title", discussion_type="CHAT", image=PostMedia(image))
         assert submission.discussion_type == "CHAT"
 
     def test_submit_image_verify_invalid(self, image_path, reddit):
@@ -1784,9 +1784,9 @@ class TestSubreddit(IntegrationTest):
         with pytest.raises(
             (RedditAPIException, BadRequest)
         ):  # waiting for prawcore fix
-            subreddit.submit_image(
-                image_media=PostMedia(image),
-                title="gdfgfdgdgdgfgfdgdfgfdgfdg",
+            subreddit.submit(
+                "gdfgfdgdgdgfgfdgdfgfdgfdg",
+                image=PostMedia(image),
                 without_websockets=True,
             )
 
@@ -1800,8 +1800,8 @@ class TestSubreddit(IntegrationTest):
         options = ["Yes", "No", "3", "4", "5", "6"]
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
-        submission = subreddit.submit_poll(
-            "Test Poll", duration=6, options=options, selftext="Test poll text."
+        submission = subreddit.submit(
+            "Test Poll", poll={"duration": 6, "options": options}, selftext="Test poll text."
         )
         assert submission.author == pytest.placeholders.username
         assert submission.selftext.startswith("Test poll text.")
@@ -1816,12 +1816,11 @@ class TestSubreddit(IntegrationTest):
         options = ["Yes", "No"]
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
-        submission = subreddit.submit_poll(
+        submission = subreddit.submit(
             "Test Poll",
-            duration=6,
             flair_id=flair_id,
             flair_text=flair_text,
-            options=options,
+            poll={"duration": 6, "options": options},
             selftext="Test poll text.",
         )
         assert submission.link_flair_text == flair_text
@@ -1831,11 +1830,10 @@ class TestSubreddit(IntegrationTest):
         options = ["Yes", "No"]
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
-        submission = subreddit.submit_poll(
+        submission = subreddit.submit(
             "Test Poll",
             discussion_type="CHAT",
-            duration=2,
-            options=options,
+            poll={"duration": 2, "options": options},
             selftext="",
         )
         assert submission.discussion_type == "CHAT"
@@ -1851,7 +1849,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         for i, file_name in enumerate(("test.mov", "test.mp4")):
             video = image_path(file_name)
-            submission = subreddit.submit_video(title=f"Test Title {i}", video_media=PostMedia(video))
+            submission = subreddit.submit(f"Test Title {i}", video=PostMedia(video))
             assert submission.author == pytest.placeholders.username
             assert submission.is_video
             assert submission.title == f"Test Title {i}"
@@ -1866,7 +1864,7 @@ class TestSubreddit(IntegrationTest):
         for file_name in ("test.mov", "test.mp4"):
             video = image_path(file_name)
             with pytest.raises(ClientException):
-                subreddit.submit_video(title="Test Title", video_media=PostMedia(video))
+                subreddit.submit("Test Title", video=PostMedia(video))
 
     @mock.patch(
         "websocket.create_connection",
@@ -1879,11 +1877,11 @@ class TestSubreddit(IntegrationTest):
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         video = image_path("test.mov")
-        submission = subreddit.submit_video(
+        submission = subreddit.submit(
+            "Test Title",
             flair_id=flair_id,
             flair_text=flair_text,
-            title="Test Title",
-            video_media=PostMedia(video),
+            video=PostMedia(video),
         )
         assert submission.link_flair_css_class == flair_class
         assert submission.link_flair_text == flair_text
@@ -1901,7 +1899,7 @@ class TestSubreddit(IntegrationTest):
             title = f"Test Title {i}"
             selftext = f"Testing **PRAW** video submission *with markdown selftext*."
             video = image_path(file_name)
-            submission = subreddit.submit_video(selftext=selftext, title=title, video_media=PostMedia(video))
+            submission = subreddit.submit(title, selftext=selftext, video=PostMedia(video))
             assert submission.author == pytest.placeholders.username
             assert submission.is_video
             assert submission.title == title
@@ -1922,10 +1920,9 @@ class TestSubreddit(IntegrationTest):
         ):
             video = image_path(video_name)
             thumb = image_path(thumb_name)
-            submission = subreddit.submit_video(
-                thumbnail_media=PostMedia(thumb),
-                title="Test Title",
-                video_media=PostMedia(video),
+            submission = subreddit.submit(
+                "Test Title",
+                video={"media": PostMedia(video), "thumbnail": PostMedia(thumb)},
             )
             assert submission.author == pytest.placeholders.username
             assert submission.is_video
@@ -1940,7 +1937,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         video = image_path("test.mov")
         with pytest.raises(WebSocketException):
-            subreddit.submit_video(title="Test Title", video_media=PostMedia(video))
+            subreddit.submit("Test Title", video=PostMedia(video))
 
     @mock.patch(
         "websocket.create_connection",
@@ -1955,7 +1952,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         video = image_path("test.mov")
         with pytest.raises(WebSocketException):
-            subreddit.submit_video(title="Test Title", video_media=PostMedia(video))
+            subreddit.submit("Test Title", video=PostMedia(video))
 
     @mock.patch(
         "websocket.create_connection",
@@ -1971,7 +1968,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         video = image_path("test.mov")
         with pytest.raises(WebSocketException):
-            subreddit.submit_video(title="Test Title", video_media=PostMedia(video))
+            subreddit.submit("Test Title", video=PostMedia(video))
 
     @mock.patch(
         "websocket.create_connection",
@@ -1987,7 +1984,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         video = image_path("test.mov")
         with pytest.raises(WebSocketException):
-            subreddit.submit_video(title="Test Title", video_media=PostMedia(video))
+            subreddit.submit("Test Title", video=PostMedia(video))
 
     @mock.patch(
         "websocket.create_connection",
@@ -2003,7 +2000,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         video = image_path("test.mov")
         with pytest.raises(WebSocketException):
-            subreddit.submit_video(title="Test Title", video_media=PostMedia(video))
+            subreddit.submit("Test Title", video=PostMedia(video))
 
     @mock.patch(
         "websocket.create_connection",
@@ -2016,7 +2013,7 @@ class TestSubreddit(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         for file_name in ("test.mov", "test.mp4"):
             video = image_path(file_name)
-            submission = subreddit.submit_video(title="Test Title", video_media=PostMedia(video), videogif=True)
+            submission = subreddit.submit("Test Title", video={"gif": True, "media": PostMedia(video)})
             assert submission.author == pytest.placeholders.username
             assert submission.is_video
             assert submission.title == "Test Title"
@@ -2026,9 +2023,9 @@ class TestSubreddit(IntegrationTest):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         for file_name in ("test.mov", "test.mp4"):
             video = image_path(file_name)
-            submission = subreddit.submit_video(
-                title="Test Title",
-                video_media=PostMedia(video),
+            submission = subreddit.submit(
+                "Test Title",
+                video=PostMedia(video),
                 without_websockets=True,
             )
             assert submission is None
@@ -2041,7 +2038,7 @@ class TestSubreddit(IntegrationTest):
         reddit.read_only = False
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         video = image_path("test.mov")
-        submission = subreddit.submit_video(discussion_type="CHAT", title="Test Title", video_media=PostMedia(video))
+        submission = subreddit.submit("Test Title", discussion_type="CHAT", video=PostMedia(video))
         assert submission.discussion_type == "CHAT"
 
     def test_submit_video_verify_invalid(self, image_path, reddit):
@@ -2052,9 +2049,9 @@ class TestSubreddit(IntegrationTest):
         with pytest.raises(
             (RedditAPIException, BadRequest)
         ):  # waiting for prawcore fix
-            subreddit.submit_video(
-                title="gdfgfdgdgdgfgfdgdfgfdgfdg",
-                video_media=PostMedia(video),
+            subreddit.submit(
+                "gdfgfdgdgdgfgfdgdfgfdgfdg",
+                video=PostMedia(video),
                 without_websockets=True,
             )
 

--- a/tests/integration/models/reddit/test_wikipage.py
+++ b/tests/integration/models/reddit/test_wikipage.py
@@ -43,7 +43,7 @@ class TestWikiPageModeration(IntegrationTest):
 
         reddit.read_only = False
         subreddit.stylesheet.upload(
-            image_media=StylesheetImage("tests/integration/files/icon.jpg"),
+            StylesheetImage("tests/integration/files/icon.jpg"),
             name="css-revert-fail",
         )
         page.edit(content="div {background: url(%%css-revert-fail%%)}")

--- a/tests/unit/models/reddit/test_subreddit.py
+++ b/tests/unit/models/reddit/test_subreddit.py
@@ -68,7 +68,7 @@ class TestSubreddit(UnitTest):
             {"payload": {}, "type": "failed"}
         )
         with pytest.raises(MediaPostFailed):
-            reddit.subreddit("test").submit_image(image_media=PostMedia(b"", name="dummy.png"), title="Test")
+            reddit.subreddit("test").submit("Test", image=PostMedia(b"", name="dummy.png"))
 
     @mock.patch("praw.models.PostMedia._post_to_s3")
     @mock.patch("websocket.create_connection")
@@ -88,7 +88,7 @@ class TestSubreddit(UnitTest):
         response.text = "<Error/>"
         mock_method.return_value = response
         with pytest.raises(ServerError):
-            reddit.subreddit("test").submit_image(image_media=PostMedia(b"", name="test.png"), title="Test")
+            reddit.subreddit("test").submit("Test", image=PostMedia(b"", name="test.png"))
 
     def test_notes_delete__invalid_args(self, reddit):
         with pytest.raises(TypeError) as excinfo:
@@ -120,17 +120,29 @@ class TestSubreddit(UnitTest):
         assert str(subreddit) == "name"
 
     def test_submit__failure(self, reddit):
-        message = "Either 'selftext' and/or 'url' must be provided."
+        message = "At least one of 'gallery', 'image', 'poll', 'selftext', 'url', or 'video' must be provided."
         subreddit = Subreddit(reddit, display_name="name")
 
         with pytest.raises(TypeError) as excinfo:
             subreddit.submit("Cool title")
         assert str(excinfo.value) == message
 
+    def test_submit__multiple_kinds_disallowed(self, reddit):
+        message = "Only one of 'gallery', 'image', 'poll', 'url', or 'video' can be provided ('image', 'url' given)."
+        subreddit = Subreddit(reddit, display_name="name")
+
+        with pytest.raises(TypeError) as excinfo:
+            subreddit.submit(
+                "Cool title",
+                image=PostMedia(b"", name="test.png"),
+                url="https://praw.readthedocs.org/en/stable/",
+            )
+        assert str(excinfo.value) == message
+
     def test_submit__url_selftext_inline_media_disallowed(self, reddit):
         # `selftext` and `url` are no longer mutually exclusive,
         # but `inline_media` is not supported for link post selftext
-        message = "As of 2025-05-07, `inline_media` is not supported for link post selftext. Only Markdown text can be added to non-self posts."
+        message = "'inline_media' is only supported for text submissions. Only Markdown text can be used for the selftext of a 'url' submission."
         subreddit = Subreddit(reddit, display_name="name")
         gif = InlineGif(caption="optional caption", media=PostMedia(b"", name="test.gif"))
         image = InlineImage(caption="optional caption", media=PostMedia(b"", name="test.png"))
@@ -144,20 +156,20 @@ class TestSubreddit(UnitTest):
                              selftext=selftext)
         assert str(excinfo.value) == message
 
-    def test_submit_gallery__invalid_image_media(self, reddit):
-        message = "'image_media' is required and must be a PostMedia instance."
+    def test_submit_gallery__invalid_media(self, reddit):
+        message = "'media' is required and must be a PostMedia instance."
         subreddit = Subreddit(reddit, display_name="name")
 
         with pytest.raises(TypeError) as excinfo:
-            subreddit.submit_gallery(images=[{"image_media": "a string is not PostMedia"}], title="Cool title")
+            subreddit.submit("Cool title", gallery=[{"media": "a string is not PostMedia"}])
         assert str(excinfo.value) == message
 
-    def test_submit_gallery__missing_image_media(self, reddit):
-        message = "'image_media' is required and must be a PostMedia instance."
+    def test_submit_gallery__missing_media(self, reddit):
+        message = "'media' is required and must be a PostMedia instance."
         subreddit = Subreddit(reddit, display_name="name")
 
         with pytest.raises(TypeError) as excinfo:
-            subreddit.submit_gallery(images=[{"caption": "caption"}, {"caption": "caption2"}], title="Cool title")
+            subreddit.submit("Cool title", gallery=[{"caption": "caption"}, {"caption": "caption2"}])
         assert str(excinfo.value) == message
 
     def test_submit_gallery__too_long_caption(self, reddit):
@@ -169,9 +181,9 @@ class TestSubreddit(UnitTest):
             "yyyyyyyyyyyyyyyy too long caption"
         )
         with pytest.raises(TypeError) as excinfo:
-            subreddit.submit_gallery(
-                images=[{"image_media": PostMedia(b"", name="test.png"), "caption": caption}],
-                title="Cool title",
+            subreddit.submit(
+                "Cool title",
+                gallery=[{"media": PostMedia(b"", name="test.png"), "caption": caption}],
             )
         assert str(excinfo.value) == message
 
@@ -180,7 +192,7 @@ class TestSubreddit(UnitTest):
         for file_name in ("test.mov", "test.mp4"):
             image = PostMedia(image_path(file_name))
             with pytest.raises(ClientException):
-                subreddit.submit_image(image_media=image, title="Test Title")
+                subreddit.submit("Test Title", image=image)
 
     def test_submit_inline_media__invalid_media(self, reddit):
         message = "'media' must be a PostMedia instance."
@@ -194,12 +206,47 @@ class TestSubreddit(UnitTest):
             subreddit.submit("title", inline_media=media, selftext=selftext)
         assert str(excinfo.value) == message
 
+    def test_submit_poll__invalid_keys(self, reddit):
+        message = "'poll' contains invalid keys: 'duratoin'."
+        subreddit = Subreddit(reddit, display_name="name")
+
+        with pytest.raises(TypeError) as excinfo:
+            subreddit.submit("Cool title", poll={"duratoin": 3, "options": ["Yes", "No"]})
+        assert str(excinfo.value) == message
+
+    def test_submit_poll__missing_keys(self, reddit):
+        message = "'poll' is missing required keys: 'duration'."
+        subreddit = Subreddit(reddit, display_name="name")
+
+        with pytest.raises(TypeError) as excinfo:
+            subreddit.submit("Cool title", poll={"options": ["Yes", "No"]})
+        assert str(excinfo.value) == message
+
     def test_submit_video__bad_filetype(self, image_path, reddit):
         subreddit = reddit.subreddit(pytest.placeholders.test_subreddit)
         for file_name in ("test.jpg", "test.png", "test.gif"):
             video = PostMedia(image_path(file_name))
             with pytest.raises(ClientException):
-                subreddit.submit_video(title="Test Title", video_media=video)
+                subreddit.submit("Test Title", video=video)
+
+    def test_submit_video__invalid_keys(self, reddit):
+        message = "'video' contains invalid keys: 'videogif'."
+        subreddit = Subreddit(reddit, display_name="name")
+
+        with pytest.raises(TypeError) as excinfo:
+            subreddit.submit(
+                "Cool title",
+                video={"media": PostMedia(b"", name="test.mp4"), "videogif": True},
+            )
+        assert str(excinfo.value) == message
+
+    def test_submit_video__invalid_media(self, reddit):
+        message = "'media' is required and must be a PostMedia instance."
+        subreddit = Subreddit(reddit, display_name="name")
+
+        with pytest.raises(TypeError) as excinfo:
+            subreddit.submit("Cool title", video={"gif": True})
+        assert str(excinfo.value) == message
 
     def test_upload_banner_additional_image(self, reddit):
         subreddit = Subreddit(reddit, display_name="name")


### PR DESCRIPTION
## Summary

`Subreddit.submit_gallery`, `submit_image`, `submit_poll`, and `submit_video` are merged into `Subreddit.submit`:

```python
subreddit.submit("Title", selftext="body")                          # self post
subreddit.submit("Title", selftext="optional", url="https://...")   # link
subreddit.submit("Title", image=PostMedia("a.png"))                 # image
subreddit.submit("Title", gallery=[PostMedia("a.png"), {...}])      # gallery
subreddit.submit("Title", video=PostMedia("clip.mp4"))              # video
subreddit.submit("Title", video={"gif": True, "media": ..., "thumbnail": ...})
subreddit.submit("Title", poll={"duration": 3, "options": ["Yes", "No"]})
```

- At least one of `gallery`/`image`/`poll`/`selftext`/`url`/`video` is required; `gallery`, `image`, `poll`, `url`, and `video` are mutually exclusive, while `selftext` may accompany any of them as optional Markdown body text.
- Video-specific options (`gif`, `thumbnail`) move into the `video` dict; poll `options`/`duration` move into the `poll` dict.
- Gallery items accept a bare `PostMedia` or the existing dict form (`image_media`/`caption`/`outbound_url`).
- `selftext` is no longer required for poll submissions.
- Invalid kind combinations and unknown/missing dict keys raise `TypeError`.

## Docs

- Migration guide gains a "Unified `submit` method" section with old/new examples for each kind.
- Dangling `:meth:` references to the removed methods in CHANGES.rst demoted to literals.

## Tests

- Unit and integration tests converted to the unified API; test/cassette names kept so all 36 existing cassettes replay unchanged.
- New unit tests for mutual exclusivity and poll/video dict key validation.
- 974 passed, pre-commit clean, sphinx `-W` build clean.