### PR TITLE
Add timezone-aware datetime properties for Unix-time fields

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,15 @@ praw follows `semantic versioning <https://semver.org/>`_.
 
 **Added**
 
+- :attr:`~.Comment.created_datetime` to objects with a creation time (for example
+  :class:`.Comment`, :class:`.Submission`, :class:`.Redditor`, :class:`.Subreddit`,
+  :class:`.Collection`, and :class:`.ModNote`), returning a timezone-aware
+  :class:`datetime.datetime`.
+- :attr:`~.Collection.updated_datetime` to :class:`.Collection`,
+  :attr:`~.PollData.voting_end_datetime` to :class:`.PollData`, and
+  :attr:`~.Comment.edited_datetime` to :class:`.Comment` and :class:`.Submission`
+  (``None`` when the object has not been edited), all returning timezone-aware
+  :class:`datetime.datetime` objects.
 - Warn when a ``praw.ini`` in the current working directory sets the ``oauth_url`` or
   ``reddit_url`` endpoint, as such a file can redirect credentials to an untrusted host.
   The warning can be silenced by setting the ``PRAW_ALLOW_ENDPOINT_OVERRIDE``

--- a/praw/models/base.py
+++ b/praw/models/base.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from copy import deepcopy
+from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -24,6 +25,19 @@ class PRAWBase:
         value = deepcopy(arguments[key]) if key in arguments else {}
         value.update(new_arguments)
         arguments[key] = value
+
+    @staticmethod
+    def _to_local_datetime(timestamp: float) -> datetime:
+        """Return ``timestamp`` as a timezone-aware :class:`datetime.datetime`.
+
+        :param timestamp: A `Unix Time`_ value, in seconds.
+
+        The returned object is localized to the system's timezone.
+
+        .. _unix time: https://en.wikipedia.org/wiki/Unix_time
+
+        """
+        return datetime.fromtimestamp(timestamp, tz=timezone.utc).astimezone()
 
     @classmethod
     def parse(cls, data: dict[str, Any], reddit: praw.Reddit) -> PRAWBase:

--- a/praw/models/mod_note.py
+++ b/praw/models/mod_note.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 from praw.endpoints import API_PATH
 from praw.models.base import PRAWBase
+from praw.models.reddit.mixins import CreatedMixin
 
 
-class ModNote(PRAWBase):
+class ModNote(CreatedMixin, PRAWBase):
     """Represent a moderator note.
 
     .. include:: ../../typical_attributes.rst
@@ -44,6 +45,8 @@ class ModNote(PRAWBase):
     .. _unix time: https://en.wikipedia.org/wiki/Unix_time
 
     """
+
+    _created_at_attribute = "created_at"
 
     def __eq__(self, other: ModNote | str | object) -> bool:
         """Return whether the other instance equals the current."""

--- a/praw/models/reddit/collections.py
+++ b/praw/models/reddit/collections.py
@@ -8,12 +8,14 @@ from praw.const import API_PATH
 from praw.exceptions import ClientException
 from praw.models.base import PRAWBase
 from praw.models.reddit.base import RedditBase
+from praw.models.reddit.mixins import CreatedMixin
 from praw.models.reddit.submission import Submission
 from praw.models.reddit.subreddit import Subreddit
 from praw.util.cache import cachedproperty
 
 if TYPE_CHECKING:
     from collections.abc import Iterator
+    from datetime import datetime
 
     import praw
     from praw import models
@@ -377,7 +379,7 @@ class SubredditCollections(PRAWBase):
         )
 
 
-class Collection(RedditBase):
+class Collection(CreatedMixin, RedditBase):
     """Class to represent a :class:`.Collection`.
 
     Obtain an instance via:
@@ -417,6 +419,7 @@ class Collection(RedditBase):
     """
 
     STR_FIELD = "collection_id"
+    _created_at_attribute = "created_at_utc"
 
     @cachedproperty
     def mod(self) -> CollectionModeration:
@@ -450,6 +453,15 @@ class Collection(RedditBase):
 
         """
         return next(self._reddit.info(fullnames=[self.subreddit_id]))
+
+    @property
+    def updated_datetime(self) -> datetime:
+        """Return the last update time as a timezone-aware :class:`datetime.datetime`.
+
+        The returned object is localized to the system's timezone.
+
+        """
+        return self._to_local_datetime(self.last_update_utc)
 
     def __init__(
         self,

--- a/praw/models/reddit/comment.py
+++ b/praw/models/reddit/comment.py
@@ -9,6 +9,7 @@ from praw.exceptions import ClientException, InvalidURL
 from praw.models.comment_forest import CommentForest
 from praw.models.reddit.base import RedditBase
 from praw.models.reddit.mixins import (
+    CreatedMixin,
     FullnameMixin,
     InboxableMixin,
     ThingModerationMixin,
@@ -22,7 +23,7 @@ if TYPE_CHECKING:
     from praw import models
 
 
-class Comment(InboxableMixin, UserContentMixin, FullnameMixin, RedditBase):
+class Comment(InboxableMixin, UserContentMixin, FullnameMixin, CreatedMixin, RedditBase):
     """A class that represents a Reddit comment.
 
     .. include:: ../../typical_attributes.rst

--- a/praw/models/reddit/live.py
+++ b/praw/models/reddit/live.py
@@ -8,7 +8,7 @@ from praw.const import API_PATH
 from praw.models.list.redditor import RedditorList
 from praw.models.listing.generator import ListingGenerator
 from praw.models.reddit.base import RedditBase
-from praw.models.reddit.mixins import FullnameMixin
+from praw.models.reddit.mixins import CreatedMixin, FullnameMixin
 from praw.models.reddit.redditor import Redditor
 from praw.models.util import stream_generator
 from praw.util.cache import cachedproperty
@@ -259,7 +259,7 @@ class LiveContributorRelationship:
         self.thread._reddit.post(url, data=data)
 
 
-class LiveThread(RedditBase):
+class LiveThread(CreatedMixin, RedditBase):
     """An individual :class:`.LiveThread` object.
 
     .. include:: ../../typical_attributes.rst
@@ -697,7 +697,7 @@ class LiveUpdateContribution:
         self.update.thread._reddit.post(url, data=data)
 
 
-class LiveUpdate(FullnameMixin, RedditBase):
+class LiveUpdate(FullnameMixin, CreatedMixin, RedditBase):
     """An individual :class:`.LiveUpdate` object.
 
     .. include:: ../../typical_attributes.rst

--- a/praw/models/reddit/message.py
+++ b/praw/models/reddit/message.py
@@ -6,7 +6,7 @@ from typing import TYPE_CHECKING, Any
 
 from praw.const import API_PATH
 from praw.models.reddit.base import RedditBase
-from praw.models.reddit.mixins import FullnameMixin, InboxableMixin, ReplyableMixin
+from praw.models.reddit.mixins import CreatedMixin, FullnameMixin, InboxableMixin, ReplyableMixin
 from praw.models.reddit.redditor import Redditor
 from praw.models.reddit.subreddit import Subreddit
 
@@ -15,7 +15,7 @@ if TYPE_CHECKING:
     from praw import models
 
 
-class Message(InboxableMixin, ReplyableMixin, FullnameMixin, RedditBase):
+class Message(InboxableMixin, ReplyableMixin, FullnameMixin, CreatedMixin, RedditBase):
     """A class for private messages.
 
     .. include:: ../../typical_attributes.rst

--- a/praw/models/reddit/mixins/__init__.py
+++ b/praw/models/reddit/mixins/__init__.py
@@ -6,6 +6,7 @@ from json import dumps
 from typing import TYPE_CHECKING, Optional
 
 from praw.const import API_PATH
+from praw.models.reddit.mixins.created import CreatedMixin
 from praw.models.reddit.mixins.editable import EditableMixin
 from praw.models.reddit.mixins.fullname import FullnameMixin
 from praw.models.reddit.mixins.inboxable import InboxableMixin

--- a/praw/models/reddit/mixins/created.py
+++ b/praw/models/reddit/mixins/created.py
@@ -1,0 +1,25 @@
+"""Provide the CreatedMixin class."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from datetime import datetime
+
+
+class CreatedMixin:
+    """Interface for objects that have a creation timestamp."""
+
+    #: The attribute holding the creation `Unix Time`_, in seconds. Subclasses whose
+    #: creation timestamp is stored under a different name override this.
+    _created_at_attribute = "created_utc"
+
+    @property
+    def created_datetime(self) -> datetime:
+        """Return the creation time as a timezone-aware :class:`datetime.datetime`.
+
+        The returned object is localized to the system's timezone.
+
+        """
+        return self._to_local_datetime(getattr(self, self._created_at_attribute))

--- a/praw/models/reddit/mixins/editable.py
+++ b/praw/models/reddit/mixins/editable.py
@@ -7,11 +7,25 @@ from typing import TYPE_CHECKING
 from praw.const import API_PATH
 
 if TYPE_CHECKING:
+    from datetime import datetime
+
     from praw import models
 
 
 class EditableMixin:
     """Interface for classes that can be edited and deleted."""
+
+    @property
+    def edited_datetime(self) -> datetime | None:
+        """Return the last edit time as a timezone-aware :class:`datetime.datetime`.
+
+        Returns ``None`` if the object has never been edited. The returned object is
+        localized to the system's timezone.
+
+        """
+        if self.edited is False:
+            return None
+        return self._to_local_datetime(self.edited)
 
     def delete(self) -> None:
         """Delete the object.

--- a/praw/models/reddit/multi.py
+++ b/praw/models/reddit/multi.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 from praw.const import API_PATH
 from praw.models.listing.mixins import SubredditListingMixin
 from praw.models.reddit.base import RedditBase
+from praw.models.reddit.mixins import CreatedMixin
 from praw.models.reddit.redditor import Redditor
 from praw.models.reddit.subreddit import Subreddit, SubredditStream
 from praw.util import cachedproperty
@@ -18,7 +19,7 @@ if TYPE_CHECKING:
     from praw import models
 
 
-class Multireddit(SubredditListingMixin, RedditBase):
+class Multireddit(SubredditListingMixin, CreatedMixin, RedditBase):
     r"""A class for users' multireddits.
 
     This is referred to as a "Custom Feed" on the Reddit UI.

--- a/praw/models/reddit/poll.py
+++ b/praw/models/reddit/poll.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from praw.models.base import PRAWBase
 from praw.util import cachedproperty
+
+if TYPE_CHECKING:
+    from datetime import datetime
 
 
 class PollOption(PRAWBase):
@@ -85,6 +88,15 @@ class PollData(PRAWBase):
         if self._user_selection is None:
             return None
         return self.option(self._user_selection)
+
+    @property
+    def voting_end_datetime(self) -> datetime:
+        """Return the poll's closing time as a timezone-aware :class:`datetime.datetime`.
+
+        The returned object is localized to the system's timezone.
+
+        """
+        return self._to_local_datetime(self.voting_end_timestamp / 1000)
 
     def __setattr__(self, attribute: str, value: Any) -> None:
         """Objectify the options attribute, and save user_selection."""

--- a/praw/models/reddit/redditor.py
+++ b/praw/models/reddit/redditor.py
@@ -8,7 +8,7 @@ from typing import TYPE_CHECKING, Any
 from praw.const import API_PATH
 from praw.models.listing.mixins import RedditorListingMixin
 from praw.models.reddit.base import RedditBase
-from praw.models.reddit.mixins import FullnameMixin, MessageableMixin
+from praw.models.reddit.mixins import CreatedMixin, FullnameMixin, MessageableMixin
 from praw.models.util import stream_generator
 from praw.util.cache import cachedproperty
 
@@ -19,7 +19,7 @@ if TYPE_CHECKING:
     from praw import models
 
 
-class Redditor(MessageableMixin, RedditorListingMixin, FullnameMixin, RedditBase):
+class Redditor(MessageableMixin, RedditorListingMixin, FullnameMixin, CreatedMixin, RedditBase):
     """A class representing the users of Reddit.
 
     .. include:: ../../typical_attributes.rst

--- a/praw/models/reddit/rules.py
+++ b/praw/models/reddit/rules.py
@@ -8,6 +8,7 @@ from urllib.parse import quote
 from praw.const import API_PATH
 from praw.exceptions import ClientException
 from praw.models.reddit.base import RedditBase
+from praw.models.reddit.mixins import CreatedMixin
 from praw.util import cachedproperty
 
 if TYPE_CHECKING:
@@ -17,7 +18,7 @@ if TYPE_CHECKING:
     from praw import models
 
 
-class Rule(RedditBase):
+class Rule(CreatedMixin, RedditBase):
     """An individual :class:`.Rule` object.
 
     .. include:: ../../typical_attributes.rst

--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -16,7 +16,13 @@ from praw.models.comment_forest import CommentForest
 from praw.models.listing.listing import Listing
 from praw.models.listing.mixins import SubmissionListingMixin
 from praw.models.reddit.base import RedditBase
-from praw.models.reddit.mixins import FullnameMixin, ModNoteMixin, ThingModerationMixin, UserContentMixin
+from praw.models.reddit.mixins import (
+    CreatedMixin,
+    FullnameMixin,
+    ModNoteMixin,
+    ThingModerationMixin,
+    UserContentMixin,
+)
 from praw.models.reddit.poll import PollData
 from praw.models.reddit.redditor import Redditor
 from praw.models.reddit.subreddit import Subreddit
@@ -393,7 +399,7 @@ class SubmissionModeration(ThingModerationMixin, ModNoteMixin):
         )
 
 
-class Submission(SubmissionListingMixin, UserContentMixin, FullnameMixin, RedditBase):
+class Submission(SubmissionListingMixin, UserContentMixin, FullnameMixin, CreatedMixin, RedditBase):
     """A class for submissions to Reddit.
 
     .. include:: ../../typical_attributes.rst

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -26,7 +26,7 @@ from praw.models.listing.mixins import SubredditListingMixin
 from praw.models.media import PostMedia
 from praw.models.reddit.base import RedditBase
 from praw.models.reddit.emoji import SubredditEmoji
-from praw.models.reddit.mixins import FullnameMixin, MessageableMixin
+from praw.models.reddit.mixins import CreatedMixin, FullnameMixin, MessageableMixin
 from praw.models.reddit.modmail import ModmailConversation
 from praw.models.reddit.removal_reasons import SubredditRemovalReasons
 from praw.models.reddit.rules import SubredditRules
@@ -2238,7 +2238,7 @@ class ModeratorRelationship(SubredditRelationship):
         self.subreddit._reddit.post(url, data=data)
 
 
-class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, RedditBase):
+class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedMixin, RedditBase):
     """A class for Subreddits.
 
     To obtain an instance of this class for r/test execute:

--- a/tests/unit/models/test_datetime_properties.py
+++ b/tests/unit/models/test_datetime_properties.py
@@ -1,0 +1,58 @@
+from datetime import datetime
+
+import pytest
+
+from praw.models import Collection, Comment, Submission
+from praw.models.mod_note import ModNote
+from praw.models.reddit.poll import PollData
+
+from .. import UnitTest
+
+
+class TestCreatedDatetime(UnitTest):
+    def test_created_datetime__from_created_at(self, reddit):
+        note = ModNote(reddit, _data={"id": "n", "created_at": 1648167599})
+        assert note.created_datetime.tzinfo is not None
+        assert note.created_datetime.timestamp() == 1648167599
+
+    def test_created_datetime__from_created_at_utc(self, reddit):
+        collection = Collection(
+            reddit,
+            _data={"collection_id": "u", "created_at_utc": 1588137147.0, "last_update_utc": 1588200000.0},
+        )
+        assert collection.created_datetime.tzinfo is not None
+        assert collection.created_datetime.timestamp() == 1588137147.0
+
+    def test_created_datetime__from_created_utc(self, reddit):
+        comment = Comment(reddit, _data={"id": "abc", "created_utc": 1588137147.0})
+        assert isinstance(comment.created_datetime, datetime)
+        assert comment.created_datetime.tzinfo is not None
+        assert comment.created_datetime.timestamp() == 1588137147.0
+
+
+class TestEditedDatetime(UnitTest):
+    def test_edited_datetime__never_edited(self, reddit):
+        comment = Comment(reddit, _data={"id": "abc", "edited": False})
+        assert comment.edited_datetime is None
+
+    def test_edited_datetime__when_edited(self, reddit):
+        submission = Submission(reddit, _data={"id": "abc", "edited": 1341972591.0})
+        assert submission.edited_datetime.tzinfo is not None
+        assert submission.edited_datetime.timestamp() == 1341972591.0
+
+
+class TestUpdatedDatetime(UnitTest):
+    def test_updated_datetime(self, reddit):
+        collection = Collection(
+            reddit,
+            _data={"collection_id": "u", "created_at_utc": 1588137147.0, "last_update_utc": 1588200000.0},
+        )
+        assert collection.updated_datetime.tzinfo is not None
+        assert collection.updated_datetime.timestamp() == 1588200000.0
+
+
+class TestVotingEndDatetime(UnitTest):
+    def test_voting_end_datetime__converts_milliseconds(self, reddit):
+        poll_data = PollData(reddit, _data={"voting_end_timestamp": 1588309947690})
+        assert poll_data.voting_end_datetime.tzinfo is not None
+        assert poll_data.voting_end_datetime.timestamp() == pytest.approx(1588309947.69)


### PR DESCRIPTION
## Summary

Reddit returns timestamps as raw Unix-time numbers (e.g. ``created_utc``, ``voting_end_timestamp``). This adds normalized, **timezone-aware** ``datetime`` companions while leaving the raw fields untouched — so existing code keeps working and the ``_utc`` names stay accurate.

The accessors are computed ``@property`` objects (lazy, never stale), localized to the system timezone via ``.astimezone()``.

## What's added

- **``CreatedMixin``** (`praw/models/reddit/mixins/created.py`) providing `created_datetime`, parameterized by a `_created_at_attribute` class var (default `"created_utc"`). Applied to `Comment`, `Submission`, `Redditor`, `Subreddit` (+ `UserSubreddit`), `Message` (+ `SubredditMessage`), `Multireddit`, `Rule`, `LiveThread`, `LiveUpdate`, plus `Collection` (`created_at_utc`) and `ModNote` (`created_at`).
- **`Collection.updated_datetime`** ← `last_update_utc`.
- **`PollData.voting_end_datetime`** ← `voting_end_timestamp`, divided by 1000 (that field is in **milliseconds**, confirmed from cassette data).
- **`EditableMixin.edited_datetime`** (Comment/Submission) → `None` when `edited is False`, else a `datetime`.
- **`PRAWBase._to_local_datetime`** centralizes the conversion (`fromtimestamp(ts, tz=utc).astimezone()`, DTZ-clean).

## Notes

- Raw Reddit fields are unchanged; this is purely additive.
- All touched models are autodoc'd with `:inherited-members:`, so each property is documented automatically from its docstring.

## Testing

- New `tests/unit/models/test_datetime_properties.py` covering tz-awareness, exact `.timestamp()` round-trips (machine-independent), the millisecond conversion, and both `edited` branches.
- Full suite: 988 passed, 1 skipped; coverage 100%.
- All pre-commit hooks pass.