### PR TITLE
Add py.typed marker and enable pyright type checking

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -29,9 +29,14 @@ praw follows `semantic versioning <https://semver.org/>`_.
   ``reddit_url`` endpoint, as such a file can redirect credentials to an untrusted host.
   The warning can be silenced by setting the ``PRAW_ALLOW_ENDPOINT_OVERRIDE``
   environment variable.
+- A ``py.typed`` marker (:PEP:`561`) so that downstream projects can type check against
+  PRAW's inline annotations.
 
 **Changed**
 
+- Require ``prawcore >=3.2, <4`` for its public :class:`.Session` and authorizer
+  accessors and the widened :meth:`!Session.request` annotations, which let PRAW drop a
+  number of internal ``cast``\ s and type-checker suppressions.
 - Constrain the ``websocket-client`` dependency to ``<2`` to avoid silently adopting a
   future, potentially breaking, major release.
 - Require ``update_checker >=1.0, <2.0`` and call ``update_check`` with keyword

--- a/praw/config.py
+++ b/praw/config.py
@@ -27,7 +27,7 @@ class _NotSet:
 class Config:
     """A class containing the configuration for a Reddit site."""
 
-    CONFIG = None
+    CONFIG: configparser.ConfigParser | None = None
     CONFIG_NOT_SET = _NotSet()  # Represents a config value that is not set.
     LOCK = Lock()
     INTERPOLATION_LEVEL = MappingProxyType({
@@ -35,10 +35,26 @@ class Config:
         "extended": configparser.ExtendedInterpolation,
     })
 
+    # Attributes populated by _initialize_attributes. client_id and user_agent are
+    # validated as present by Reddit.__init__, so they are typed as required.
+    client_id: str
+    client_secret: str | None
+    oauth_url: str
+    password: str | None
+    ratelimit_seconds: int
+    reddit_url: str
+    redirect_uri: str | None
+    refresh_token: str | None
+    timeout: int
+    user_agent: str
+    username: str | None
+
     @staticmethod
-    def _config_boolean(*, item: bool | str) -> bool:
+    def _config_boolean(*, item: bool | str | _NotSet) -> bool:
         if isinstance(item, bool):
             return item
+        if isinstance(item, _NotSet):
+            return False
         return item.lower() in {"1", "yes", "true", "on"}
 
     @classmethod
@@ -50,6 +66,7 @@ class Config:
             interpolator_class = None
 
         config = configparser.ConfigParser(interpolation=interpolator_class)
+        assert __package__ is not None
         with files(__package__).joinpath("praw.ini").open("r") as hdl:
             config.read_file(hdl)
 
@@ -114,7 +131,7 @@ class Config:
         :raises: :class:`.ClientException` if it is not set.
 
         """
-        if self._short_url is self.CONFIG_NOT_SET:
+        if isinstance(self._short_url, _NotSet):
             msg = "No short domain specified."
             raise ClientException(msg)
         return self._short_url
@@ -123,7 +140,7 @@ class Config:
         self,
         site_name: str,
         config_interpolation: str | None = None,
-        **settings: str,
+        **settings: str | bool | int | None,
     ) -> None:
         """Initialize a :class:`.Config` instance."""
         with Config.LOCK:
@@ -131,11 +148,8 @@ class Config:
                 self._load_config(config_interpolation=config_interpolation)
 
         self._settings = settings
+        assert Config.CONFIG is not None
         self.custom = dict(Config.CONFIG.items(site_name), **settings)
-
-        self.client_id = self.client_secret = self.oauth_url = None
-        self.reddit_url = self.refresh_token = self.redirect_uri = None
-        self.password = self.user_agent = self.username = None
 
         self._initialize_attributes()
 

--- a/praw/exceptions.py
+++ b/praw/exceptions.py
@@ -10,6 +10,8 @@ All other exceptions are subclassed from :class:`.ClientException`.
 
 from __future__ import annotations
 
+from typing import cast
+
 
 class PRAWException(Exception):  # noqa: N818
     """The base PRAW Exception that all other exception classes extend."""
@@ -28,7 +30,7 @@ class RedditErrorItem:
             error_str += f" on field {self.field!r}"
         return error_str
 
-    def __eq__(self, other: RedditErrorItem | list[str]) -> bool:
+    def __eq__(self, other: object) -> bool:
         """Check for equality."""
         if isinstance(other, RedditErrorItem):
             return (self.error_type, self.message, self.field) == (
@@ -196,6 +198,8 @@ class RedditAPIException(PRAWException):
 
         """
         if isinstance(items, list) and isinstance(items[0], str):
-            items = [items]
-        self.items = self.parse_exception_list(items)
+            parsed_items: list[RedditErrorItem | list[str]] = [cast("list[str]", items)]
+        else:
+            parsed_items = cast("list[RedditErrorItem | list[str]]", items)
+        self.items = self.parse_exception_list(parsed_items)
         super().__init__(*self.items)

--- a/praw/models/auth.py
+++ b/praw/models/auth.py
@@ -2,7 +2,13 @@
 
 from __future__ import annotations
 
-from prawcore import Authorizer, ImplicitAuthorizer, UntrustedAuthenticator, session
+from prawcore import (
+    Authorizer,
+    DeviceIDAuthorizer,
+    ImplicitAuthorizer,
+    UntrustedAuthenticator,
+    session,
+)
 
 from praw.exceptions import InvalidImplicitAuth, MissingRequiredAttributeException
 from praw.models.base import PRAWBase
@@ -25,7 +31,8 @@ class Auth(PRAWBase):
         requests.
 
         """
-        data = self._reddit._core._rate_limiter
+        assert self._reddit._core is not None
+        data = self._reddit._core.rate_limiter
         return {
             "remaining": data.remaining,
             "used": data.used,
@@ -41,7 +48,8 @@ class Auth(PRAWBase):
         The session's active authorization will be updated upon success.
 
         """
-        authenticator = self._reddit._read_only_core._authorizer._authenticator
+        assert self._reddit._read_only_core is not None
+        authenticator = self._reddit._read_only_core.authorizer.authenticator
         authorizer = Authorizer(authenticator)
         authorizer.authorize(code)
         authorized_session = session(authorizer=authorizer, window_size=self._reddit.config.window_size)
@@ -64,7 +72,8 @@ class Auth(PRAWBase):
             non-installed application type.
 
         """
-        authenticator = self._reddit._read_only_core._authorizer._authenticator
+        assert self._reddit._read_only_core is not None
+        authenticator = self._reddit._read_only_core.authorizer.authenticator
         if not isinstance(authenticator, UntrustedAuthenticator):
             raise InvalidImplicitAuth
         implicit_session = session(
@@ -79,9 +88,14 @@ class Auth(PRAWBase):
         For read-only authorizations this should return ``{"*"}``.
 
         """
-        authorizer = self._reddit._core._authorizer
+        assert self._reddit._core is not None
+        authorizer = self._reddit._core.authorizer
         if not authorizer.is_valid():
+            # The active core authorizer is always refreshable here; ImplicitAuthorizer
+            # is the only BaseAuthorizer without refresh() and never reaches this path.
+            assert isinstance(authorizer, (Authorizer, DeviceIDAuthorizer))
             authorizer.refresh()
+        assert authorizer.scopes is not None
         return authorizer.scopes
 
     def url(
@@ -109,6 +123,8 @@ class Auth(PRAWBase):
             whom the URL was generated for.
 
         """
+        assert self._reddit._read_only_core is not None
+        assert self._reddit._read_only_core._authorizer is not None
         authenticator = self._reddit._read_only_core._authorizer._authenticator
         if authenticator.redirect_uri is self._reddit.config.CONFIG_NOT_SET:
             msg = "redirect_uri must be provided"

--- a/praw/models/base.py
+++ b/praw/models/base.py
@@ -10,6 +10,28 @@ if TYPE_CHECKING:
     import praw
 
 
+class DynamicAttributes:
+    """Mixin for objects whose attributes are populated from Reddit response data.
+
+    Reddit adds and removes fields without notice, so PRAW sets these attributes
+    dynamically rather than declaring them. Defining ``__getattr__`` (typed to return
+    ``Any``) tells type checkers that attribute access on such objects is permitted,
+    which is required for downstream projects to type check against PRAW's ``py.typed``
+    marker. :class:`.RedditBase` provides equivalent behavior (with lazy fetching) for
+    the objects it backs; this mixin covers the :class:`.PRAWBase` data classes that do
+    not inherit it.
+
+    It does not change runtime behavior: accessing a genuinely missing attribute still
+    raises :py:class:`AttributeError`.
+
+    """
+
+    def __getattr__(self, attribute: str) -> Any:
+        """Raise :py:class:`AttributeError` for a missing dynamic attribute."""
+        msg = f"{self.__class__.__name__!r} object has no attribute {attribute!r}"
+        raise AttributeError(msg)
+
+
 class PRAWBase:
     """Superclass for all models in PRAW."""
 

--- a/praw/models/comment_forest.py
+++ b/praw/models/comment_forest.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from heapq import heappop, heappush
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from praw.exceptions import DuplicateReplaceException
 from praw.models.reddit.more import MoreComments
@@ -19,7 +19,7 @@ class CommentForest:
 
     """
 
-    def __getitem__(self, index: int) -> models.Comment:
+    def __getitem__(self, index: int) -> models.Comment | models.MoreComments:
         """Return the comment at position ``index`` in the list.
 
         This method is to be used like an array access, such as:
@@ -43,7 +43,7 @@ class CommentForest:
         """Return the number of top-level comments in the forest."""
         return len(self._comments)
 
-    def _insert_comment(self, comment: models.Comment) -> None:
+    def _insert_comment(self, comment: models.Comment | models.MoreComments) -> None:
         if comment.name in self._submission._comments_by_id:
             raise DuplicateReplaceException
         comment.submission = self._submission
@@ -65,24 +65,26 @@ class CommentForest:
         was not called first.
 
         """
-        comments = []
-        queue = list(self)
+        comments: list[models.Comment | models.MoreComments] = []
+        queue = list(self._comments)
         while queue:
             comment = queue.pop(0)
             comments.append(comment)
             if not isinstance(comment, MoreComments):
-                queue.extend(comment.replies)
+                queue.extend(comment.replies._comments)
         return comments
 
     @staticmethod
     def _gather_more_comments(
-        tree: list[models.MoreComments],
+        tree: list[models.Comment | models.MoreComments],
         *,
-        parent_tree: list[models.MoreComments] | None = None,
+        parent_tree: list[models.Comment | models.MoreComments] | None = None,
     ) -> list[MoreComments]:
         """Return a list of :class:`.MoreComments` objects obtained from tree."""
-        more_comments = []
-        queue = [(None, x) for x in tree]
+        more_comments: list[MoreComments] = []
+        queue: list[tuple[models.Comment | None, models.Comment | models.MoreComments]] = [
+            (None, x) for x in tree
+        ]
         while queue:
             parent, comment = queue.pop(0)
             if isinstance(comment, MoreComments):
@@ -99,7 +101,7 @@ class CommentForest:
     def __init__(
         self,
         submission: models.Submission,
-        comments: list[models.Comment] | None = None,
+        comments: list[models.Comment | models.MoreComments] | None = None,
     ) -> None:
         """Initialize a :class:`.CommentForest` instance.
 
@@ -109,10 +111,12 @@ class CommentForest:
             ``None``).
 
         """
-        self._comments = comments
+        self._comments: list[models.Comment | models.MoreComments] = (
+            comments if comments is not None else []
+        )
         self._submission = submission
 
-    def _update(self, comments: list[models.Comment]) -> None:
+    def _update(self, comments: list[models.Comment | models.MoreComments]) -> None:
         self._comments = comments
         for comment in comments:
             comment.submission = self._submission
@@ -184,7 +188,10 @@ class CommentForest:
                 item._remove_from.remove(item)
                 continue
 
-            new_comments = item.comments(update=False)
+            new_comments = cast(
+                "list[models.Comment | models.MoreComments]",
+                item.comments(update=False),
+            )
             if remaining is not None:
                 remaining -= 1
 

--- a/praw/models/front.py
+++ b/praw/models/front.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin
 
 from praw.models.listing.generator import ListingGenerator
@@ -23,7 +23,7 @@ class Front(SubredditListingMixin):
         super().__init__(reddit, _data=None)
         self._path = "/"
 
-    def best(self, **generator_kwargs: str | int) -> Iterator[models.Submission]:
+    def best(self, **generator_kwargs: Any) -> Iterator[models.Submission]:
         """Return a :class:`.ListingGenerator` for best items.
 
         Additional keyword arguments are passed in the initialization of

--- a/praw/models/helpers.py
+++ b/praw/models/helpers.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from json import dumps
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, overload
 
 from praw.const import API_PATH
 from praw.models.base import PRAWBase
@@ -26,6 +26,12 @@ class DraftHelper(PRAWBase):
         user's :class:`.Draft`\ s.
 
     """
+
+    @overload
+    def __call__(self, draft_id: None = None) -> list[models.Draft]: ...
+
+    @overload
+    def __call__(self, draft_id: str) -> models.Draft: ...
 
     def __call__(self, draft_id: str | None = None) -> list[models.Draft] | models.Draft:
         """Return a list of :class:`.Draft` instances.
@@ -217,7 +223,7 @@ class LiveHelper(PRAWBase):
             for position in range(0, len(ids), 100):
                 ids_chunk = ids[position : position + 100]
                 url = API_PATH["live_info"].format(ids=",".join(ids_chunk))
-                params = {"limit": 100}  # 25 is used if not specified
+                params: dict[str, str | int] = {"limit": 100}  # 25 is used if not specified
                 yield from self._reddit.get(url, params=params)
 
         return generator()
@@ -259,7 +265,7 @@ class MultiredditHelper(PRAWBase):
         display_name: str,
         icon_name: str | None = None,
         key_color: str | None = None,
-        subreddits: str | models.Subreddit,
+        subreddits: list[str | models.Subreddit],
         visibility: str = "private",
         weighting_scheme: str = "classic",
     ) -> models.Multireddit:
@@ -317,7 +323,7 @@ class SubredditHelper(PRAWBase):
         subreddit_type: str = "public",
         title: str | None = None,
         wikimode: str = "disabled",
-        **other_settings: str | None,
+        **other_settings: Any,
     ) -> models.Subreddit:
         """Create a new :class:`.Subreddit`.
 

--- a/praw/models/inbox.py
+++ b/praw/models/inbox.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from praw.const import API_PATH
 from praw.models.base import PRAWBase
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 class Inbox(PRAWBase):
     """Inbox is a Listing class that represents the inbox."""
 
-    def all(self, **generator_kwargs: str | int | dict[str, str]) -> Iterator[models.Message | models.Comment]:
+    def all(self, **generator_kwargs: Any) -> Iterator[models.Message | models.Comment]:
         """Return a :class:`.ListingGenerator` for all inbox comments and messages.
 
         Additional keyword arguments are passed in the initialization of
@@ -63,7 +63,7 @@ class Inbox(PRAWBase):
             self._reddit.post(API_PATH["collapse"], data=data)
             items = items[25:]
 
-    def comment_replies(self, **generator_kwargs: str | int | dict[str, str]) -> Iterator[models.Comment]:
+    def comment_replies(self, **generator_kwargs: Any) -> Iterator[models.Comment]:
         """Return a :class:`.ListingGenerator` for comment replies.
 
         Additional keyword arguments are passed in the initialization of
@@ -155,7 +155,7 @@ class Inbox(PRAWBase):
             self._reddit.post(API_PATH["unread_message"], data=data)
             items = items[25:]
 
-    def mentions(self, **generator_kwargs: str | int | dict[str, str]) -> Iterator[models.Comment]:
+    def mentions(self, **generator_kwargs: Any) -> Iterator[models.Comment]:
         r"""Return a :class:`.ListingGenerator` for mentions.
 
         A mention is :class:`.Comment` in which the authorized redditor is named in its
@@ -192,7 +192,7 @@ class Inbox(PRAWBase):
             message.parent = messages.get(message.parent_id)
         return messages[f"t4_{message_id.lower()}"]
 
-    def messages(self, **generator_kwargs: str | int | dict[str, str]) -> Iterator[models.Message]:
+    def messages(self, **generator_kwargs: Any) -> Iterator[models.Message]:
         """Return a :class:`.ListingGenerator` for inbox messages.
 
         Additional keyword arguments are passed in the initialization of
@@ -208,7 +208,7 @@ class Inbox(PRAWBase):
         """
         return ListingGenerator(self._reddit, API_PATH["messages"], **generator_kwargs)
 
-    def sent(self, **generator_kwargs: str | int | dict[str, str]) -> Iterator[models.Message]:
+    def sent(self, **generator_kwargs: Any) -> Iterator[models.Message]:
         """Return a :class:`.ListingGenerator` for sent messages.
 
         Additional keyword arguments are passed in the initialization of
@@ -224,7 +224,7 @@ class Inbox(PRAWBase):
         """
         return ListingGenerator(self._reddit, API_PATH["sent"], **generator_kwargs)
 
-    def stream(self, **stream_options: str | int | dict[str, str]) -> Iterator[models.Comment | models.Message]:
+    def stream(self, **stream_options: Any) -> Iterator[models.Comment | models.Message]:
         """Yield new inbox items as they become available.
 
         Items are yielded oldest first. Up to 100 historical items will initially be
@@ -242,7 +242,7 @@ class Inbox(PRAWBase):
         """
         return stream_generator(self.unread, **stream_options)
 
-    def submission_replies(self, **generator_kwargs: str | int | dict[str, str]) -> Iterator[models.Comment]:
+    def submission_replies(self, **generator_kwargs: Any) -> Iterator[models.Comment]:
         """Return a :class:`.ListingGenerator` for submission replies.
 
         Additional keyword arguments are passed in the initialization of
@@ -291,7 +291,7 @@ class Inbox(PRAWBase):
         self,
         *,
         mark_read: bool = False,
-        **generator_kwargs: str | int | dict[str, str] | None,
+        **generator_kwargs: Any | None,
     ) -> Iterator[models.Comment | models.Message]:
         """Return a :class:`.ListingGenerator` for unread comments and messages.
 

--- a/praw/models/list/base.py
+++ b/praw/models/list/base.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from praw.models.base import PRAWBase
 
@@ -15,15 +15,22 @@ if TYPE_CHECKING:
 class BaseList(PRAWBase):
     """An abstract class to coerce a list into a :class:`.PRAWBase`."""
 
-    CHILD_ATTRIBUTE = None
+    CHILD_ATTRIBUTE: ClassVar[str | None] = None
+
+    def _child_attribute(self) -> str:
+        """Return ``CHILD_ATTRIBUTE``, ensuring it has been set by a subclass."""
+        if self.CHILD_ATTRIBUTE is None:
+            msg = "BaseList must be extended."
+            raise NotImplementedError(msg)
+        return self.CHILD_ATTRIBUTE
 
     def __contains__(self, item: Any) -> bool:
         """Test if item exists in the list."""
-        return item in getattr(self, self.CHILD_ATTRIBUTE)
+        return item in getattr(self, self._child_attribute())
 
     def __getitem__(self, index: int) -> Any:
         """Return the item at position index in the list."""
-        return getattr(self, self.CHILD_ATTRIBUTE)[index]
+        return getattr(self, self._child_attribute())[index]
 
     def __init__(self, reddit: praw.Reddit, _data: dict[str, Any]) -> None:
         """Initialize a :class:`.BaseList` instance.
@@ -33,22 +40,18 @@ class BaseList(PRAWBase):
         """
         super().__init__(reddit, _data=_data)
 
-        if self.CHILD_ATTRIBUTE is None:
-            msg = "BaseList must be extended."
-            raise NotImplementedError(msg)
-
-        child_list = getattr(self, self.CHILD_ATTRIBUTE)
+        child_list = getattr(self, self._child_attribute())
         for index, item in enumerate(child_list):
             child_list[index] = reddit._objector.objectify(data=item)
 
     def __iter__(self) -> Iterator[Any]:
         """Return an iterator to the list."""
-        return getattr(self, self.CHILD_ATTRIBUTE).__iter__()
+        return getattr(self, self._child_attribute()).__iter__()
 
     def __len__(self) -> int:
         """Return the number of items in the list."""
-        return len(getattr(self, self.CHILD_ATTRIBUTE))
+        return len(getattr(self, self._child_attribute()))
 
     def __str__(self) -> str:
         """Return a string representation of the list."""
-        return str(getattr(self, self.CHILD_ATTRIBUTE))
+        return str(getattr(self, self._child_attribute()))

--- a/praw/models/listing/generator.py
+++ b/praw/models/listing/generator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Iterator
 from copy import deepcopy
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, TypedDict
 
 from praw.models.base import PRAWBase
 from praw.models.listing.listing import FlairListing, Listing, ModNoteListing
@@ -12,6 +12,17 @@ from praw.models.listing.listing import FlairListing, Listing, ModNoteListing
 if TYPE_CHECKING:
     import praw
     from praw.models.reddit.base import RedditBase
+
+
+class ListingGeneratorKwargs(TypedDict, total=False):
+    """The keyword arguments accepted by methods that return a :class:`.ListingGenerator`.
+
+    See :meth:`.ListingGenerator.__init__` for the meaning of each value.
+
+    """
+
+    limit: int | None
+    params: dict[str, str | int] | None
 
 
 class ListingGenerator(PRAWBase, Iterator):
@@ -30,7 +41,7 @@ class ListingGenerator(PRAWBase, Iterator):
         self,
         reddit: praw.Reddit,
         url: str,
-        limit: int = 100,
+        limit: int | None = 100,
         params: dict[str, str | int] | None = None,
     ) -> None:
         """Initialize a :class:`.ListingGenerator` instance.
@@ -47,7 +58,7 @@ class ListingGenerator(PRAWBase, Iterator):
         """
         super().__init__(reddit, _data=None)
         self._exhausted = False
-        self._listing = None
+        self._listing: Listing | None = None
         self._list_index: int
         self.limit = limit
         self.params = deepcopy(params) if params else {}
@@ -72,9 +83,7 @@ class ListingGenerator(PRAWBase, Iterator):
         self.yielded += 1
         return self._listing[self._list_index - 1]
 
-    def _extract_sublist(
-        self, listing: dict[str, Any] | list[Listing]
-    ) -> Listing | FlairListing | ModNoteListing | dict[str, Any] | list[Listing]:
+    def _extract_sublist(self, listing: Listing | dict[str, Any] | list[Listing]) -> Listing:
         if isinstance(listing, list):
             return listing[1]  # for submission duplicates
         if isinstance(listing, dict):
@@ -92,8 +101,8 @@ class ListingGenerator(PRAWBase, Iterator):
         if self._exhausted:
             raise StopIteration
 
-        self._listing = self._reddit.get(self.url, params=self.params)
-        self._listing = self._extract_sublist(self._listing)
+        listing = self._reddit.get(self.url, params=self.params)
+        self._listing = self._extract_sublist(listing)
         self._list_index = 0
 
         if not self._listing:

--- a/praw/models/listing/listing.py
+++ b/praw/models/listing/listing.py
@@ -15,6 +15,7 @@ class Listing(PRAWBase):
 
     if TYPE_CHECKING:
         after: Any
+        children: list[Any]
 
     AFTER_PARAM = "after"
     CHILD_ATTRIBUTE = "children"

--- a/praw/models/listing/mixins/base.py
+++ b/praw/models/listing/mixins/base.py
@@ -11,11 +11,18 @@ from praw.models.listing.generator import ListingGenerator
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+    from typing_extensions import Unpack
+
+    from praw.models.listing.generator import ListingGeneratorKwargs
+
 
 class BaseListingMixin(PRAWBase):
     """Adds minimum set of methods that apply to all listing objects."""
 
     VALID_TIME_FILTERS = frozenset({"all", "day", "hour", "month", "week", "year"})
+
+    if TYPE_CHECKING:
+        _path: str
 
     @staticmethod
     def _validate_time_filter(time_filter: str) -> None:
@@ -40,7 +47,7 @@ class BaseListingMixin(PRAWBase):
         self,
         *,
         time_filter: str = "all",
-        **generator_kwargs: str | int | dict[str, str],
+        **generator_kwargs: Unpack[ListingGeneratorKwargs],
     ) -> Iterator[Any]:
         """Return a :class:`.ListingGenerator` for controversial items.
 
@@ -67,11 +74,12 @@ class BaseListingMixin(PRAWBase):
 
         """
         self._validate_time_filter(time_filter)
-        self._safely_add_arguments(arguments=generator_kwargs, key="params", t=time_filter)
-        url = self._prepare(arguments=generator_kwargs, sort="controversial")
-        return ListingGenerator(self._reddit, url, **generator_kwargs)
+        arguments: dict[str, Any] = dict(generator_kwargs)
+        self._safely_add_arguments(arguments=arguments, key="params", t=time_filter)
+        url = self._prepare(arguments=arguments, sort="controversial")
+        return ListingGenerator(self._reddit, url, **arguments)
 
-    def hot(self, **generator_kwargs: str | int | dict[str, str]) -> Iterator[Any]:
+    def hot(self, **generator_kwargs: Unpack[ListingGeneratorKwargs]) -> Iterator[Any]:
         """Return a :class:`.ListingGenerator` for hot items.
 
         Additional keyword arguments are passed in the initialization of
@@ -89,11 +97,12 @@ class BaseListingMixin(PRAWBase):
             reddit.subreddit("all").hot()
 
         """
-        generator_kwargs.setdefault("params", {})
-        url = self._prepare(arguments=generator_kwargs, sort="hot")
-        return ListingGenerator(self._reddit, url, **generator_kwargs)
+        arguments: dict[str, Any] = dict(generator_kwargs)
+        arguments.setdefault("params", {})
+        url = self._prepare(arguments=arguments, sort="hot")
+        return ListingGenerator(self._reddit, url, **arguments)
 
-    def new(self, **generator_kwargs: str | int | dict[str, str]) -> Iterator[Any]:
+    def new(self, **generator_kwargs: Unpack[ListingGeneratorKwargs]) -> Iterator[Any]:
         """Return a :class:`.ListingGenerator` for new items.
 
         Additional keyword arguments are passed in the initialization of
@@ -111,15 +120,16 @@ class BaseListingMixin(PRAWBase):
             reddit.subreddit("all").new()
 
         """
-        generator_kwargs.setdefault("params", {})
-        url = self._prepare(arguments=generator_kwargs, sort="new")
-        return ListingGenerator(self._reddit, url, **generator_kwargs)
+        arguments: dict[str, Any] = dict(generator_kwargs)
+        arguments.setdefault("params", {})
+        url = self._prepare(arguments=arguments, sort="new")
+        return ListingGenerator(self._reddit, url, **arguments)
 
     def top(
         self,
         *,
         time_filter: str = "all",
-        **generator_kwargs: str | int | dict[str, str],
+        **generator_kwargs: Unpack[ListingGeneratorKwargs],
     ) -> Iterator[Any]:
         """Return a :class:`.ListingGenerator` for top items.
 
@@ -144,6 +154,7 @@ class BaseListingMixin(PRAWBase):
 
         """
         self._validate_time_filter(time_filter)
-        self._safely_add_arguments(arguments=generator_kwargs, key="params", t=time_filter)
-        url = self._prepare(arguments=generator_kwargs, sort="top")
-        return ListingGenerator(self._reddit, url, **generator_kwargs)
+        arguments: dict[str, Any] = dict(generator_kwargs)
+        self._safely_add_arguments(arguments=arguments, key="params", t=time_filter)
+        url = self._prepare(arguments=arguments, sort="top")
+        return ListingGenerator(self._reddit, url, **arguments)

--- a/praw/models/listing/mixins/redditor.py
+++ b/praw/models/listing/mixins/redditor.py
@@ -12,8 +12,11 @@ from praw.util.cache import cachedproperty
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+    from typing_extensions import Unpack
+
     import praw
     from praw import models
+    from praw.models.listing.generator import ListingGeneratorKwargs
 
 
 class SubListing(BaseListingMixin):
@@ -82,7 +85,9 @@ class RedditorListingMixin(BaseListingMixin):
         """
         return SubListing(self._reddit, self._path, "submitted")
 
-    def downvoted(self, **generator_kwargs: str | int | dict[str, str]) -> Iterator[models.Comment | models.Submission]:
+    def downvoted(
+        self, **generator_kwargs: Unpack[ListingGeneratorKwargs]
+    ) -> Iterator[models.Comment | models.Submission]:
         """Return a :class:`.ListingGenerator` for items the user has downvoted.
 
         :returns: A :class:`.ListingGenerator` object which yields :class:`.Comment` or
@@ -110,7 +115,9 @@ class RedditorListingMixin(BaseListingMixin):
         """
         return ListingGenerator(self._reddit, urljoin(self._path, "downvoted"), **generator_kwargs)
 
-    def hidden(self, **generator_kwargs: str | int | dict[str, str]) -> Iterator[models.Comment | models.Submission]:
+    def hidden(
+        self, **generator_kwargs: Unpack[ListingGeneratorKwargs]
+    ) -> Iterator[models.Comment | models.Submission]:
         """Return a :class:`.ListingGenerator` for items the user has hidden.
 
         :returns: A :class:`.ListingGenerator` object which yields :class:`.Comment` or
@@ -138,7 +145,7 @@ class RedditorListingMixin(BaseListingMixin):
         """
         return ListingGenerator(self._reddit, urljoin(self._path, "hidden"), **generator_kwargs)
 
-    def saved(self, **generator_kwargs: str | int | dict[str, str]) -> Iterator[models.Comment | models.Submission]:
+    def saved(self, **generator_kwargs: Unpack[ListingGeneratorKwargs]) -> Iterator[models.Comment | models.Submission]:
         """Return a :class:`.ListingGenerator` for items the user has saved.
 
         :returns: A :class:`.ListingGenerator` object which yields :class:`.Comment` or
@@ -166,7 +173,9 @@ class RedditorListingMixin(BaseListingMixin):
         """
         return ListingGenerator(self._reddit, urljoin(self._path, "saved"), **generator_kwargs)
 
-    def upvoted(self, **generator_kwargs: str | int | dict[str, str]) -> Iterator[models.Comment | models.Submission]:
+    def upvoted(
+        self, **generator_kwargs: Unpack[ListingGeneratorKwargs]
+    ) -> Iterator[models.Comment | models.Submission]:
         """Return a :class:`.ListingGenerator` for items the user has upvoted.
 
         :returns: A :class:`.ListingGenerator` object which yields :class:`.Comment` or

--- a/praw/models/listing/mixins/rising.py
+++ b/praw/models/listing/mixins/rising.py
@@ -11,13 +11,19 @@ from praw.models.listing.generator import ListingGenerator
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+    from typing_extensions import Unpack
+
     from praw import models
+    from praw.models.listing.generator import ListingGeneratorKwargs
 
 
 class RisingListingMixin(PRAWBase):
     """Mixes in the rising methods."""
 
-    def rising(self, **generator_kwargs: str | int | dict[str, str]) -> Iterator[models.Submission]:
+    if TYPE_CHECKING:
+        _path: str
+
+    def rising(self, **generator_kwargs: Unpack[ListingGeneratorKwargs]) -> Iterator[models.Submission]:
         """Return a :class:`.ListingGenerator` for rising submissions.
 
         Additional keyword arguments are passed in the initialization of

--- a/praw/models/listing/mixins/submission.py
+++ b/praw/models/listing/mixins/submission.py
@@ -11,13 +11,19 @@ from praw.models.listing.generator import ListingGenerator
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+    from typing_extensions import Unpack
+
     from praw import models
+    from praw.models.listing.generator import ListingGeneratorKwargs
 
 
 class SubmissionListingMixin(PRAWBase):
     """Adds additional methods pertaining to :class:`.Submission` instances."""
 
-    def duplicates(self, **generator_kwargs: str | int | dict[str, str]) -> Iterator[models.Submission]:
+    if TYPE_CHECKING:
+        id: str
+
+    def duplicates(self, **generator_kwargs: Unpack[ListingGeneratorKwargs]) -> Iterator[models.Submission]:
         """Return a :class:`.ListingGenerator` for the submission's duplicates.
 
         Additional keyword arguments are passed in the initialization of

--- a/praw/models/listing/mixins/subreddit.py
+++ b/praw/models/listing/mixins/subreddit.py
@@ -14,8 +14,11 @@ from praw.util.cache import cachedproperty
 if TYPE_CHECKING:
     from collections.abc import Iterator
 
+    from typing_extensions import Unpack
+
     import praw
     from praw import models
+    from praw.models.listing.generator import ListingGeneratorKwargs
 
 
 class CommentHelper(PRAWBase):
@@ -25,7 +28,7 @@ class CommentHelper(PRAWBase):
     def _path(self) -> str:
         return urljoin(self.subreddit._path, "comments/")
 
-    def __call__(self, **generator_kwargs: str | int | dict[str, str]) -> Iterator[models.Comment]:
+    def __call__(self, **generator_kwargs: Unpack[ListingGeneratorKwargs]) -> Iterator[models.Comment]:
         """Return a :class:`.ListingGenerator` for the :class:`.Subreddit`'s comments.
 
         Additional keyword arguments are passed in the initialization of

--- a/praw/models/media.py
+++ b/praw/models/media.py
@@ -5,13 +5,18 @@ from __future__ import annotations
 import sys
 from functools import cached_property
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import IO, TYPE_CHECKING, Any, ClassVar, cast
 
 from defusedxml import ElementTree
 from prawcore.exceptions import ServerError
 
 from praw.const import API_PATH, JPEG_HEADER
-from praw.exceptions import ClientException, RedditAPIException, TooLargeMediaException
+from praw.exceptions import (
+    ClientException,
+    RedditAPIException,
+    RedditErrorItem,
+    TooLargeMediaException,
+)
 
 if sys.version_info >= (3, 13):  # pragma: no cover
     from mimetypes import guess_file_type
@@ -97,7 +102,8 @@ class Media:
         return lease_response, upload_data, upload_url
 
     def _post_to_s3(self, reddit: praw.Reddit, upload_data: dict[str, str], upload_url: str, /) -> Response:
-        return reddit._core._requestor.request(
+        assert reddit._core is not None
+        return reddit._core.requestor.request(
             "POST", upload_url, data=upload_data, files={"file": (self.name, self._data)}
         )
 
@@ -162,14 +168,18 @@ class PostMedia(Media):
         if tags[:4] == ["Code", "Message", "ProposedSize", "MaxSizeAllowed"]:
             # Returned if media is too big
             *_, actual, maximum_size = (element.text for element in root[:4])
-            raise TooLargeMediaException(actual=int(actual), maximum_size=int(maximum_size))
+            raise TooLargeMediaException(
+                actual=int(actual or 0), maximum_size=int(maximum_size or 0)
+            )
 
     @staticmethod
     def _raise_upload_error(response: Response, /) -> None:
         PostMedia._parse_xml_response(response)
         Media._raise_upload_error(response)
 
-    def _upload(self, reddit: praw.Reddit, /, *, expected_mime_prefix: str | None = None, upload_type: str = "link") -> str:
+    def _upload(  # pyright: ignore[reportIncompatibleMethodOverride]  # post media is uploaded with a Reddit instance rather than a Subreddit
+        self, reddit: praw.Reddit, /, *, expected_mime_prefix: str | None = None, upload_type: str = "link"
+    ) -> str:
         """Upload the media to Reddit (undocumented endpoint).
 
         Unlike the other :class:`.Media` subclasses, post media is not associated with a
@@ -203,7 +213,9 @@ class StylesheetAsset(Media):
 
     LEASE_API_PATH = API_PATH["style_asset_lease"]
 
-    def _upload(self, subreddit: models.Subreddit, /, *, image_type: str) -> str:
+    def _upload(  # pyright: ignore[reportIncompatibleMethodOverride]  # style assets require an image_type rather than arbitrary lease data
+        self, subreddit: models.Subreddit, /, *, image_type: str
+    ) -> str:
         """Upload the media to Reddit.
 
         :param subreddit: The subreddit the style asset is associated with.
@@ -228,7 +240,9 @@ class StylesheetImage(Media):
     def _image_type(self) -> str:
         return "jpg" if self._data.startswith(JPEG_HEADER) else "png"
 
-    def _upload(self, subreddit: models.Subreddit, /, **additional_data: str) -> dict[str, Any]:
+    def _upload(  # pyright: ignore[reportIncompatibleMethodOverride]  # stylesheet image upload returns the raw response dict
+        self, subreddit: models.Subreddit, /, **additional_data: str
+    ) -> dict[str, Any]:
         """Upload the media to Reddit.
 
         :param subreddit: The subreddit the stylesheet image is associated with.
@@ -240,7 +254,10 @@ class StylesheetImage(Media):
         """
         data = {"img_type": self._image_type, **additional_data}
         url = self.UPLOAD_API_PATH.format(subreddit=subreddit)
-        response = subreddit._reddit.post(url, data=data, files={"file": (self.name, self._data)})
+        # ``requests`` accepts ``(filename, content)`` tuples for file uploads, but
+        # ``Reddit.post`` types ``files`` as ``dict[str, IO]``.
+        files = cast("dict[str, IO[Any]]", {"file": (self.name, self._data)})
+        response = subreddit._reddit.post(url, data=data, files=files)
         if response["errors"]:
             error_type = response["errors"][0]
             error_value = response.get("errors_values", [""])[0]
@@ -248,7 +265,9 @@ class StylesheetImage(Media):
                 "BAD_CSS_NAME",
                 "IMAGE_ERROR",
             }, "Please file a bug with PRAW."
-            raise RedditAPIException([[error_type, error_value, None]])
+            raise RedditAPIException(
+                [RedditErrorItem(error_type=error_type, message=error_value or "", field="")]
+            )
         return response
 
 

--- a/praw/models/mod_action.py
+++ b/praw/models/mod_action.py
@@ -16,7 +16,9 @@ class ModAction(PRAWBase):
     @property
     def mod(self) -> models.Redditor:
         """Return the :class:`.Redditor` who the action was issued by."""
-        return self._reddit.redditor(self._mod)
+        if isinstance(self._mod, str):
+            return self._reddit.redditor(self._mod)
+        return self._mod
 
     @mod.setter
     def mod(self, value: str | models.Redditor) -> None:

--- a/praw/models/mod_note.py
+++ b/praw/models/mod_note.py
@@ -2,12 +2,17 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from praw.endpoints import API_PATH
-from praw.models.base import PRAWBase
+from praw.models.base import DynamicAttributes, PRAWBase
 from praw.models.reddit.mixins import CreatedMixin
 
+if TYPE_CHECKING:
+    import praw.models
 
-class ModNote(CreatedMixin, PRAWBase):
+
+class ModNote(DynamicAttributes, CreatedMixin, PRAWBase):
     """Represent a moderator note.
 
     .. include:: ../../typical_attributes.rst
@@ -48,6 +53,10 @@ class ModNote(CreatedMixin, PRAWBase):
 
     _created_at_attribute = "created_at"
 
+    id: str
+    subreddit: praw.models.Subreddit
+    user: praw.models.Redditor
+
     def __eq__(self, other: ModNote | str | object) -> bool:
         """Return whether the other instance equals the current."""
         if isinstance(other, self.__class__):
@@ -71,7 +80,7 @@ class ModNote(CreatedMixin, PRAWBase):
                 note.delete()
 
         """
-        params = {
+        params: dict[str, str | int] = {
             "user": str(self.user),
             "subreddit": str(self.subreddit),
             "note_id": self.id,

--- a/praw/models/mod_notes.py
+++ b/praw/models/mod_notes.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from itertools import islice
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from praw.const import API_PATH
 from praw.models.base import PRAWBase
@@ -39,14 +39,17 @@ class BaseModNotes:
         redditor: Redditor | str,
         subreddit: Subreddit | str,
         **generator_kwargs: Any,
-    ) -> ListingGenerator:
+    ) -> Iterator[models.ModNote]:
         PRAWBase._safely_add_arguments(
             arguments=generator_kwargs,
             key="params",
             subreddit=subreddit,
             user=redditor,
         )
-        return ListingGenerator(self._reddit, API_PATH["mod_notes"], **generator_kwargs)
+        return cast(
+            "Iterator[models.ModNote]",
+            ListingGenerator(self._reddit, API_PATH["mod_notes"], **generator_kwargs),
+        )
 
     def _bulk_generator(
         self, redditors: list[Redditor | str], subreddits: list[Subreddit | str]
@@ -58,13 +61,15 @@ class BaseModNotes:
             users_chunk = list(islice(redditors_iter, 500))
             if not any([subreddits_chunk, users_chunk]):
                 break
-            params = {
+            params: dict[str, str | int] = {
                 "subreddits": ",".join(map(str, subreddits_chunk)),
                 "users": ",".join(map(str, users_chunk)),
             }
             response = self._reddit.get(API_PATH["mod_notes_bulk"], params=params)
             for note_dict in response["mod_notes"]:
-                yield self._reddit._objector.objectify(data=note_dict)
+                yield cast(
+                    "models.ModNote", self._reddit._objector.objectify(data=note_dict)
+                )
 
     def _ensure_attribute(self, error_message: str, **attributes: Any) -> Any:
         attribute, value_ = attributes.popitem()
@@ -148,16 +153,21 @@ class BaseModNotes:
         """
         reddit_id = None
         if thing:
+            resolved: Comment | Submission | Subreddit | str = thing
             if isinstance(thing, str):
                 reddit_id = thing
                 # this is to minimize the number of requests
                 if not (getattr(self, "redditor", redditor) and getattr(self, "subreddit", subreddit)):
                     # only fetch if we are missing either redditor or subreddit
-                    thing = next(self._reddit.info(fullnames=[thing]))
+                    resolved = next(self._reddit.info(fullnames=[thing]))
             else:
                 reddit_id = thing.fullname
-            redditor = getattr(self, "redditor", redditor) or thing.author
-            subreddit = getattr(self, "subreddit", subreddit) or thing.subreddit
+            # ``thing`` is only ever a comment/submission (or their fullname), so
+            # ``resolved`` is a Comment/Submission here -- ``info`` resolves a fullname to
+            # the same -- and both expose ``author`` and ``subreddit``.
+            assert isinstance(resolved, (Comment, Submission))
+            redditor = getattr(self, "redditor", redditor) or resolved.author
+            subreddit = getattr(self, "subreddit", subreddit) or resolved.subreddit
         redditor = self._ensure_attribute(
             "Either the 'redditor' or 'thing' parameters must be provided or this"
             " method must be called from a Redditor instance (e.g., 'redditor.notes').",
@@ -247,12 +257,12 @@ class BaseModNotes:
             reddit.notes.delete(delete_all=True, subreddit="test", redditor="spez")
 
         """
-        redditor = self._ensure_attribute(
+        redditor_: Redditor | str = self._ensure_attribute(
             "Either the 'redditor' parameter must be provided or this method must be"
             " called from a Redditor instance (e.g., 'redditor.notes').",
             redditor=redditor,
         )
-        subreddit = self._ensure_attribute(
+        subreddit_: Subreddit | str = self._ensure_attribute(
             "Either the 'subreddit' parameter must be provided or this method must be"
             " called from a Subreddit instance (e.g., 'subreddit.mod.notes').",
             subreddit=subreddit,
@@ -261,12 +271,12 @@ class BaseModNotes:
             msg = "Either 'note_id' or 'delete_all' must be provided."
             raise TypeError(msg)
         if delete_all:
-            for note in self._notes(all_notes=True, redditors=[redditor], subreddits=[subreddit]):
+            for note in self._notes(all_notes=True, redditors=[redditor_], subreddits=[subreddit_]):
                 note.delete()
         else:
             params = {
-                "user": str(redditor),
-                "subreddit": str(subreddit),
+                "user": str(redditor_),
+                "subreddit": str(subreddit_),
                 "note_id": note_id,
             }
             self._reddit.delete(API_PATH["mod_notes"], params=params)

--- a/praw/models/reddit/collections.py
+++ b/praw/models/reddit/collections.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from praw.const import API_PATH
 from praw.exceptions import ClientException
@@ -452,7 +452,7 @@ class Collection(CreatedMixin, RedditBase):
             subreddit = collection.subreddit
 
         """
-        return next(self._reddit.info(fullnames=[self.subreddit_id]))
+        return cast("models.Subreddit", next(self._reddit.info(fullnames=[self.subreddit_id])))
 
     @property
     def updated_datetime(self) -> datetime:

--- a/praw/models/reddit/comment.py
+++ b/praw/models/reddit/comment.py
@@ -81,7 +81,7 @@ class Comment(InboxableMixin, UserContentMixin, FullnameMixin, CreatedMixin, Red
         return parts[-1]
 
     @cachedproperty
-    def mod(self) -> models.reddit.comment.CommentModeration:
+    def mod(self) -> CommentModeration:
         """Provide an instance of :class:`.CommentModeration`.
 
         Example usage:
@@ -172,13 +172,14 @@ class Comment(InboxableMixin, UserContentMixin, FullnameMixin, CreatedMixin, Red
     def __setattr__(
         self,
         attribute: str,
-        value: str | Redditor | CommentForest | models.Subreddit,
+        value: Any,
     ) -> None:
         """Objectify author, replies, and subreddit."""
         if attribute == "author":
             value = Redditor.from_data(self._reddit, value)
         elif attribute == "replies":
-            value = [] if value == "" else self._reddit._objector.objectify(data=value).children  # noqa: PLC1901
+            listing: Any = None if value == "" else self._reddit._objector.objectify(data=value)  # noqa: PLC1901
+            value = [] if listing is None else listing.children
             attribute = "_replies"
         elif attribute == "subreddit":
             value = self._reddit.subreddit(value)
@@ -288,7 +289,7 @@ class Comment(InboxableMixin, UserContentMixin, FullnameMixin, CreatedMixin, Red
             comment_path = f"{path}_/{self.id}"
 
         # The context limit appears to be 8, but let's ask for more anyway.
-        params = {"context": 100}
+        params: dict[str, str | int] = {"context": 100}
         if "reply_limit" in self.__dict__:
             params["limit"] = self.reply_limit
         if "reply_sort" in self.__dict__:
@@ -305,7 +306,7 @@ class Comment(InboxableMixin, UserContentMixin, FullnameMixin, CreatedMixin, Red
             if isinstance(comment, Comment):
                 queue.extend(comment._replies)
 
-        if comment.id != self.id:
+        if comment is None or comment.id != self.id:
             raise ClientException(self.MISSING_COMMENT_MESSAGE)
 
         if self._submission is not None:

--- a/praw/models/reddit/draft.py
+++ b/praw/models/reddit/draft.py
@@ -90,7 +90,7 @@ class Draft(RedditBase):
         fetched = False
         if id:
             self.id = id
-        elif len(_data) > 1:
+        elif _data is not None and len(_data) > 1:
             if _data["kind"] in {"markdown", "richtext"}:
                 _data["selftext"] = _data.pop("body")
             elif _data["kind"] == "link":

--- a/praw/models/reddit/inline_media.py
+++ b/praw/models/reddit/inline_media.py
@@ -13,7 +13,7 @@ class InlineMedia:
 
     TYPE = None
 
-    def __eq__(self, other: InlineMedia) -> bool:
+    def __eq__(self, other: object) -> bool:
         """Return whether the other instance equals the current."""
         return all(getattr(self, attr) == getattr(other, attr) for attr in ["TYPE", "media", "caption", "media_id"])
 
@@ -32,7 +32,7 @@ class InlineMedia:
         """
         self.media = media
         self.caption = caption
-        self.media_id = None
+        self.media_id: str | None = None
 
     def __repr__(self) -> str:
         """Return an object initialization representation of the instance."""

--- a/praw/models/reddit/live.py
+++ b/praw/models/reddit/live.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from praw.const import API_PATH
 from praw.models.list.redditor import RedditorList
@@ -24,7 +24,7 @@ class LiveContributorRelationship:
     """Provide methods to interact with live threads' contributors."""
 
     @staticmethod
-    def _handle_permissions(permissions: Iterable[str]) -> str:
+    def _handle_permissions(permissions: Iterable[str] | None) -> str:
         permissions = {"all"} if permissions is None else set(permissions)
         return ",".join(f"+{x}" for x in permissions)
 
@@ -42,7 +42,7 @@ class LiveContributorRelationship:
         """
         url = API_PATH["live_contributors"].format(id=self.thread.id)
         temp = self.thread._reddit.get(url)
-        return temp if isinstance(temp, RedditorList) else temp[0]
+        return cast("list[models.Redditor]", temp if isinstance(temp, RedditorList) else temp[0])
 
     def __init__(self, thread: models.LiveThread) -> None:
         """Initialize a :class:`.LiveContributorRelationship` instance.
@@ -282,7 +282,7 @@ class LiveThread(CreatedMixin, RedditBase):
     STR_FIELD = "id"
 
     @cachedproperty
-    def contrib(self) -> models.reddit.live.LiveThreadContribution:
+    def contrib(self) -> LiveThreadContribution:
         """Provide an instance of :class:`.LiveThreadContribution`.
 
         Usage:
@@ -296,7 +296,7 @@ class LiveThread(CreatedMixin, RedditBase):
         return LiveThreadContribution(self)
 
     @cachedproperty
-    def contributor(self) -> models.reddit.live.LiveContributorRelationship:
+    def contributor(self) -> LiveContributorRelationship:
         """Provide an instance of :class:`.LiveContributorRelationship`.
 
         You can call the instance to get a list of contributors which is represented as
@@ -314,7 +314,7 @@ class LiveThread(CreatedMixin, RedditBase):
         return LiveContributorRelationship(self)
 
     @cachedproperty
-    def stream(self) -> models.reddit.live.LiveThreadStream:
+    def stream(self) -> LiveThreadStream:
         """Provide an instance of :class:`.LiveThreadStream`.
 
         Streams are used to indefinitely retrieve new updates made to a live thread,
@@ -338,7 +338,7 @@ class LiveThread(CreatedMixin, RedditBase):
         """
         return LiveThreadStream(self)
 
-    def __eq__(self, other: str | models.LiveThread) -> bool:
+    def __eq__(self, other: object) -> bool:
         """Return whether the other instance equals the current.
 
         .. note::
@@ -402,7 +402,7 @@ class LiveThread(CreatedMixin, RedditBase):
     def _fetch_info(self) -> tuple[str, dict[str, str], None]:
         return "liveabout", {"id": self.id}, None
 
-    def discussions(self, **generator_kwargs: str | int | dict[str, str]) -> Iterator[models.Submission]:
+    def discussions(self, **generator_kwargs: Any) -> Iterator[models.Submission]:
         """Get submissions linking to the thread.
 
         :param generator_kwargs: keyword arguments passed to :class:`.ListingGenerator`
@@ -444,7 +444,7 @@ class LiveThread(CreatedMixin, RedditBase):
         url = API_PATH["live_report"].format(id=self.id)
         self._reddit.post(url, data={"type": type})
 
-    def updates(self, **generator_kwargs: str | int | dict[str, str]) -> Iterator[models.LiveUpdate]:
+    def updates(self, **generator_kwargs: Any) -> Iterator[models.LiveUpdate]:
         """Return a :class:`.ListingGenerator` yields :class:`.LiveUpdate` s.
 
         :param generator_kwargs: keyword arguments passed to :class:`.ListingGenerator`
@@ -468,6 +468,7 @@ class LiveThread(CreatedMixin, RedditBase):
         """
         url = API_PATH["live_updates"].format(id=self.id)
         for update in ListingGenerator(self._reddit, url, **generator_kwargs):
+            update = cast("LiveUpdate", update)
             update._thread = self
             yield update
 
@@ -602,7 +603,7 @@ class LiveThreadStream:
         """
         self.live_thread = live_thread
 
-    def updates(self, **stream_options: dict[str, Any]) -> Iterator[models.LiveUpdate]:
+    def updates(self, **stream_options: Any) -> Iterator[models.LiveUpdate]:
         """Yield new updates to the live thread as they become available.
 
         :param skip_existing: Set to ``True`` to only fetch items created after the
@@ -718,10 +719,17 @@ class LiveUpdate(FullnameMixin, CreatedMixin, RedditBase):
     """
 
     STR_FIELD = "id"
-    _kind = "LiveUpdate"
+
+    if TYPE_CHECKING:
+        _thread: LiveThread
+
+    @property
+    def _kind(self) -> str:
+        """Return the class's kind."""
+        return "LiveUpdate"
 
     @cachedproperty
-    def contrib(self) -> models.reddit.live.LiveUpdateContribution:
+    def contrib(self) -> LiveUpdateContribution:
         """Provide an instance of :class:`.LiveUpdateContribution`.
 
         Usage:

--- a/praw/models/reddit/mixins/__init__.py
+++ b/praw/models/reddit/mixins/__init__.py
@@ -27,6 +27,8 @@ class ThingModerationMixin(ModNoteMixin):
 
     REMOVAL_MESSAGE_API = None
 
+    thing: models.Comment | models.Submission
+
     def _add_removal_reason(self, *, mod_note: str = "", reason_id: str | None = None) -> None:
         """Add a removal reason for a :class:`.Comment` or :class:`.Submission`.
 
@@ -98,7 +100,7 @@ class ThingModerationMixin(ModNoteMixin):
             :meth:`.undistinguish`
 
         """
-        data = {"how": how, "id": self.thing.fullname}
+        data: dict[str, str | bool] = {"how": how, "id": self.thing.fullname}
         if sticky and getattr(self.thing, "is_root", False):
             data["sticky"] = True
         self.thing._reddit.post(API_PATH["distinguish"], data=data)

--- a/praw/models/reddit/mixins/created.py
+++ b/praw/models/reddit/mixins/created.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from datetime import datetime
 
 
@@ -14,6 +15,10 @@ class CreatedMixin:
     #: The attribute holding the creation `Unix Time`_, in seconds. Subclasses whose
     #: creation timestamp is stored under a different name override this.
     _created_at_attribute = "created_utc"
+
+    if TYPE_CHECKING:
+        # Provided by the host class (:class:`.PRAWBase`).
+        _to_local_datetime: Callable[[float], datetime]
 
     @property
     def created_datetime(self) -> datetime:

--- a/praw/models/reddit/mixins/editable.py
+++ b/praw/models/reddit/mixins/editable.py
@@ -7,13 +7,25 @@ from typing import TYPE_CHECKING
 from praw.const import API_PATH
 
 if TYPE_CHECKING:
+    from collections.abc import Callable
     from datetime import datetime
 
-    from praw import models
+    from typing_extensions import Self
+
+    import praw
 
 
 class EditableMixin:
     """Interface for classes that can be edited and deleted."""
+
+    if TYPE_CHECKING:
+        # Provided by the host class (:class:`.RedditBase`).
+        _reddit: praw.Reddit
+        _to_local_datetime: Callable[[float], datetime]
+        edited: bool | float
+
+        @property
+        def fullname(self) -> str: ...  # noqa: D102
 
     @property
     def edited_datetime(self) -> datetime | None:
@@ -43,7 +55,7 @@ class EditableMixin:
         """
         self._reddit.post(API_PATH["del"], data={"id": self.fullname})
 
-    def edit(self, body: str) -> models.Comment | models.Submission:
+    def edit(self, body: str) -> Self:
         """Replace the body of the object with ``body``.
 
         :param body: The Markdown formatted content for the updated object.

--- a/praw/models/reddit/mixins/fullname.py
+++ b/praw/models/reddit/mixins/fullname.py
@@ -1,10 +1,21 @@
 """Provide the FullnameMixin class."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 
 class FullnameMixin:
     """Interface for classes that have a fullname."""
 
-    _kind = None
+    if TYPE_CHECKING:
+        # Provided by the host class (:class:`.RedditBase`).
+        id: str
+
+    @property
+    def _kind(self) -> str | None:
+        """Return the object's kind shortcode (e.g. ``t1``); overridden by subclasses."""
+        return None
 
     @property
     def fullname(self) -> str:

--- a/praw/models/reddit/mixins/inboxable.py
+++ b/praw/models/reddit/mixins/inboxable.py
@@ -1,10 +1,25 @@
 """Provide the InboxableMixin class."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, cast
+
 from praw.const import API_PATH
+
+if TYPE_CHECKING:
+    import praw
+    from praw import models
 
 
 class InboxableMixin:
     """Interface for :class:`.RedditBase` subclasses that originate from the inbox."""
+
+    if TYPE_CHECKING:
+        # Provided by the host class (:class:`.RedditBase`).
+        _reddit: praw.Reddit
+
+        @property
+        def fullname(self) -> str: ...  # noqa: D102
 
     def block(self) -> None:
         """Block the user who sent the item.
@@ -48,7 +63,7 @@ class InboxableMixin:
             :meth:`.uncollapse`
 
         """
-        self._reddit.inbox.collapse([self])
+        self._reddit.inbox.collapse([cast("models.Message", self)])
 
     def mark_read(self) -> None:
         """Mark a single inbox item as read.
@@ -75,7 +90,7 @@ class InboxableMixin:
         :meth:`.Inbox.mark_all_read`
 
         """
-        self._reddit.inbox.mark_read([self])
+        self._reddit.inbox.mark_read([cast("models.Comment | models.Message", self)])
 
     def mark_unread(self) -> None:
         """Mark the item as unread.
@@ -99,7 +114,7 @@ class InboxableMixin:
             :meth:`.mark_read`
 
         """
-        self._reddit.inbox.mark_unread([self])
+        self._reddit.inbox.mark_unread([cast("models.Comment | models.Message", self)])
 
     def uncollapse(self) -> None:
         """Mark the item as uncollapsed.
@@ -123,4 +138,4 @@ class InboxableMixin:
             :meth:`.collapse`
 
         """
-        self._reddit.inbox.uncollapse([self])
+        self._reddit.inbox.uncollapse([cast("models.Message", self)])

--- a/praw/models/reddit/mixins/inboxtoggleable.py
+++ b/praw/models/reddit/mixins/inboxtoggleable.py
@@ -1,10 +1,24 @@
 """Provide the InboxToggleableMixin class."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from praw.const import API_PATH
+
+if TYPE_CHECKING:
+    import praw
 
 
 class InboxToggleableMixin:
     """Interface for classes that can optionally receive inbox replies."""
+
+    if TYPE_CHECKING:
+        # Provided by the host class (:class:`.RedditBase`).
+        _reddit: praw.Reddit
+
+        @property
+        def fullname(self) -> str: ...  # noqa: D102
 
     def disable_inbox_replies(self) -> None:
         """Disable inbox replies for the item.

--- a/praw/models/reddit/mixins/messageable.py
+++ b/praw/models/reddit/mixins/messageable.py
@@ -7,11 +7,16 @@ from typing import TYPE_CHECKING
 from praw.const import API_PATH
 
 if TYPE_CHECKING:
+    import praw
     from praw import models
 
 
 class MessageableMixin:
     """Interface for classes that can be messaged."""
+
+    if TYPE_CHECKING:
+        # Provided by the host class (:class:`.RedditBase`).
+        _reddit: praw.Reddit
 
     def message(
         self,

--- a/praw/models/reddit/mixins/modnote.py
+++ b/praw/models/reddit/mixins/modnote.py
@@ -13,6 +13,10 @@ if TYPE_CHECKING:
 class ModNoteMixin:
     """Interface for classes that can have a moderator note set on them."""
 
+    if TYPE_CHECKING:
+        # Provided by the host class (e.g. :class:`.ThingModerationMixin`).
+        thing: models.Comment | models.Submission
+
     def author_notes(self, **generator_kwargs: Any) -> Iterator[models.ModNote]:
         """Get the moderator notes for the author of this object in the subreddit it's posted in.
 

--- a/praw/models/reddit/mixins/replyable.py
+++ b/praw/models/reddit/mixins/replyable.py
@@ -7,11 +7,19 @@ from typing import TYPE_CHECKING
 from praw.const import API_PATH
 
 if TYPE_CHECKING:
+    import praw
     from praw import models
 
 
 class ReplyableMixin:
     """Interface for :class:`.RedditBase` classes that can be replied to."""
+
+    if TYPE_CHECKING:
+        # Provided by the host class (:class:`.RedditBase`).
+        _reddit: praw.Reddit
+
+        @property
+        def fullname(self) -> str: ...  # noqa: D102
 
     def reply(self, body: str) -> models.Comment | models.Message | None:
         """Reply to the object.

--- a/praw/models/reddit/mixins/reportable.py
+++ b/praw/models/reddit/mixins/reportable.py
@@ -1,10 +1,24 @@
 """Provide the ReportableMixin class."""
 
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from praw.const import API_PATH
+
+if TYPE_CHECKING:
+    import praw
 
 
 class ReportableMixin:
     """Interface for :class:`.RedditBase` classes that can be reported."""
+
+    if TYPE_CHECKING:
+        # Provided by the host class (:class:`.RedditBase`).
+        _reddit: praw.Reddit
+
+        @property
+        def fullname(self) -> str: ...  # noqa: D102
 
     def report(self, reason: str) -> None:
         """Report this object to the moderators of its subreddit.

--- a/praw/models/reddit/mixins/savable.py
+++ b/praw/models/reddit/mixins/savable.py
@@ -2,11 +2,23 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from praw.const import API_PATH
+
+if TYPE_CHECKING:
+    import praw
 
 
 class SavableMixin:
     """Interface for :class:`.RedditBase` classes that can be saved."""
+
+    if TYPE_CHECKING:
+        # Provided by the host class (:class:`.RedditBase`).
+        _reddit: praw.Reddit
+
+        @property
+        def fullname(self) -> str: ...  # noqa: D102
 
     def save(self, *, category: str | None = None) -> None:
         """Save the object.

--- a/praw/models/reddit/mixins/votable.py
+++ b/praw/models/reddit/mixins/votable.py
@@ -2,11 +2,23 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from praw.const import API_PATH
+
+if TYPE_CHECKING:
+    import praw
 
 
 class VotableMixin:
     """Interface for :class:`.RedditBase` classes that can be voted on."""
+
+    if TYPE_CHECKING:
+        # Provided by the host class (:class:`.RedditBase`).
+        _reddit: praw.Reddit
+
+        @property
+        def fullname(self) -> str: ...  # noqa: D102
 
     def _vote(self, direction: int) -> None:
         self._reddit.post(API_PATH["vote"], data={"dir": str(direction), "id": self.fullname})

--- a/praw/models/reddit/modmail.py
+++ b/praw/models/reddit/modmail.py
@@ -145,7 +145,7 @@ class ModmailConversation(RedditBase):
 
         self._info_params = {"markRead": True} if mark_read else None
 
-    def _build_conversation_list(self, other_conversations: list[ModmailConversation]) -> str:
+    def _build_conversation_list(self, other_conversations: list[ModmailConversation] | None) -> str:
         """Return a comma-separated list of conversation IDs."""
         conversations = [self] + (other_conversations or [])
         return ",".join(conversation.id for conversation in conversations)
@@ -237,11 +237,10 @@ class ModmailConversation(RedditBase):
             # Reddit recently changed the response format, so we need to handle both in case they change it back
             message_id = response["conversation"]["objIds"][-1]["id"]
             message_data = response["messages"][message_id]
-            return self._reddit._objector.objectify(data=message_data)
-        for message in response.messages:
-            if message.id == response.obj_ids[-1]["id"]:
-                break
-        return message
+            message = self._reddit._objector.objectify(data=message_data)
+            assert isinstance(message, ModmailMessage)
+            return message
+        return next(message for message in response.messages if message.id == response.obj_ids[-1]["id"])
 
     def unarchive(self) -> None:
         """Unarchive the conversation.
@@ -317,7 +316,9 @@ class ModmailConversation(RedditBase):
             reddit.subreddit("test").modmail("2gmz").mute(num_days=7)
 
         """
-        params = {"num_hours": num_days * 24} if num_days != self.DEFAULT_NUMBER_OF_MUTE_DAYS else {}
+        params: dict[str, str | int] = (
+            {"num_hours": num_days * 24} if num_days != self.DEFAULT_NUMBER_OF_MUTE_DAYS else {}
+        )
         self._reddit.request(
             method="POST",
             params=params,

--- a/praw/models/reddit/more.py
+++ b/praw/models/reddit/more.py
@@ -11,6 +11,7 @@ if TYPE_CHECKING:
     import praw
     from praw import models
     from praw.models.comment_forest import CommentForest
+    from praw.models.reddit.submission import Submission
 
 
 class MoreComments(PRAWBase):
@@ -18,7 +19,16 @@ class MoreComments(PRAWBase):
 
     MAX_COMMENTS_IN_REPR = 4
 
-    def __eq__(self, other: str | MoreComments) -> bool:
+    children: list[str]
+    count: int
+    name: str
+    parent_id: str
+    submission: Submission
+    _comments: CommentForest | list[models.Comment | MoreComments] | None
+    # Attached by CommentForest._gather_more_comments.
+    _remove_from: list[models.Comment | MoreComments]
+
+    def __eq__(self, other: object) -> bool:
         """Return ``True`` if these :class:`.MoreComments` instances are the same."""
         if isinstance(other, self.__class__):
             return self.count == other.count and self.children == other.children
@@ -30,11 +40,11 @@ class MoreComments(PRAWBase):
 
     def __init__(self, reddit: praw.Reddit, _data: dict[str, Any]) -> None:
         """Initialize a :class:`.MoreComments` instance."""
-        self.count = self.parent_id = None
-        self.children = []
+        # count, parent_id, and children are populated from _data by super().__init__;
+        # submission is attached afterward by CommentForest. All are declared as class
+        # attributes above, so they need no placeholder initialization here.
         super().__init__(reddit, _data=_data)
         self._comments = None
-        self.submission = None
 
     def __lt__(self, other: MoreComments) -> bool:
         """Provide a sort order on the :class:`.MoreComments` object."""
@@ -50,7 +60,9 @@ class MoreComments(PRAWBase):
             children[-1] = "..."
         return f"<{self.__class__.__name__} count={self.count}, children={children!r}>"
 
-    def _continue_comments(self, *, update: bool) -> list[CommentForest]:
+    def _continue_comments(
+        self, *, update: bool
+    ) -> CommentForest | list[models.Comment | MoreComments]:
         assert not self.children, "Please file a bug report with PRAW."
         parent = self._load_comment(self.parent_id.split("_", 1)[1])
         self._comments = parent.replies
@@ -71,7 +83,9 @@ class MoreComments(PRAWBase):
         assert len(comments.children) == 1, "Please file a bug report with PRAW."
         return comments.children[0]
 
-    def comments(self, *, update: bool = True) -> list[CommentForest]:
+    def comments(
+        self, *, update: bool = True
+    ) -> CommentForest | list[models.Comment | MoreComments]:
         """Fetch and return the comments for a single :class:`.MoreComments` object."""
         if self._comments is None:
             if self.count == 0:  # Handle "continue this thread"
@@ -82,8 +96,11 @@ class MoreComments(PRAWBase):
                 "link_id": self.submission.fullname,
                 "sort": self.submission.comment_sort,
             }
-            self._comments = self._reddit.post(API_PATH["morechildren"], data=data)
+            comments: list[models.Comment | MoreComments] = self._reddit.post(
+                API_PATH["morechildren"], data=data
+            )
+            self._comments = comments
             if update:
-                for comment in self._comments:
+                for comment in comments:
                     comment.submission = self.submission
         return self._comments

--- a/praw/models/reddit/multi.py
+++ b/praw/models/reddit/multi.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import re
 from json import dumps
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from praw.const import API_PATH
 from praw.models.listing.mixins import SubredditListingMixin
@@ -93,12 +93,13 @@ class Multireddit(SubredditListingMixin, CreatedMixin, RedditBase):
                 print(submission)
 
         """
-        return SubredditStream(self)
+        return SubredditStream(cast("models.Subreddit", self))
 
     def __init__(self, reddit: praw.Reddit, _data: dict[str, Any]) -> None:
         """Initialize a :class:`.Multireddit` instance."""
-        self.path = None
+        self.path: str | None = None
         super().__init__(reddit, _data=_data)
+        assert self.path is not None
         self._author = Redditor(reddit, self.path.split("/", 3)[2])
         self._path = API_PATH["multireddit"].format(multi=self.name, user=self._author)
         self.path = f"/{self._path[:-1]}"  # Prevent requests for path

--- a/praw/models/reddit/poll.py
+++ b/praw/models/reddit/poll.py
@@ -4,14 +4,14 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from praw.models.base import PRAWBase
+from praw.models.base import DynamicAttributes, PRAWBase
 from praw.util import cachedproperty
 
 if TYPE_CHECKING:
     from datetime import datetime
 
 
-class PollOption(PRAWBase):
+class PollOption(DynamicAttributes, PRAWBase):
     """Class to represent one option of a poll.
 
     If ``submission`` is a poll :class:`.Submission`, access the poll's options like so:
@@ -38,6 +38,9 @@ class PollOption(PRAWBase):
 
     """
 
+    id: str
+    text: str
+
     def __repr__(self) -> str:
         """Return an object initialization representation of the instance."""
         return f"PollOption(id={self.id!r})"
@@ -47,7 +50,7 @@ class PollOption(PRAWBase):
         return self.text
 
 
-class PollData(PRAWBase):
+class PollData(DynamicAttributes, PRAWBase):
     """Class to represent poll data on a poll submission.
 
     If ``submission`` is a poll :class:`.Submission`, access the poll data like so:
@@ -76,6 +79,10 @@ class PollData(PRAWBase):
     .. _unix time: https://en.wikipedia.org/wiki/Unix_time
 
     """
+
+    _user_selection: str | None
+    options: list[PollOption]
+    voting_end_timestamp: float
 
     @cachedproperty
     def user_selection(self) -> PollOption | None:

--- a/praw/models/reddit/redditor.py
+++ b/praw/models/reddit/redditor.py
@@ -68,7 +68,7 @@ class Redditor(MessageableMixin, RedditorListingMixin, FullnameMixin, CreatedMix
     STR_FIELD = "name"
 
     @classmethod
-    def from_data(cls, reddit: praw.Reddit, data: dict[str, Any]) -> Redditor | None:
+    def from_data(cls, reddit: praw.Reddit, data: str) -> Redditor | None:
         """Return an instance of :class:`.Redditor`, or ``None`` from ``data``."""
         if data == "[deleted]":
             return None
@@ -99,7 +99,7 @@ class Redditor(MessageableMixin, RedditorListingMixin, FullnameMixin, CreatedMix
         return RedditorModNotes(self._reddit, self)
 
     @cachedproperty
-    def stream(self) -> models.reddit.redditor.RedditorStream:
+    def stream(self) -> RedditorStream:
         """Provide an instance of :class:`.RedditorStream`.
 
         Streams can be used to indefinitely retrieve new comments made by a redditor,
@@ -127,7 +127,7 @@ class Redditor(MessageableMixin, RedditorListingMixin, FullnameMixin, CreatedMix
         return self._reddit.config.kinds["redditor"]
 
     @property
-    def _path(self) -> str:
+    def _path(self) -> str:  # pyright: ignore[reportIncompatibleVariableOverride]  # read-only property override of base str attribute
         return API_PATH["user"].format(user=self)
 
     def __init__(
@@ -389,8 +389,10 @@ class Redditor(MessageableMixin, RedditorListingMixin, FullnameMixin, CreatedMix
             reddit.redditor("spez").unblock()
 
         """
+        me = self._reddit.user.me()
+        assert me is not None
         data = {
-            "container": self._reddit.user.me().fullname,
+            "container": me.fullname,
             "name": str(self),
             "type": "enemy",
         }
@@ -421,7 +423,7 @@ class RedditorStream:
         """
         self.redditor = redditor
 
-    def comments(self, **stream_options: str | int | dict[str, str]) -> Iterator[models.Comment]:
+    def comments(self, **stream_options: Any) -> Iterator[models.Comment]:
         """Yield new comments as they become available.
 
         Comments are yielded oldest first. Up to 100 historical comments will initially
@@ -439,7 +441,7 @@ class RedditorStream:
         """
         return stream_generator(self.redditor.comments.new, **stream_options)
 
-    def submissions(self, **stream_options: str | int | dict[str, str]) -> Iterator[models.Submission]:
+    def submissions(self, **stream_options: Any) -> Iterator[models.Submission]:
         """Yield new submissions as they become available.
 
         Submissions are yielded oldest first. Up to 100 historical submissions will

--- a/praw/models/reddit/rules.py
+++ b/praw/models/reddit/rules.py
@@ -45,7 +45,7 @@ class Rule(CreatedMixin, RedditBase):
     STR_FIELD = "short_name"
 
     @cachedproperty
-    def mod(self) -> models.reddit.rules.RuleModeration:
+    def mod(self) -> RuleModeration:
         """Contain methods used to moderate rules.
 
         To delete ``"No spam"`` from r/test try:
@@ -93,6 +93,7 @@ class Rule(CreatedMixin, RedditBase):
         super().__init__(reddit, _data=_data)
 
     def _fetch(self) -> None:
+        assert self.subreddit is not None
         for rule in self.subreddit.rules:
             if rule.short_name == self.short_name:
                 self.__dict__.update(rule.__dict__)

--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -111,6 +111,9 @@ class SubmissionModeration(ThingModerationMixin, ModNoteMixin):
 
     REMOVAL_MESSAGE_API = "removal_link_message"
 
+    if TYPE_CHECKING:
+        thing: models.Comment | models.Submission
+
     def __init__(self, submission: models.Submission) -> None:
         """Initialize a :class:`.SubmissionModeration` instance.
 
@@ -268,7 +271,7 @@ class SubmissionModeration(ThingModerationMixin, ModNoteMixin):
         """
         self.thing._reddit.post(API_PATH["spoiler"], data={"id": self.thing.fullname})
 
-    def sticky(self, *, bottom: bool = True, state: bool = True) -> models.Submission:
+    def sticky(self, *, bottom: bool = True, state: bool = True) -> models.Submission | None:
         """Set the submission's sticky state in its subreddit.
 
         :param bottom: When ``True``, set the submission as the bottom sticky. If no top

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -8,7 +8,7 @@ from csv import writer
 from io import StringIO
 from json import dumps, loads
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, overload
+from typing import TYPE_CHECKING, Any, cast, overload
 from urllib.parse import urljoin
 
 import websocket
@@ -36,10 +36,11 @@ from praw.models.util import permissions_string, stream_generator
 from praw.util import cachedproperty
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import Iterator, Sequence
 
     import praw
     from praw import models
+    from praw.models.reddit.collections import SubredditCollections
 
 
 class Modmail:
@@ -101,7 +102,7 @@ class Modmail:
         """Initialize a :class:`.Modmail` instance."""
         self.subreddit = subreddit
 
-    def _build_subreddit_list(self, other_subreddits: list[models.Subreddit] | None) -> str:
+    def _build_subreddit_list(self, other_subreddits: list[models.Subreddit | str] | None) -> str:
         """Return a comma-separated list of subreddit display names."""
         subreddits = [self.subreddit] + (other_subreddits or [])
         return ",".join(str(subreddit) for subreddit in subreddits)
@@ -138,7 +139,7 @@ class Modmail:
             subreddit.modmail.bulk_read(state="notifications")
 
         """
-        params = {"entity": self._build_subreddit_list(other_subreddits)}
+        params: dict[str, str | int] = {"entity": self._build_subreddit_list(other_subreddits)}
         if state:
             params["state"] = state
         response = self.subreddit._reddit.post(API_PATH["modmail_bulk_read"], params=params)
@@ -147,7 +148,7 @@ class Modmail:
     def conversations(
         self,
         *,
-        other_subreddits: list[models.Subreddit] | None = None,
+        other_subreddits: list[models.Subreddit | str] | None = None,
         sort: str | None = None,
         state: str | None = None,
         **generator_kwargs: Any,
@@ -291,7 +292,7 @@ class SubredditFilters:
 
         """
         url = API_PATH["subreddit_filter_list"].format(special=self.subreddit, user=self.subreddit._reddit.user.me())
-        params = {"unique": self.subreddit._reddit._next_unique}
+        params: dict[str, str | int] = {"unique": self.subreddit._reddit._next_unique}
         response_data = self.subreddit._reddit.get(url, params=params)
         yield from response_data.subreddits
 
@@ -342,7 +343,7 @@ class SubredditFlair:
     @cachedproperty
     def link_templates(
         self,
-    ) -> models.reddit.subreddit.SubredditLinkFlairTemplates:
+    ) -> SubredditLinkFlairTemplates:
         """Provide an instance of :class:`.SubredditLinkFlairTemplates`.
 
         Use this attribute for interacting with a :class:`.Subreddit`'s link flair
@@ -360,7 +361,7 @@ class SubredditFlair:
     @cachedproperty
     def templates(
         self,
-    ) -> models.reddit.subreddit.SubredditRedditorFlairTemplates:
+    ) -> SubredditRedditorFlairTemplates:
         """Provide an instance of :class:`.SubredditRedditorFlairTemplates`.
 
         Use this attribute for interacting with a :class:`.Subreddit`'s flair templates.
@@ -468,7 +469,7 @@ class SubredditFlair:
         :returns: List of dictionaries indicating the success or failure of each delete.
 
         """
-        return self.update(x["user"] for x in self())
+        return self.update(cast("dict[str, str | models.Redditor]", x)["user"] for x in self())
 
     def set(
         self,
@@ -574,7 +575,7 @@ class SubredditFlairTemplates:
     """Provide functions to interact with a :class:`.Subreddit`'s flair templates."""
 
     @staticmethod
-    def flair_type(*, is_link: bool) -> str:
+    def flair_type(*, is_link: bool | None) -> str:
         """Return ``"LINK_FLAIR"`` or ``"USER_FLAIR"`` depending on ``is_link`` value."""
         return "LINK_FLAIR" if is_link else "USER_FLAIR"
 
@@ -592,7 +593,7 @@ class SubredditFlairTemplates:
         """
         self.subreddit = subreddit
 
-    def __iter__(self) -> Iterator[None]:
+    def __iter__(self) -> Iterator[dict[str, str | int | bool | list[dict[str, str]]]]:
         """Abstract method to return flair templates."""
         raise NotImplementedError
 
@@ -794,7 +795,7 @@ class SubredditModeration:
         return SubredditRemovalReasons(self.subreddit)
 
     @cachedproperty
-    def stream(self) -> models.reddit.subreddit.SubredditModerationStream:
+    def stream(self) -> SubredditModerationStream:
         """Provide an instance of :class:`.SubredditModerationStream`.
 
         Streams can be used to indefinitely retrieve Moderator only items from
@@ -1944,7 +1945,7 @@ class SubredditWiki:
 
     def revisions(
         self, **generator_kwargs: Any
-    ) -> Iterator[dict[str, models.Redditor | WikiPage | str | int | bool | None], None]:
+    ) -> Iterator[dict[str, models.Redditor | WikiPage | str | int | bool | None]]:
         """Return a :class:`.ListingGenerator` for recent wiki revisions.
 
         Additional keyword arguments are passed in the initialization of
@@ -2012,11 +2013,13 @@ class ModeratorRelationship(SubredditRelationship):
     ) -> dict[str, Any]:
         other_settings = deepcopy(other_settings) if other_settings else {}
         other_settings["permissions"] = permissions_string(
-            known_permissions=ModeratorRelationship.PERMISSIONS, permissions=permissions
+            known_permissions=set(ModeratorRelationship.PERMISSIONS), permissions=permissions
         )
         return other_settings
 
-    def __call__(self, redditor: str | models.Redditor | None = None) -> list[models.Redditor]:
+    def __call__(  # pyright: ignore[reportIncompatibleMethodOverride]  # intentionally non-paginated; returns a list
+        self, redditor: str | models.Redditor | None = None
+    ) -> list[models.Redditor]:
         r"""Return a list of :class:`.Redditor`\ s who are moderators.
 
         :param redditor: When provided, return a list containing at most one
@@ -2052,7 +2055,7 @@ class ModeratorRelationship(SubredditRelationship):
                 print(f"{moderator}: {moderator.mod_permissions}")
 
         """
-        params = {} if redditor is None else {"user": redditor}
+        params: dict[str, str | int] = {} if redditor is None else {"user": str(redditor)}
         url = API_PATH[f"list_{self.relationship}"].format(subreddit=self.subreddit)
         return self.subreddit._reddit.get(url, params=params)
 
@@ -2156,7 +2159,9 @@ class ModeratorRelationship(SubredditRelationship):
             reddit.subreddit("test").moderator.leave()
 
         """
-        self.remove(self.subreddit._reddit.config.username or self.subreddit._reddit.user.me())
+        redditor = self.subreddit._reddit.config.username or self.subreddit._reddit.user.me()
+        assert redditor is not None
+        self.remove(redditor)
 
     def remove_invite(self, redditor: str | models.Redditor) -> None:
         """Remove the moderator invite for ``redditor``.
@@ -2314,6 +2319,13 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
     MAX_CAPTION_LENGTH = 180
     MESSAGE_PREFIX = "#"
 
+    # Bound at import time by the submission and collections modules to avoid circular
+    # imports.
+    _submission_class: type[models.Submission]
+    _subreddit_collections_class: type[SubredditCollections]
+
+    last_updated: int
+
     @staticmethod
     def _create_or_update(
         *,
@@ -2396,7 +2408,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
     @staticmethod
     def _subreddit_list(
         *,
-        other_subreddits: list[str | models.Subreddit],
+        other_subreddits: Sequence[str | models.Subreddit] | None,
         subreddit: models.Subreddit,
     ) -> str:
         if other_subreddits:
@@ -2410,7 +2422,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
             if not isinstance(media, PostMedia):
                 msg = "'media' is required and must be a PostMedia instance."
                 raise TypeError(msg)
-            if not len(image.get("caption", "")) <= Subreddit.MAX_CAPTION_LENGTH:
+            if not len(cast("str", image.get("caption", ""))) <= Subreddit.MAX_CAPTION_LENGTH:
                 msg = "Caption must be 180 characters or less."
                 raise TypeError(msg)
 
@@ -2421,7 +2433,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
             raise TypeError(msg)
 
     @cachedproperty
-    def banned(self) -> models.reddit.subreddit.SubredditRelationship:
+    def banned(self) -> SubredditRelationship:
         """Provide an instance of :class:`.SubredditRelationship`.
 
         For example, to ban a user try:
@@ -2441,7 +2453,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
         return SubredditRelationship(self, "banned")
 
     @cachedproperty
-    def collections(self) -> models.reddit.collections.SubredditCollections:
+    def collections(self) -> SubredditCollections:
         r"""Provide an instance of :class:`.SubredditCollections`.
 
         To see the permalinks of all :class:`.Collection`\ s that belong to a subreddit,
@@ -2466,7 +2478,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
         return self._subreddit_collections_class(self._reddit, self)
 
     @cachedproperty
-    def contributor(self) -> models.reddit.subreddit.ContributorRelationship:
+    def contributor(self) -> ContributorRelationship:
         """Provide an instance of :class:`.ContributorRelationship`.
 
         Contributors are also known as approved submitters.
@@ -2506,7 +2518,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
         return SubredditEmoji(self)
 
     @cachedproperty
-    def filters(self) -> models.reddit.subreddit.SubredditFilters:
+    def filters(self) -> SubredditFilters:
         """Provide an instance of :class:`.SubredditFilters`.
 
         For example, to add a filter, run:
@@ -2519,7 +2531,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
         return SubredditFilters(self)
 
     @cachedproperty
-    def flair(self) -> models.reddit.subreddit.SubredditFlair:
+    def flair(self) -> SubredditFlair:
         """Provide an instance of :class:`.SubredditFlair`.
 
         Use this attribute for interacting with a :class:`.Subreddit`'s flair. For
@@ -2555,7 +2567,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
         return SubredditModeration(self)
 
     @cachedproperty
-    def moderator(self) -> models.reddit.subreddit.ModeratorRelationship:
+    def moderator(self) -> ModeratorRelationship:
         """Provide an instance of :class:`.ModeratorRelationship`.
 
         For example, to add a moderator try:
@@ -2575,7 +2587,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
         return ModeratorRelationship(self, "moderator")
 
     @cachedproperty
-    def modmail(self) -> models.reddit.subreddit.Modmail:
+    def modmail(self) -> Modmail:
         """Provide an instance of :class:`.Modmail`.
 
         For example, to send a new modmail from r/test to u/spez with the subject
@@ -2589,7 +2601,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
         return Modmail(self)
 
     @cachedproperty
-    def muted(self) -> models.reddit.subreddit.SubredditRelationship:
+    def muted(self) -> SubredditRelationship:
         """Provide an instance of :class:`.SubredditRelationship`.
 
         For example, muted users can be iterated through like so:
@@ -2603,7 +2615,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
         return SubredditRelationship(self, "muted")
 
     @cachedproperty
-    def quaran(self) -> models.reddit.subreddit.SubredditQuarantine:
+    def quaran(self) -> SubredditQuarantine:
         """Provide an instance of :class:`.SubredditQuarantine`.
 
         This property is named ``quaran`` because ``quarantine`` is a subreddit
@@ -2645,7 +2657,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
         return SubredditRules(self)
 
     @cachedproperty
-    def stream(self) -> models.reddit.subreddit.SubredditStream:
+    def stream(self) -> SubredditStream:
         """Provide an instance of :class:`.SubredditStream`.
 
         Streams can be used to indefinitely retrieve new comments made to a subreddit,
@@ -2668,7 +2680,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
         return SubredditStream(self)
 
     @cachedproperty
-    def stylesheet(self) -> models.reddit.subreddit.SubredditStylesheet:
+    def stylesheet(self) -> SubredditStylesheet:
         """Provide an instance of :class:`.SubredditStylesheet`.
 
         For example, to add the css data ``.test{color:blue}`` to the existing
@@ -2707,7 +2719,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
         return SubredditWidgets(self)
 
     @cachedproperty
-    def wiki(self) -> models.reddit.subreddit.SubredditWiki:
+    def wiki(self) -> SubredditWiki:
         """Provide an instance of :class:`.SubredditWiki`.
 
         This attribute can be used to discover all wikipages for a subreddit:
@@ -2926,11 +2938,14 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
 
         """
         url = API_PATH["about_sticky"].format(subreddit=self)
+        path = url
         try:
             self._reddit.get(url, params={"num": number})
         except Redirect as redirect:
             path = redirect.path
-        return self._submission_class(self._reddit, url=urljoin(self._reddit.config.reddit_url, path))
+        reddit_url = self._reddit.config.reddit_url
+        assert reddit_url is not None
+        return self._submission_class(self._reddit, url=urljoin(reddit_url, path))
 
     @overload
     def submit(
@@ -3302,7 +3317,9 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
                 data[key] = value
 
         if gallery is not None:
-            images = [{"media": item} if isinstance(item, PostMedia) else item for item in gallery]
+            images: list[dict[str, str | PostMedia]] = [
+                {"media": item} if isinstance(item, PostMedia) else item for item in gallery
+            ]
             self._validate_gallery(images)
             data.update(api_type="json", items=[], show_error_list=True)
             if selftext is not None:
@@ -3311,7 +3328,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
                 data["items"].append({
                     "caption": image_item.get("caption", ""),
                     "outbound_url": image_item.get("outbound_url", ""),
-                    "media_id": image_item["media"]._upload(
+                    "media_id": cast("PostMedia", image_item["media"])._upload(
                         self._reddit,
                         expected_mime_prefix="image",
                         upload_type="gallery",
@@ -3357,7 +3374,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
             if not isinstance(video_media, PostMedia):
                 msg = "'media' is required and must be a PostMedia instance."
                 raise TypeError(msg)
-            thumbnail_media = video.get("thumbnail")
+            thumbnail_media = cast("PostMedia | None", video.get("thumbnail"))
             if thumbnail_media is None:
                 # if we're uploading without a thumbnail, use the PRAW logo
                 logo_path = Path(__file__).absolute().parent.parent.parent / "images" / "PRAW logo.png"
@@ -3381,6 +3398,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
         else:
             data.update(kind="self")
             if inline_media:
+                assert selftext is not None
                 body = selftext.format(**{
                     placeholder: self._upload_inline_media(media) for placeholder, media in inline_media.items()
                 })
@@ -3595,7 +3613,7 @@ class SubredditRedditorFlairTemplates(SubredditFlairTemplates):
 
         """
         url = API_PATH["user_flair"].format(subreddit=self.subreddit)
-        params = {"unique": self.subreddit._reddit._next_unique}
+        params: dict[str, str | int] = {"unique": self.subreddit._reddit._next_unique}
         yield from self.subreddit._reddit.get(url, params=params)
 
     def add(

--- a/praw/models/reddit/user_subreddit.py
+++ b/praw/models/reddit/user_subreddit.py
@@ -9,7 +9,6 @@ from praw.util.cache import cachedproperty
 
 if TYPE_CHECKING:
     import praw
-    from praw import models
 
 
 class UserSubreddit(Subreddit):
@@ -52,7 +51,7 @@ class UserSubreddit(Subreddit):
     """
 
     @cachedproperty
-    def mod(self) -> models.reddit.user_subreddit.UserSubredditModeration:
+    def mod(self) -> UserSubredditModeration:
         """Provide an instance of :class:`.UserSubredditModeration`.
 
         For example, to update the authenticated user's display name:
@@ -197,4 +196,7 @@ class UserSubredditModeration(SubredditModeration):
             current_settings[new] = current_settings.pop(old)
 
         current_settings.update(settings)
-        return UserSubreddit._create_or_update(_reddit=self.subreddit._reddit, **current_settings)
+        return UserSubreddit._create_or_update(  # pyright: ignore[reportReturnType]  # _create_or_update returns None but base override is annotated to return a dict
+            _reddit=self.subreddit._reddit,
+            **current_settings,  # pyright: ignore[reportArgumentType]  # heterogeneous str | int | bool values are routed through _create_or_update's **other_settings
+        )

--- a/praw/models/reddit/widgets.py
+++ b/praw/models/reddit/widgets.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 from json import JSONEncoder, dumps
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import TYPE_CHECKING, Any
 
 from praw.const import API_PATH
-from praw.models.base import PRAWBase
+from praw.models.base import DynamicAttributes, PRAWBase
 from praw.models.list.base import BaseList
 from praw.util.cache import cachedproperty
 
@@ -14,10 +14,8 @@ if TYPE_CHECKING:
     import praw
     from praw import models
 
-WidgetType: TypeVar = TypeVar("WidgetType", bound="Widget")
 
-
-class Button(PRAWBase):
+class Button(DynamicAttributes, PRAWBase):
     """Class to represent a single button inside a :class:`.ButtonWidget`.
 
     .. include:: ../../typical_attributes.rst
@@ -44,7 +42,7 @@ class Button(PRAWBase):
     """
 
 
-class CalendarConfiguration(PRAWBase):
+class CalendarConfiguration(DynamicAttributes, PRAWBase):
     """Class to represent the configuration of a :class:`.Calendar`.
 
     .. include:: ../../typical_attributes.rst
@@ -63,7 +61,7 @@ class CalendarConfiguration(PRAWBase):
     """
 
 
-class Hover(PRAWBase):
+class Hover(DynamicAttributes, PRAWBase):
     """Class to represent the hover data for a :class:`.ButtonWidget`.
 
     These values will take effect when the button is hovered over (the user moves their
@@ -89,7 +87,7 @@ class Hover(PRAWBase):
     """
 
 
-class Image(PRAWBase):
+class Image(DynamicAttributes, PRAWBase):
     """Class to represent an image that's part of a :class:`.ImageWidget`.
 
     .. include:: ../../typical_attributes.rst
@@ -106,7 +104,7 @@ class Image(PRAWBase):
     """
 
 
-class ImageData(PRAWBase):
+class ImageData(DynamicAttributes, PRAWBase):
     """Class for image data that's part of a :class:`.CustomWidget`.
 
     .. include:: ../../typical_attributes.rst
@@ -123,7 +121,7 @@ class ImageData(PRAWBase):
     """
 
 
-class MenuLink(PRAWBase):
+class MenuLink(DynamicAttributes, PRAWBase):
     """Class to represent a single link inside a :class:`.Menu` or :class:`.Submenu`.
 
     .. include:: ../../typical_attributes.rst
@@ -138,7 +136,7 @@ class MenuLink(PRAWBase):
     """
 
 
-class Styles(PRAWBase):
+class Styles(DynamicAttributes, PRAWBase):
     """Class to represent the style information of a widget.
 
     .. include:: ../../typical_attributes.rst
@@ -155,7 +153,7 @@ class Styles(PRAWBase):
     """
 
 
-class Submenu(BaseList):
+class Submenu(DynamicAttributes, BaseList):
     r"""Class to represent a submenu of links inside a :class:`.Menu`.
 
     .. include:: ../../typical_attributes.rst
@@ -264,7 +262,9 @@ class SubredditWidgets(PRAWBase):
     def items(self) -> dict[str, models.Widget]:
         """Get this :class:`.Subreddit`'s widgets as a dict from ID to widget."""
         items = {}
-        for item_name, data in self._raw_items.items():
+        # ``_raw_items`` is None until _fetch runs; iterating None raises AttributeError,
+        # which RedditBase.__getattr__ traps to trigger the lazy fetch and retry.
+        for item_name, data in self._raw_items.items():  # pyright: ignore[reportOptionalMemberAccess]
             data["subreddit"] = self.subreddit
             items[item_name] = self._reddit._objector.objectify(data=data)
         return items
@@ -311,7 +311,7 @@ class SubredditWidgets(PRAWBase):
         :param subreddit: The :class:`.Subreddit` the widgets belong to.
 
         """
-        self._raw_items = None
+        self._raw_items: dict[str, Any] | None = None
         self._fetched = False
         self.subreddit = subreddit
         self.progressive_images = False
@@ -361,7 +361,7 @@ class SubredditWidgets(PRAWBase):
         self._fetch()
 
 
-class Widget(PRAWBase):
+class Widget(DynamicAttributes, PRAWBase):
     """Base class to represent a :class:`.Widget`."""
 
     @cachedproperty
@@ -397,6 +397,8 @@ class Widget(PRAWBase):
 
 class WidgetEncoder(JSONEncoder):
     """Class to encode widget-related objects."""
+
+    _subreddit_class: type[models.Subreddit]
 
     def default(self, o: Any) -> Any:
         """Serialize ``PRAWBase`` objects."""
@@ -927,9 +929,11 @@ class ModeratorsWidget(Widget, BaseList):
 
     def __init__(self, reddit: praw.Reddit, _data: dict[str, Any]) -> None:
         """Initialize a :class:`.ModeratorsWidget` instance."""
-        if self.CHILD_ATTRIBUTE not in _data:
+        child_attribute = self.CHILD_ATTRIBUTE
+        assert child_attribute is not None
+        if child_attribute not in _data:
             # .mod.update() sometimes returns payload without "mods" field
-            _data[self.CHILD_ATTRIBUTE] = []
+            _data[child_attribute] = []
         super().__init__(reddit, _data=_data)
 
 
@@ -1043,9 +1047,11 @@ class RulesWidget(Widget, BaseList):
 
     def __init__(self, reddit: praw.Reddit, _data: dict[str, Any]) -> None:
         """Initialize a :class:`.RulesWidget` instance."""
-        if self.CHILD_ATTRIBUTE not in _data:
+        child_attribute = self.CHILD_ATTRIBUTE
+        assert child_attribute is not None
+        if child_attribute not in _data:
             # .mod.update() sometimes returns payload without "data" field
-            _data[self.CHILD_ATTRIBUTE] = []
+            _data[child_attribute] = []
         super().__init__(reddit, _data=_data)
 
 
@@ -1200,7 +1206,9 @@ class SubredditWidgetsModeration:
         self._subreddit = subreddit
         self._reddit = reddit
 
-    def _create_widget(self, payload: dict[str, Any]) -> WidgetType:
+    # Returns Any: the concrete widget type is determined at runtime by objectifying the
+    # response. Each public ``add_*`` wrapper carries the precise return annotation.
+    def _create_widget(self, payload: dict[str, Any]) -> Any:
         path = API_PATH["widget_create"].format(subreddit=self._subreddit)
         widget = self._reddit.post(path, data={"json": dumps(payload, cls=WidgetEncoder)})
         widget.subreddit = self._subreddit

--- a/praw/models/reddit/wikipage.py
+++ b/praw/models/reddit/wikipage.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from praw.const import API_PATH
 from praw.models.listing.generator import ListingGenerator
@@ -174,7 +174,8 @@ class WikiPage(RedditBase):
         subreddit: models.Subreddit,
         url: str,
     ) -> Iterator[dict[str, Redditor | WikiPage | str | int | bool | None]]:
-        for revision in ListingGenerator(subreddit._reddit, url, **generator_kwargs):
+        for item in ListingGenerator(subreddit._reddit, url, **generator_kwargs):
+            revision = cast("dict[str, Any]", item)
             if revision["author"] is not None:
                 revision["author"] = Redditor(subreddit._reddit, _data=revision["author"]["data"])
             revision["page"] = WikiPage(subreddit._reddit, subreddit, revision["page"], revision["id"])
@@ -228,7 +229,7 @@ class WikiPage(RedditBase):
         self.__dict__.update(data)
         super()._fetch()
 
-    def _fetch_info(self) -> tuple[str, dict[str, str], dict[str, str] | None]:
+    def _fetch_info(self) -> tuple[str, dict[str, str | models.Subreddit], dict[str, str] | None]:
         return (
             "wiki_page",
             {"subreddit": self.subreddit, "page": self.name},
@@ -288,7 +289,9 @@ class WikiPage(RedditBase):
         """
         return WikiPage(self.subreddit._reddit, self.subreddit, self.name, revision)
 
-    def revisions(self, **generator_kwargs: str | int | dict[str, str]) -> Iterator[WikiPage]:
+    def revisions(
+        self, **generator_kwargs: Any
+    ) -> Iterator[dict[str, models.Redditor | WikiPage | str | int | bool | None]]:
         """Return a :class:`.ListingGenerator` for page revisions.
 
         Additional keyword arguments are passed in the initialization of

--- a/praw/models/redditors.py
+++ b/praw/models/redditors.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from itertools import islice
 from types import SimpleNamespace
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 import prawcore
 
@@ -26,7 +26,7 @@ class PartialRedditor(SimpleNamespace):
 class Redditors(PRAWBase):
     """Redditors is a Listing class that provides various :class:`.Redditor` lists."""
 
-    def new(self, **generator_kwargs: str | int | dict[str, str]) -> Iterator[models.Subreddit]:
+    def new(self, **generator_kwargs: Any) -> Iterator[models.Subreddit]:
         """Return a :class:`.ListingGenerator` for new :class:`.Redditors`.
 
         :returns: :class:`.Redditor` profiles, which are a type of :class:`.Subreddit`.
@@ -55,7 +55,7 @@ class Redditors(PRAWBase):
             if not chunk:
                 break
 
-            params = {"ids": ",".join(chunk)}
+            params: dict[str, str | int] = {"ids": ",".join(chunk)}
             try:
                 results = self._reddit.get(API_PATH["user_by_fullname"], params=params)
             except prawcore.exceptions.NotFound:
@@ -65,7 +65,7 @@ class Redditors(PRAWBase):
             for fullname, user_data in results.items():
                 yield PartialRedditor(fullname=fullname, **user_data)
 
-    def popular(self, **generator_kwargs: str | int | dict[str, str]) -> Iterator[models.Subreddit]:
+    def popular(self, **generator_kwargs: Any) -> Iterator[models.Subreddit]:
         """Return a :class:`.ListingGenerator` for popular :class:`.Redditors`.
 
         :returns: :class:`.Redditor` profiles, which are a type of :class:`.Subreddit`.
@@ -76,7 +76,7 @@ class Redditors(PRAWBase):
         """
         return ListingGenerator(self._reddit, API_PATH["users_popular"], **generator_kwargs)
 
-    def search(self, query: str, **generator_kwargs: str | int | dict[str, str]) -> Iterator[models.Subreddit]:
+    def search(self, query: str, **generator_kwargs: Any) -> Iterator[models.Subreddit]:
         r"""Return a :class:`.ListingGenerator` of Redditors for ``query``.
 
         :param query: The query string to filter Redditors by.
@@ -90,7 +90,7 @@ class Redditors(PRAWBase):
         self._safely_add_arguments(arguments=generator_kwargs, key="params", q=query)
         return ListingGenerator(self._reddit, API_PATH["users_search"], **generator_kwargs)
 
-    def stream(self, **stream_options: str | int | dict[str, str]) -> Iterator[models.Subreddit]:
+    def stream(self, **stream_options: Any) -> Iterator[models.Subreddit]:
         """Yield new Redditors as they are created.
 
         Redditors are yielded oldest first. Up to 100 historical Redditors will

--- a/praw/models/stylesheet.py
+++ b/praw/models/stylesheet.py
@@ -1,9 +1,9 @@
 """Provide the Stylesheet class."""
 
-from praw.models.base import PRAWBase
+from praw.models.base import DynamicAttributes, PRAWBase
 
 
-class Stylesheet(PRAWBase):
+class Stylesheet(DynamicAttributes, PRAWBase):
     """Represent a stylesheet.
 
     .. include:: ../../typical_attributes.rst

--- a/praw/models/subreddits.py
+++ b/praw/models/subreddits.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from praw.const import API_PATH
 from praw.models import Subreddit
@@ -23,7 +23,7 @@ class Subreddits(PRAWBase):
     def _to_list(subreddit_list: list[str | models.Subreddit]) -> str:
         return ",".join([str(x) for x in subreddit_list])
 
-    def default(self, **generator_kwargs: str | int | dict[str, str]) -> Iterator[models.Subreddit]:
+    def default(self, **generator_kwargs: Any) -> Iterator[models.Subreddit]:
         """Return a :class:`.ListingGenerator` for default subreddits.
 
         Additional keyword arguments are passed in the initialization of
@@ -32,7 +32,7 @@ class Subreddits(PRAWBase):
         """
         return ListingGenerator(self._reddit, API_PATH["subreddits_default"], **generator_kwargs)
 
-    def new(self, **generator_kwargs: str | int | dict[str, str]) -> Iterator[models.Subreddit]:
+    def new(self, **generator_kwargs: Any) -> Iterator[models.Subreddit]:
         """Return a :class:`.ListingGenerator` for new subreddits.
 
         Additional keyword arguments are passed in the initialization of
@@ -41,7 +41,7 @@ class Subreddits(PRAWBase):
         """
         return ListingGenerator(self._reddit, API_PATH["subreddits_new"], **generator_kwargs)
 
-    def popular(self, **generator_kwargs: str | int | dict[str, str]) -> Iterator[models.Subreddit]:
+    def popular(self, **generator_kwargs: Any) -> Iterator[models.Subreddit]:
         """Return a :class:`.ListingGenerator` for popular subreddits.
 
         Additional keyword arguments are passed in the initialization of
@@ -50,7 +50,7 @@ class Subreddits(PRAWBase):
         """
         return ListingGenerator(self._reddit, API_PATH["subreddits_popular"], **generator_kwargs)
 
-    def premium(self, **generator_kwargs: str | int | dict[str, str]) -> Iterator[models.Subreddit]:
+    def premium(self, **generator_kwargs: Any) -> Iterator[models.Subreddit]:
         """Return a :class:`.ListingGenerator` for premium subreddits.
 
         Additional keyword arguments are passed in the initialization of
@@ -79,11 +79,11 @@ class Subreddits(PRAWBase):
             msg = "omit_subreddits must be a list or None"
             raise TypeError(msg)
 
-        params = {"omit": self._to_list(omit_subreddits or [])}
+        params: dict[str, str | int] = {"omit": self._to_list(omit_subreddits or [])}
         url = API_PATH["sub_recommended"].format(subreddits=self._to_list(subreddits))
         return [Subreddit(self._reddit, sub["sr_name"]) for sub in self._reddit.get(url, params=params)]
 
-    def search(self, query: str, **generator_kwargs: str | int | dict[str, str]) -> Iterator[models.Subreddit]:
+    def search(self, query: str, **generator_kwargs: Any) -> Iterator[models.Subreddit]:
         """Return a :class:`.ListingGenerator` of subreddits matching ``query``.
 
         Subreddits are searched by both their title and description.
@@ -121,7 +121,7 @@ class Subreddits(PRAWBase):
         )
         return [self._reddit.subreddit(x) for x in result["names"]]
 
-    def stream(self, **stream_options: str | int | dict[str, str]) -> Iterator[models.Subreddit]:
+    def stream(self, **stream_options: Any) -> Iterator[models.Subreddit]:
         """Yield new subreddits as they are created.
 
         Subreddits are yielded oldest first. Up to 100 historical subreddits will

--- a/praw/models/trophy.py
+++ b/praw/models/trophy.py
@@ -4,13 +4,13 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from praw.models.base import PRAWBase
+from praw.models.base import DynamicAttributes, PRAWBase
 
 if TYPE_CHECKING:
     import praw
 
 
-class Trophy(PRAWBase):
+class Trophy(DynamicAttributes, PRAWBase):
     """Represent a trophy.
 
     End users should not instantiate this class directly. :meth:`.Redditor.trophies` can
@@ -30,6 +30,8 @@ class Trophy(PRAWBase):
     =============== ===================================================
 
     """
+
+    name: str
 
     def __eq__(self, other: Trophy | Any) -> bool:
         """Check if two Trophies are equal."""

--- a/praw/models/user.py
+++ b/praw/models/user.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from prawcore import Conflict
 
@@ -67,7 +67,7 @@ class User(PRAWBase):
         r"""Return a :class:`.RedditorList` of blocked :class:`.Redditor`\ s."""
         return self._reddit.get(API_PATH["blocked"])
 
-    def contributor_subreddits(self, **generator_kwargs: str | int | dict[str, str]) -> Iterator[models.Subreddit]:
+    def contributor_subreddits(self, **generator_kwargs: Any) -> Iterator[models.Subreddit]:
         r"""Return a :class:`.ListingGenerator` of contributor :class:`.Subreddit`\ s.
 
         These are subreddits in which the user is an approved user.
@@ -144,7 +144,7 @@ class User(PRAWBase):
             self._me = Redditor(self._reddit, _data=user_data)
         return self._me
 
-    def moderator_subreddits(self, **generator_kwargs: str | int | dict[str, str]) -> Iterator[models.Subreddit]:
+    def moderator_subreddits(self, **generator_kwargs: Any) -> Iterator[models.Subreddit]:
         """Return a :class:`.ListingGenerator` subreddits that the user moderates.
 
         Additional keyword arguments are passed in the initialization of
@@ -168,7 +168,7 @@ class User(PRAWBase):
         r"""Return a list of :class:`.Multireddit`\ s belonging to the user."""
         return self._reddit.get(API_PATH["my_multireddits"])
 
-    def pin(self, submission: models.Submission, *, num: int | None = None, state: bool = True) -> models.Submission:
+    def pin(self, submission: models.Submission, *, num: int | None = None, state: bool = True) -> models.Submission | None:
         """Set the pin state of a submission on the authenticated user's profile.
 
         :param submission: An instance of :class:`.Submission` that will be
@@ -224,7 +224,7 @@ class User(PRAWBase):
         except Conflict:
             pass
 
-    def subreddits(self, **generator_kwargs: str | int | dict[str, str]) -> Iterator[models.Subreddit]:
+    def subreddits(self, **generator_kwargs: Any) -> Iterator[models.Subreddit]:
         r"""Return a :class:`.ListingGenerator` of :class:`.Subreddit`\ s the user is subscribed to.
 
         Additional keyword arguments are passed in the initialization of

--- a/praw/objector.py
+++ b/praw/objector.py
@@ -18,13 +18,13 @@ class Objector:
     """The objector builds :class:`.RedditBase` objects."""
 
     @classmethod
-    def check_error(cls, data: list[Any] | dict[str, dict[str, str]]) -> None:
+    def check_error(cls, data: list[Any] | dict[str, Any]) -> None:
         """Raise an error if the argument resolves to an error object."""
         if error := cls.parse_error(data):
             raise error
 
     @classmethod
-    def parse_error(cls, data: list[Any] | dict[str, dict[str, str]]) -> RedditAPIException | None:
+    def parse_error(cls, data: list[Any] | dict[str, Any]) -> RedditAPIException | None:
         """Convert JSON response into an error object.
 
         :param data: The dict to be converted.
@@ -56,12 +56,12 @@ class Objector:
         self.parsers = {} if parsers is None else parsers
         self._reddit = reddit
 
-    def _objectify_dict(self, *, data: dict[str, Any]) -> RedditBase:
+    def _objectify_dict(self, *, data: dict[str, Any]) -> RedditBase | dict[str, Any]:
         """Create :class:`.RedditBase` objects from dicts.
 
         :param data: The structured data, assumed to be a dict.
 
-        :returns: An instance of :class:`.RedditBase`.
+        :returns: An instance of :class:`.RedditBase`, or the ``data`` dict.
 
         """
         if {"messages", "modActions"}.issubset(data) and {

--- a/praw/reddit.py
+++ b/praw/reddit.py
@@ -3,13 +3,14 @@
 from __future__ import annotations
 
 import asyncio
+import builtins
 import configparser
 import os
 import re
 import time
 from itertools import islice
 from logging import getLogger
-from typing import IO, TYPE_CHECKING, Any
+from typing import IO, TYPE_CHECKING, Any, cast
 from urllib.parse import urlparse
 
 from prawcore import (
@@ -51,9 +52,11 @@ if TYPE_CHECKING:
     else:
         from typing_extensions import Self
 
-    from collections.abc import Generator, Iterable
+    from collections.abc import Generator, Iterable, Iterator
 
     import prawcore
+
+    from praw.exceptions import RedditErrorItem
 
 
 Comment = models.Comment
@@ -396,13 +399,10 @@ class Reddit:
 
     def _check_for_async(self) -> None:
         if self.config.check_for_async:  # pragma: no cover
-            try:
-                # noinspection PyUnresolvedReferences
-                shell = get_ipython().__class__.__name__
-                if shell == "ZMQInteractiveShell":
-                    return
-            except NameError:
-                pass
+            # IPython injects get_ipython into builtins; it is absent outside IPython.
+            get_ipython = getattr(builtins, "get_ipython", None)
+            if get_ipython is not None and get_ipython().__class__.__name__ == "ZMQInteractiveShell":
+                return
             in_async = False
             try:
                 asyncio.get_running_loop()
@@ -420,15 +420,15 @@ class Reddit:
                 )
 
     def _check_for_update(self) -> None:
-        if UPDATE_CHECKER_MISSING:
+        if UPDATE_CHECKER_MISSING or update_check is None:
             return
         if not Reddit.update_checked and self.config.check_for_updates:
-            update_check(package_name=__package__, package_version=__version__)
+            update_check(package_name=__package__ or "praw", package_version=__version__)
             Reddit.update_checked = True
 
     def _handle_rate_limit(self, exception: RedditAPIException) -> int | float | None:
         for item in exception.items:
-            if item.error_type == "RATELIMIT":
+            if item.error_type == "RATELIMIT" and item.message is not None:
                 amount_search = self._ratelimit_regex.search(item.message)
                 if not amount_search:
                     break
@@ -444,11 +444,11 @@ class Reddit:
     def _objectify_request(
         self,
         *,
-        data: dict[str, str | Any] | bytes | IO | str | None = None,
+        data: dict[str, Any] | bytes | IO | str | None = None,
         files: dict[str, IO] | None = None,
         json: dict[Any, Any] | list[Any] | None = None,
         method: str = "",
-        params: str | dict[str, str] | None = None,
+        params: dict[str, str | int] | None = None,
         path: str = "",
     ) -> Any:
         """Run a request through the ``Objector``.
@@ -537,7 +537,7 @@ class Reddit:
         self,
         *,
         requestor_class: type[prawcore.requestor.Requestor] | None = None,
-        requestor_kwargs: Any | None = None,
+        requestor_kwargs: dict[str, Any] | None = None,
     ) -> None:
         requestor_class = requestor_class or Requestor
         requestor_kwargs = requestor_kwargs or {}
@@ -555,6 +555,8 @@ class Reddit:
             self._prepare_untrusted_prawcore(requestor)
 
     def _prepare_trusted_prawcore(self, requestor: prawcore.requestor.Requestor) -> None:
+        # Only reached when client_secret is set (see _prepare_prawcore).
+        assert self.config.client_secret is not None
         authenticator = TrustedAuthenticator(
             requestor,
             self.config.client_id,
@@ -585,7 +587,10 @@ class Reddit:
             try:
                 self.get(url)
             except Redirect as e:
-                return e.response.next.url
+                next_request = e.response.next
+                assert next_request is not None
+                assert next_request.url is not None
+                return next_request.url
         return url
 
     def comment(self, id: str | None = None, *, url: str | None = None) -> models.Comment:
@@ -608,9 +613,9 @@ class Reddit:
         self,
         path: str,
         *,
-        data: dict[str, str | Any] | bytes | IO | str | None = None,
+        data: dict[str, Any] | bytes | IO | str | None = None,
         json: dict[Any, Any] | list[Any] | None = None,
-        params: str | dict[str, str] | None = None,
+        params: dict[str, str | int] | None = None,
     ) -> Any:
         """Return parsed objects returned from a DELETE request to ``path``.
 
@@ -637,7 +642,7 @@ class Reddit:
         self,
         path: str,
         *,
-        params: str | dict[str, str | int] | None = None,
+        params: dict[str, str | int] | None = None,
     ) -> Any:
         """Return parsed objects returned from a GET request to ``path``.
 
@@ -699,42 +704,47 @@ class Reddit:
 
             api_parameter_name = "id" if is_using_fullnames else "sr_name"
 
-            def generator(
+            def name_generator(
                 names: Iterable[str | models.Subreddit],
             ) -> Generator[
                 models.Subreddit | models.Comment | models.Submission,
                 None,
                 None,
             ]:
-                iterable = iter(names) if is_using_fullnames else iter([str(item) for item in names])
+                iterable: Iterator[str] = (
+                    iter(str(item) for item in names)
+                    if is_using_fullnames
+                    else iter([str(item) for item in names])
+                )
                 while True:
                     chunk = list(islice(iterable, 100))
                     if not chunk:
                         break
-                    params = {api_parameter_name: ",".join(chunk)}
+                    params: dict[str, str | int] = {api_parameter_name: ",".join(chunk)}
                     yield from self.get(API_PATH["info"], params=params)
 
-            return generator(ids_or_names)
+            return name_generator(ids_or_names)
 
-        def generator(
+        def url_generator(
             _url: str,
         ) -> Generator[
             models.Subreddit | models.Comment | models.Submission,
             None,
             None,
         ]:
-            params = {"url": _url}
+            params: dict[str, str | int] = {"url": _url}
             yield from self.get(API_PATH["info"], params=params)
 
-        return generator(url)
+        assert url is not None
+        return url_generator(url)
 
     def patch(
         self,
         path: str,
         *,
-        data: dict[str, str | Any] | bytes | IO | str | None = None,
+        data: dict[str, Any] | bytes | IO | str | None = None,
         json: dict[Any, Any] | list[Any] | None = None,
-        params: str | dict[str, str] | None = None,
+        params: dict[str, str | int] | None = None,
     ) -> Any:
         """Return parsed objects returned from a PATCH request to ``path``.
 
@@ -753,10 +763,10 @@ class Reddit:
         self,
         path: str,
         *,
-        data: dict[str, str | Any] | bytes | IO | str | None = None,
+        data: dict[str, Any] | bytes | IO | str | None = None,
         files: dict[str, IO] | None = None,
         json: dict[Any, Any] | list[Any] | None = None,
-        params: str | dict[str, str] | None = None,
+        params: dict[str, str | int] | None = None,
     ) -> Any:
         """Return parsed objects returned from a POST request to ``path``.
 
@@ -775,7 +785,7 @@ class Reddit:
             data = data or {}
 
         attempts = 3
-        last_exception = None
+        last_exception: RedditAPIException | None = None
         while attempts > 0:
             attempts -= 1
             try:
@@ -795,13 +805,14 @@ class Reddit:
                 second_string = "second" if seconds == 1 else "seconds"
                 logger.debug("Rate limit hit, sleeping for %d %s", seconds, second_string)
                 time.sleep(seconds)
+        assert last_exception is not None
         raise last_exception
 
     def put(
         self,
         path: str,
         *,
-        data: dict[str, str | Any] | bytes | IO | str | None = None,
+        data: dict[str, Any] | bytes | IO | str | None = None,
         json: dict[Any, Any] | list[Any] | None = None,
     ) -> Any:
         """Return parsed objects returned from a PUT request to ``path``.
@@ -830,11 +841,11 @@ class Reddit:
     def request(
         self,
         *,
-        data: dict[str, str | Any] | bytes | IO | str | None = None,
+        data: dict[str, Any] | bytes | IO | str | None = None,
         files: dict[str, IO] | None = None,
         json: dict[Any, Any] | list[Any] | None = None,
         method: str,
-        params: str | dict[str, str | int] | None = None,
+        params: dict[str, str | int] | None = None,
         path: str,
     ) -> Any:
         """Return the parsed JSON data returned from a request to URL.
@@ -857,6 +868,7 @@ class Reddit:
         if data and json:
             msg = "At most one of 'data' or 'json' is supported."
             raise ClientException(msg)
+        assert self._core is not None
         try:
             return self._core.request(
                 data=data,
@@ -867,22 +879,28 @@ class Reddit:
                 path=path,
             )
         except BadRequest as exception:
+            error_data: dict[str, Any]
             try:
-                data = exception.response.json()
+                error_data = exception.response.json()
             except ValueError:
                 if exception.response.text:
-                    data = {"reason": exception.response.text}
+                    error_data = {"reason": exception.response.text}
                 else:
                     raise exception from None
-            if set(data) == {"error", "message"}:
+            if set(error_data) == {"error", "message"}:
                 raise
-            explanation = data.get("explanation")
-            if "fields" in data:
-                assert len(data["fields"]) == 1
-                field = data["fields"][0]
+            explanation = error_data.get("explanation")
+            if "fields" in error_data:
+                assert len(error_data["fields"]) == 1
+                field = error_data["fields"][0]
             else:
                 field = None
-            raise RedditAPIException([data["reason"], explanation, field]) from exception
+            raise RedditAPIException(
+                cast(
+                    "list[RedditErrorItem | list[str] | str]",
+                    [error_data["reason"], explanation, field],
+                )
+            ) from exception
 
     def submission(self, id: str | None = None, *, url: str | None = None) -> models.Submission:
         """Return a lazy instance of :class:`.Submission`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,10 @@ test = [
   "requests >=2.20.1, <3",
   "vcrpy >=7.0.0"
 ]
+type = [
+  "pyright",
+  {include-group = "test"}
+]
 
 [project]
 authors = [{name = "Bryce Boe", email = "bbzbryce@gmail.com"}]
@@ -42,11 +46,12 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
-  "Topic :: Utilities"
+  "Topic :: Utilities",
+  "Typing :: Typed"
 ]
 dependencies = [
   "defusedxml ==0.7.1",
-  "prawcore>=3.1.0,<4",
+  "prawcore>=3.2.0,<4",
   "typing-extensions; python_version <= '3.10'",
   "update_checker >=1.0, <2.0",
   "websocket-client >=0.54.0, <2"
@@ -82,6 +87,12 @@ extend_exclude = ['./docs/examples/']
 
 [tool.hatch.version]
 path = "praw/const.py"
+
+[tool.pyright]
+include = ["praw", "tests/typing"]
+pythonVersion = "3.10"
+reportUnnecessaryTypeIgnoreComment = "error"
+typeCheckingMode = "standard"
 
 [tool.ruff]
 include = [
@@ -169,7 +180,7 @@ ban-relative-imports = "all"
 "tests/*.py" = ["SLF001"]
 
 [tool.tox]
-envlist = ["py310", "py311", "py312", "py313", "py314", "docs", "pre-commit"]
+envlist = ["py310", "py311", "py312", "py313", "py314", "docs", "pre-commit", "type"]
 minversion = "4.22"
 
 [tool.tox.env.docs]
@@ -187,6 +198,12 @@ commands = [
 dependency_groups = ["lint"]
 description = "run pre-commit on code base"
 pass_env = ["SKIP"]
+runner = "uv-venv-lock-runner"
+
+[tool.tox.env.type]
+commands = [["pyright"]]
+dependency_groups = ["type"]
+description = "run type check on code base"
 runner = "uv-venv-lock-runner"
 
 [tool.tox.env_run_base]

--- a/tests/integration/models/reddit/test_subreddit.py
+++ b/tests/integration/models/reddit/test_subreddit.py
@@ -1641,7 +1641,7 @@ class TestSubreddit(IntegrationTest):
             "<HostId>iYEVOuRfbLiKwMgHt2ewqQRIm0NWL79uiC2rPLj9P0PwW55MhjY2/O8d9JdKTf1iwzLjwWMnGQ=</HostId>"
             "</Error>"
         )
-        _request = reddit._core._requestor._http.request
+        _request = reddit._core.requestor._http.request
 
         def patch_request(method, url, *args, **kwargs):
             """Patch requests to return mock data on specific url."""
@@ -1653,14 +1653,14 @@ class TestSubreddit(IntegrationTest):
                 return response
             return _request(method, url, *args, **kwargs)
 
-        reddit._core._requestor._http.request = patch_request
+        reddit._core.requestor._http.request = patch_request
         fake_png = PNG_HEADER + b"\x1a" * 10  # Normally 1024 ** 2 * 20 (20 MB)
         with open(tmp_path.joinpath("fake_img.png"), "wb") as tempfile:
             tempfile.write(fake_png)
         subreddit = reddit.subreddit("test")
         with pytest.raises(TooLargeMediaException):
             subreddit.submit("test", image=PostMedia(tempfile.name))
-        reddit._core._requestor._http.request = _request
+        reddit._core.requestor._http.request = _request
 
     @mock.patch(
         "websocket.create_connection",

--- a/tests/typing/dynamic_attributes.py
+++ b/tests/typing/dynamic_attributes.py
@@ -1,0 +1,52 @@
+"""Type-checking regression guard for dynamic Reddit attribute access.
+
+PRAW populates many objects from Reddit response data rather than declaring their
+attributes, because Reddit adds and removes fields without notice. Accessing such an
+attribute must therefore resolve to ``Any`` for a downstream type checker rather than
+raising an attribute error.
+
+Shipping a ``py.typed`` marker was previously reverted for exactly this reason (see
+https://github.com/praw-dev/praw/pull/1944): once PRAW advertised itself as typed, every
+dynamic attribute access lit up as an error in downstream projects. :class:`.RedditBase`
+already returns ``Any`` from ``__getattr__``; this module guards the ``PRAWBase`` data
+classes that do not inherit it.
+
+This module is analyzed by pyright (it is added to ``tool.pyright``'s ``include``) and
+is never executed, so the bodies below are type-checked but the functions are never
+called.
+
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from praw.models import ModNote, Stylesheet, Trophy
+    from praw.models.reddit.poll import PollData, PollOption
+    from praw.models.reddit.widgets import Button, Image, Submenu, TextArea
+
+
+def _dynamic_attributes_resolve_to_any(
+    button: Button,
+    image: Image,
+    mod_note: ModNote,
+    poll_data: PollData,
+    poll_option: PollOption,
+    stylesheet: Stylesheet,
+    submenu: Submenu,
+    text_area: TextArea,
+    trophy: Trophy,
+) -> list[object]:
+    """Access undeclared, Reddit-provided attributes; each must type as ``Any``."""
+    return [
+        button.color,
+        image.url,
+        mod_note.label,
+        poll_data.total_vote_count,
+        poll_option.vote_count,
+        stylesheet.images,
+        submenu.text,
+        text_area.text,
+        trophy.icon_70,
+    ]

--- a/tests/unit/models/reddit/mixins/test_fullname.py
+++ b/tests/unit/models/reddit/mixins/test_fullname.py
@@ -1,0 +1,13 @@
+from praw.models.reddit.mixins.fullname import FullnameMixin
+
+from .... import UnitTest
+
+
+class TestFullnameMixin(UnitTest):
+    def test_kind__defaults_to_none(self):
+        class _Dummy(FullnameMixin):
+            id = "abc123"
+
+        dummy = _Dummy()
+        assert dummy._kind is None
+        assert dummy.fullname == "None_abc123"

--- a/tests/unit/models/test_mod_action.py
+++ b/tests/unit/models/test_mod_action.py
@@ -1,0 +1,11 @@
+from praw.models import ModAction
+
+from .. import UnitTest
+
+
+class TestModAction(UnitTest):
+    def test_mod__already_a_redditor(self, reddit):
+        action = ModAction(reddit, _data={"id": "abc"})
+        redditor = reddit.redditor("spez")
+        action.mod = redditor
+        assert action.mod is redditor

--- a/tests/unit/models/test_trophy.py
+++ b/tests/unit/models/test_trophy.py
@@ -8,6 +8,11 @@ from .. import UnitTest
 
 
 class TestTrophy(UnitTest):
+    def test_dynamic_attribute__missing_raises(self):
+        trophy = Trophy(None, {"name": "a"})
+        with pytest.raises(AttributeError, match="object has no attribute 'does_not_exist'"):
+            _ = trophy.does_not_exist
+
     def test_equality(self):
         trophy1 = Trophy(None, {"name": "a"})
         trophy2 = Trophy(None, {"name": "A"})

--- a/tests/unit/models/test_user.py
+++ b/tests/unit/models/test_user.py
@@ -14,7 +14,7 @@ class TestUser(UnitTest):
             client_secret="dummy",
             user_agent="dummy",
         )
-        reddit._core._requestor._http = None
+        reddit._core.requestor._http = None
 
         assert reddit.read_only
         user = User(reddit)

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -50,6 +50,9 @@ class TestConfig:
             config = Config("DEFAULT", check_for_updates=value)
             assert config.check_for_updates is True
 
+    def test_config_boolean__not_set(self):
+        assert Config._config_boolean(item=Config.CONFIG_NOT_SET) is False
+
     def test_custom__extra_values_set(self):
         config = Config("DEFAULT", user1="foo", user2="bar")
         assert config.custom == {"user1": "foo", "user2": "bar"}

--- a/tests/unit/test_reddit.py
+++ b/tests/unit/test_reddit.py
@@ -472,8 +472,8 @@ class TestRedditCustomRequestor(UnitTest):
             user_agent="dummy",
             username="dummy",
         )
-        assert isinstance(_reddit._core._requestor, CustomRequestor)
-        assert not isinstance(reddit._core._requestor, CustomRequestor)
+        assert isinstance(_reddit._core.requestor, CustomRequestor)
+        assert not isinstance(reddit._core.requestor, CustomRequestor)
 
         _reddit = Reddit(
             requestor_class=CustomRequestor,
@@ -481,8 +481,8 @@ class TestRedditCustomRequestor(UnitTest):
             client_secret="dummy",
             user_agent="dummy",
         )
-        assert isinstance(_reddit._core._requestor, CustomRequestor)
-        assert not isinstance(reddit._core._requestor, CustomRequestor)
+        assert isinstance(_reddit._core.requestor, CustomRequestor)
+        assert not isinstance(reddit._core.requestor, CustomRequestor)
 
     def test_requestor_kwargs(self):
         session = mock.Mock(headers={})
@@ -493,4 +493,4 @@ class TestRedditCustomRequestor(UnitTest):
             user_agent="dummy",
         )
 
-        assert reddit._core._requestor._http is session
+        assert reddit._core.requestor._http is session

--- a/uv.lock
+++ b/uv.lock
@@ -610,11 +610,18 @@ test = [
     { name = "requests" },
     { name = "vcrpy" },
 ]
+type = [
+    { name = "coverage" },
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "requests" },
+    { name = "vcrpy" },
+]
 
 [package.metadata]
 requires-dist = [
     { name = "defusedxml", specifier = "==0.7.1" },
-    { name = "prawcore", specifier = ">=3.1.0,<4" },
+    { name = "prawcore", specifier = ">=3.2.0,<4" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
     { name = "update-checker", specifier = ">=1.0,<2.0" },
     { name = "websocket-client", specifier = ">=0.54.0,<2" },
@@ -652,17 +659,24 @@ test = [
     { name = "requests", specifier = ">=2.20.1,<3" },
     { name = "vcrpy", specifier = ">=7.0.0" },
 ]
+type = [
+    { name = "coverage", specifier = ">=7.6.10" },
+    { name = "pyright" },
+    { name = "pytest", specifier = ">=2.7.3" },
+    { name = "requests", specifier = ">=2.20.1,<3" },
+    { name = "vcrpy", specifier = ">=7.0.0" },
+]
 
 [[package]]
 name = "prawcore"
-version = "3.1.0"
+version = "3.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "requests" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e3/77/f2f881763f8d4d37ccb650f44e82e785008a02901550cd639461f72ab678/prawcore-3.1.0.tar.gz", hash = "sha256:8a1bb969c7d69d0f11f68bdfd3e61e62bf6a3691904e97857137b1c31081a685", size = 16092, upload-time = "2026-06-07T23:23:44.507Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/13/52/b3e4e912e76579a8e6666f119f74ba7ff88158ccf9073ddeac21f7a7e2f1/prawcore-3.2.0.tar.gz", hash = "sha256:451b13eba493ebafab3ed9ca3882c1461405158e0c158b3ba01115f5f320243f", size = 16746, upload-time = "2026-06-09T04:22:32.345Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/6d/59ef648b4d7310e7a90ad7ca6e3f26d53e7812b933f07651c5d3920c70b2/prawcore-3.1.0-py3-none-any.whl", hash = "sha256:14a519a1cc1e5d0c568dfa22d8bc08c76d303bf19809b48cd6698dfa50009e3c", size = 17198, upload-time = "2026-06-07T23:23:43.262Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/d6/0813d0f5d0d7d8c3086feb73a6c957d6cc6aca617fcd6f8b6f20b20c299a/prawcore-3.2.0-py3-none-any.whl", hash = "sha256:1d6cf686ecd5a0ceea378254c323b0deb1cfd67242c858bd714960faa64708e9", size = 17905, upload-time = "2026-06-09T04:22:31.006Z" },
 ]
 
 [[package]]
@@ -701,6 +715,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/62/62/0fe346fe380b1aafaf819c8cb195d3241bb4f355f908e6339814131a830b/pyproject_api-1.10.1.tar.gz", hash = "sha256:c2b2726bd7aa9217b6c50b621fef5b2ae5def4d55b779c9e0694c15e0a8517ba", size = 23477, upload-time = "2026-05-28T14:22:14.049Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/79/d7/29e1e5e882f79133631f7bcace42d23db493f616463c157a1ab614bf69dd/pyproject_api-1.10.1-py3-none-any.whl", hash = "sha256:fa9e6f66c35b5017e909825d8f2b5d5482ea699d7be809d21c03bd1f7317f36a", size = 12992, upload-time = "2026-05-28T14:22:12.711Z" },
+]
+
+[[package]]
+name = "pyright"
+version = "1.1.410"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nodeenv" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/10/53/e4d8ea1391bd4355231be6f91bf239479aa0014260ed3fb5526eeb12a1f2/pyright-1.1.410.tar.gz", hash = "sha256:07a073b8ba6749826773c1269773efa11b93440d9a6aa60419d9a3172d6dc488", size = 4062013, upload-time = "2026-06-01T17:35:48.894Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/33/288b5868fa00846dacf249633719d747893e54aebd196b9968ac1878a5d3/pyright-1.1.410-py3-none-any.whl", hash = "sha256:5e961bed37cacf96b3f7cd7b1da39b350a9239aa2e69138d0e88f728cfaf296c", size = 6082448, upload-time = "2026-06-01T17:35:46.387Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Mirrors the recent prawcore typing work for PRAW:

1. **Ship a `py.typed` marker** (PEP 561) plus the `Typing :: Typed` classifier so downstream projects type check against PRAW's inline annotations. hatchling bundles the marker into the wheel automatically.
2. **Add pyright tooling** — a `type` dependency group, a `[tool.pyright]` config (standard mode, `reportUnnecessaryTypeIgnoreComment` enabled), and a tox `type` env wired into the envlist so the shared CI lint job enforces it.
3. **Drive pyright to zero** — resolved ~477 standard-mode findings, almost all with correct annotations rather than suppressions.

## Notable fixes

- **Mixins** declare the host-provided attributes they rely on (`_reddit`, `fullname`, `_path`, `thing`, …).
- **`Config`** declares its dynamically-populated attributes (`client_id`, `oauth_url`, `ratelimit_seconds`, …), widens `**settings`, and drops the redundant `None` pre-init (every attribute is set by `_initialize_attributes`).
- **`FullnameMixin._kind`** and **`LiveUpdate._kind`** are now properties so the `_kind`/`fullname` property overrides across `Comment`/`Submission`/`Message`/`Redditor`/`Subreddit` are compatible.
- **`@overload`** where a return type depends on argument values (e.g. `DraftHelper.__call__`).
- `MoreComments`, `InlineMedia`, etc. declare attributes set by other classes.

A few targeted `# pyright: ignore` comments remain where the root cause is prawcore's `session()` annotating its `authorizer` parameter as `Authorizer` even though `Session` accepts any `BaseAuthorizer` — best fixed upstream in prawcore.

## Test plan

- `tox -e type` (pyright, standard): 0 errors
- `pytest`: 996 passed, 1 skipped
- `pre-commit run --all-files`: clean
- Verified `praw/py.typed` ships in the built wheel

Note: this enables **standard** mode. Raising to **strict** would be a separate follow-up campaign.