### PR TITLE
Require update_checker 1.x and call update_check with keyword arguments

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -19,6 +19,9 @@ praw follows `semantic versioning <https://semver.org/>`_.
 
 - Constrain the ``websocket-client`` dependency to ``<2`` to avoid silently adopting a
   future, potentially breaking, major release.
+- Require ``update_checker >=1.0, <2.0`` and call ``update_check`` with keyword
+  arguments. The 1.0 release is dependency-free, dropping ``requests`` from PRAW's
+  transitive dependencies.
 
 ***********************
  8.0.0rc2 (2026/06/08)

--- a/praw/reddit.py
+++ b/praw/reddit.py
@@ -424,7 +424,7 @@ class Reddit:
         if UPDATE_CHECKER_MISSING:
             return
         if not Reddit.update_checked and self.config.check_for_updates:
-            update_check(__package__, __version__)
+            update_check(package_name=__package__, package_version=__version__)
             Reddit.update_checked = True
 
     def _handle_rate_limit(self, exception: RedditAPIException) -> int | float | None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dependencies = [
   "defusedxml ==0.7.1",
   "prawcore >=3.0.2, <4",
   "typing-extensions; python_version <= '3.10'",
-  "update_checker >=0.18",
+  "update_checker >=1.0, <2.0",
   "websocket-client >=0.54.0, <2"
 ]
 dynamic = ["version", "description"]

--- a/tests/unit/test_reddit.py
+++ b/tests/unit/test_reddit.py
@@ -61,7 +61,7 @@ class TestReddit(UnitTest):
     def test_check_for_updates(self, mock_update_check):
         Reddit(check_for_updates="1", **self.REQUIRED_DUMMY_SETTINGS)
         assert Reddit.update_checked
-        mock_update_check.assert_called_with("praw", __version__)
+        mock_update_check.assert_called_with(package_name="praw", package_version=__version__)
 
     @mock.patch("praw.reddit.UPDATE_CHECKER_MISSING", True)
     @mock.patch("praw.reddit.Reddit.update_checked", False)

--- a/uv.lock
+++ b/uv.lock
@@ -642,7 +642,7 @@ requires-dist = [
     { name = "defusedxml", specifier = "==0.7.1" },
     { name = "prawcore", specifier = ">=3.0.2,<4" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
-    { name = "update-checker", specifier = ">=0.18" },
+    { name = "update-checker", specifier = ">=1.0,<2.0" },
     { name = "websocket-client", specifier = ">=0.54.0,<2" },
 ]
 
@@ -1236,14 +1236,11 @@ wheels = [
 
 [[package]]
 name = "update-checker"
-version = "0.18.0"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "requests" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/5c/0b/1bec4a6cc60d33ce93d11a7bcf1aeffc7ad0aa114986073411be31395c6f/update_checker-0.18.0.tar.gz", hash = "sha256:6a2d45bb4ac585884a6b03f9eade9161cedd9e8111545141e9aa9058932acb13", size = 6699, upload-time = "2020-08-04T07:08:50.429Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/92/0d/cdf2a0bc53f2b0b85a9cc7a81d0c5fa666dc140d26a1797ddf8ce4a24d0d/update_checker-1.0.0.tar.gz", hash = "sha256:bfcac66414572a82a98ea8c8633bf1ce5d102750e3b93469b89b30aa845cd1d7", size = 9600, upload-time = "2026-06-08T07:08:20.799Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/ba/8dd7fa5f0b1c6a8ac62f8f57f7e794160c1f86f31c6d0fb00f582372a3e4/update_checker-0.18.0-py3-none-any.whl", hash = "sha256:cbba64760a36fe2640d80d85306e8fe82b6816659190993b7bdabadee4d4bbfd", size = 7008, upload-time = "2020-08-04T07:08:49.51Z" },
+    { url = "https://files.pythonhosted.org/packages/51/f5/a264987b052d61c172d23eec92935480535fd32e45357bd6557fa2c687d5/update_checker-1.0.0-py3-none-any.whl", hash = "sha256:5837640948ff21820ba3ea881fb4bed5abefb39037895c6447f5e712236d60c6", size = 10618, upload-time = "2026-06-08T07:08:19.782Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Updates the update_checker dependency to the new 1.0 release.

## Changes

- **Dependency:** `update_checker >=0.18` → `update_checker >=1.0, <2.0`. The 1.0 release is dependency-free, so this also drops `requests` from PRAW's transitive dependency tree. The bounded major matches the style of the other dependencies (`prawcore >=3.0.2, <4`, `websocket-client >=0.54.0, <2`).
- **Keyword arguments:** `update_check(__package__, __version__)` → `update_check(package_name=__package__, package_version=__version__)`, matching update_checker 1.0's keyword-only-friendly signature.

## Tests

The `_check_for_update` unit test assertion updated to keyword form. Full unit suite passes (309 tests); `update_checker >=1.0` resolves and installs cleanly; `praw/reddit.py` is ruff-clean and format-clean.