### PR TITLE
Add exception_handler to stream_generator

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,10 @@ praw follows `semantic versioning <https://semver.org/>`_.
 
 **Added**
 
+- An ``exception_handler`` keyword argument to :func:`.stream_generator` (and thus all
+  ``stream`` methods) that is invoked with any exception raised while fetching items,
+  allowing the stream to resume rather than terminate. Re-raise from the handler to stop
+  the stream.
 - :attr:`~.Comment.created_datetime` to objects with a creation time (for example
   :class:`.Comment`, :class:`.Submission`, :class:`.Redditor`, :class:`.Subreddit`,
   :class:`.Collection`, and :class:`.ModNote`), returning a timezone-aware

--- a/praw/models/util.py
+++ b/praw/models/util.py
@@ -39,6 +39,7 @@ def stream_generator(
     attribute_name: str = "fullname",
     continue_after_id: str | None = None,
     exclude_before: bool = False,
+    exception_handler: Callable[[Exception], None] | None = None,
     pause_after: int | None = None,
     skip_existing: bool = False,
     **function_kwargs: Any,
@@ -50,6 +51,12 @@ def stream_generator(
     :param attribute_name: The field to use as an ID (default: ``"fullname"``).
     :param exclude_before: When ``True`` does not pass ``params`` to ``function``
         (default: ``False``).
+    :param exception_handler: A callable that is invoked with the exception raised while
+        fetching items, instead of letting it propagate and terminate the stream. After
+        the handler returns, the stream waits (using the same exponential backoff
+        applied to empty responses) and then resumes. To stop the stream, re-raise the
+        exception (or raise a new one) from within the handler. When ``None``,
+        exceptions propagate and terminate the stream as before (default: ``None``).
     :param pause_after: An integer representing the number of requests that result in no
         new items before this function yields ``None``, effectively introducing a pause
         into the stream. A negative value yields ``None`` after items from a single
@@ -121,6 +128,31 @@ def stream_generator(
                 continue
             print(comment)
 
+    To keep a stream alive across transient errors (e.g., network issues or server
+    errors) rather than having it terminate, pass an ``exception_handler``:
+
+    .. code-block:: python
+
+        def log_exception(exception):
+            print(f"Stream error, retrying: {exception}")
+
+
+        subreddit = reddit.subreddit("test")
+        for comment in subreddit.stream.comments(exception_handler=log_exception):
+            print(comment)
+
+    The handler can stop the stream for errors it considers fatal by re-raising:
+
+    .. code-block:: python
+
+        from prawcore.exceptions import Forbidden
+
+
+        def handle_exception(exception):
+            if isinstance(exception, Forbidden):
+                raise exception
+            print(f"Stream error, retrying: {exception}")
+
     """
     before_attribute = continue_after_id
     exponential_counter = ExponentialCounter(max_counter=16)
@@ -137,7 +169,15 @@ def stream_generator(
             without_before_counter = (without_before_counter + 1) % 30
         if not exclude_before:
             function_kwargs["params"] = {"before": before_attribute}
-        for item in reversed(list(function(limit=limit, **function_kwargs))):
+        try:
+            items = list(function(limit=limit, **function_kwargs))
+        except Exception as exception:
+            if exception_handler is None:
+                raise
+            exception_handler(exception)
+            time.sleep(exponential_counter.counter())
+            continue
+        for item in reversed(items):
             attribute = getattr(item, attribute_name)
             if attribute in seen_attributes:
                 continue

--- a/tests/unit/models/test_util.py
+++ b/tests/unit/models/test_util.py
@@ -2,6 +2,8 @@
 
 from collections import namedtuple
 
+import pytest
+
 from praw.models.util import (
     BoundedSet,
     ExponentialCounter,
@@ -156,3 +158,42 @@ class TestStream(UnitTest):
             thing = next(stream)
             assert thing not in seen
             seen.add(thing)
+
+    def test_stream__exception_handler(self, monkeypatch):
+        monkeypatch.setattr("praw.models.util.time.sleep", lambda *_: None)
+        Thing = namedtuple("Thing", ["fullname"])
+        things = [Thing(n) for n in reversed(range(100))]
+        counter = 99
+        handled = []
+
+        def generate(limit, **kwargs):
+            nonlocal counter
+            counter += 1
+            if counter == 100:
+                raise RuntimeError("boom")
+            return [Thing(counter)] + things[:-1]
+
+        stream = stream_generator(generate, exception_handler=handled.append)
+        thing = next(stream)
+        assert thing is not None
+        assert len(handled) == 1
+        assert str(handled[0]) == "boom"
+
+    def test_stream__exception_handler__reraise(self):
+        def generate(limit, **kwargs):
+            raise RuntimeError("boom")
+
+        def handler(exception):
+            raise exception
+
+        stream = stream_generator(generate, exception_handler=handler)
+        with pytest.raises(RuntimeError):
+            next(stream)
+
+    def test_stream__exception_propagates_without_handler(self):
+        def generate(limit, **kwargs):
+            raise RuntimeError("boom")
+
+        stream = stream_generator(generate)
+        with pytest.raises(RuntimeError):
+            next(stream)

--- a/tests/unit/models/test_util.py
+++ b/tests/unit/models/test_util.py
@@ -162,20 +162,18 @@ class TestStream(UnitTest):
     def test_stream__exception_handler(self, monkeypatch):
         monkeypatch.setattr("praw.models.util.time.sleep", lambda *_: None)
         Thing = namedtuple("Thing", ["fullname"])
-        things = [Thing(n) for n in reversed(range(100))]
-        counter = 99
         handled = []
+        fail_next = [True]
 
         def generate(limit, **kwargs):
-            nonlocal counter
-            counter += 1
-            if counter == 100:
+            if fail_next[0]:
+                fail_next[0] = False
                 raise RuntimeError("boom")
-            return [Thing(counter)] + things[:-1]
+            return [Thing(1)]
 
         stream = stream_generator(generate, exception_handler=handled.append)
         thing = next(stream)
-        assert thing is not None
+        assert thing.fullname == 1
         assert len(handled) == 1
         assert str(handled[0]) == "boom"
 

--- a/tests/unit/models/test_util.py
+++ b/tests/unit/models/test_util.py
@@ -163,17 +163,19 @@ class TestStream(UnitTest):
         monkeypatch.setattr("praw.models.util.time.sleep", lambda *_: None)
         Thing = namedtuple("Thing", ["fullname"])
         handled = []
-        fail_next = [True]
+        responses = [RuntimeError("boom"), [Thing(1)], [Thing(2)]]
 
         def generate(limit, **kwargs):
-            if fail_next[0]:
-                fail_next[0] = False
-                raise RuntimeError("boom")
-            return [Thing(1)]
+            response = responses.pop(0)
+            if isinstance(response, Exception):
+                raise response
+            return response
 
         stream = stream_generator(generate, exception_handler=handled.append)
-        thing = next(stream)
-        assert thing.fullname == 1
+        # The first fetch raises and is handled; the stream then resumes and keeps
+        # yielding new items on subsequent iterations.
+        assert next(stream).fullname == 1
+        assert next(stream).fullname == 2
         assert len(handled) == 1
         assert str(handled[0]) == "boom"
 


### PR DESCRIPTION
Addresses #1025.

## Problem

PRAW's `stream_generator` has no internal exception handling. When any exception is raised while fetching items (a transient network blip, a 5xx, a rate-limit error), it propagates out of the generator — and because an exception in a generator stops all further iteration, the stream is **permanently dead**. Long-running bots are forced into awkward workarounds (recreating the stream in an `except`, running each stream in its own process, or monkeypatching `prawcore.sessions.Session.request`).

## Change

Add an opt-in `exception_handler` keyword argument to :func:`.stream_generator`. Since every `stream` method forwards `**stream_options`, it's available everywhere automatically (`subreddit.stream.comments(exception_handler=...)`, etc.).

```python
def log_exception(exception):
    print(f"Stream error, retrying: {exception}")

for comment in reddit.subreddit("test").stream.comments(exception_handler=log_exception):
    print(comment)
```

- When a fetch raises and a handler is set, the exception is passed to the handler, the stream waits (reusing the existing exponential backoff), and then resumes.
- The handler decides policy: **return** to keep going, **re-raise** to stop (e.g. treat `Forbidden` as fatal). This also lets callers implement a circuit breaker.
- **Fully backwards-compatible**: with no handler (the default), exceptions propagate and terminate the stream exactly as before.

## Tests

Added unit tests covering: handler invoked + stream resumes, handler re-raise stops the stream, and default propagation without a handler. 100% coverage maintained; full suite passes (991 passed, 1 skipped); pre-commit clean.

If this direction looks good, I'll mirror it to Async PRAW.