### PR TITLE
Raise ClientException for fetch-controlling changes after a submission is fetched

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -42,6 +42,15 @@ praw follows `semantic versioning <https://semver.org/>`_.
 - Require ``update_checker >=1.0, <2.0`` and call ``update_check`` with keyword
   arguments. The 1.0 release is dependency-free, dropping ``requests`` from PRAW's
   transitive dependencies.
+- :meth:`.Submission.add_fetch_param` now raises :class:`.ClientException` when called
+  on a submission that has already been fetched, rather than logging a warning, since
+  the added parameters would have no effect.
+
+**Removed**
+
+- The ``warn_additional_fetch_params`` configuration option, which is obsolete now that
+  adding fetch parameters to an already-fetched submission raises
+  :class:`.ClientException`.
 
 ***********************
  8.0.0rc2 (2026/06/08)

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -45,11 +45,17 @@ praw follows `semantic versioning <https://semver.org/>`_.
 - :meth:`.Submission.add_fetch_param` now raises :class:`.ClientException` when called
   on a submission that has already been fetched, rather than logging a warning, since
   the added parameters would have no effect.
+- Setting the ``comment_sort`` or ``comment_limit`` attribute of a :class:`.Submission`
+  after its comments have been fetched now raises :class:`.ClientException`, rather than
+  logging a warning, since the change would have no effect.
 
 **Removed**
 
 - The ``warn_additional_fetch_params`` configuration option, which is obsolete now that
   adding fetch parameters to an already-fetched submission raises
+  :class:`.ClientException`.
+- The ``warn_comment_sort`` configuration option, which is obsolete now that setting
+  ``comment_sort`` or ``comment_limit`` after the comments have been fetched raises
   :class:`.ClientException`.
 
 ***********************

--- a/praw/config.py
+++ b/praw/config.py
@@ -178,9 +178,6 @@ class Config:
         self.check_for_async = self._config_boolean(item=self._fetch_default("check_for_async", default=True))
         self.check_for_updates = self._config_boolean(item=self._fetch_or_not_set("check_for_updates"))
         self.warn_comment_sort = self._config_boolean(item=self._fetch_default("warn_comment_sort", default=True))
-        self.warn_additional_fetch_params = self._config_boolean(
-            item=self._fetch_default("warn_additional_fetch_params", default=True)
-        )
         self.window_size = self._fetch_default("window_size", default=600)
         self.kinds = {
             x: self._fetch(f"{x}_kind")

--- a/praw/config.py
+++ b/praw/config.py
@@ -177,7 +177,6 @@ class Config:
         self._short_url = self._fetch_default("short_url") or self.CONFIG_NOT_SET
         self.check_for_async = self._config_boolean(item=self._fetch_default("check_for_async", default=True))
         self.check_for_updates = self._config_boolean(item=self._fetch_or_not_set("check_for_updates"))
-        self.warn_comment_sort = self._config_boolean(item=self._fetch_default("warn_comment_sort", default=True))
         self.window_size = self._fetch_default("window_size", default=600)
         self.kinds = {
             x: self._fetch(f"{x}_kind")

--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -6,7 +6,6 @@ import re
 from json import dumps
 from typing import TYPE_CHECKING, Any
 from urllib.parse import urljoin
-from warnings import warn
 
 from prawcore import Conflict
 
@@ -544,7 +543,8 @@ class Submission(SubmissionListingMixin, UserContentMixin, FullnameMixin, Create
 
         Sort order and comment limit can be set with the ``comment_sort`` and
         ``comment_limit`` attributes before comments are fetched, including any call to
-        :meth:`.replace_more`:
+        :meth:`.replace_more`. Setting either attribute after the comments have been
+        fetched raises a :class:`.ClientException`:
 
         .. code-block:: python
 
@@ -615,18 +615,12 @@ class Submission(SubmissionListingMixin, UserContentMixin, FullnameMixin, Create
             value = Subreddit(self._reddit, value)
         elif attribute == "poll_data":
             value = PollData(self._reddit, value)
-        elif (
-            attribute == "comment_sort"
-            and hasattr(self, "_fetched")
-            and self._fetched
-            and hasattr(self, "_reddit")
-            and self._reddit.config.warn_comment_sort
-        ):
-            warn(
-                "The comments for this submission have already been fetched, so the"
-                " updated comment_sort will not have any effect.",
-                stacklevel=2,
+        elif attribute in {"comment_limit", "comment_sort"} and getattr(self, "_fetched", False):
+            msg = (
+                f"Cannot update {attribute!r} because the comments for this submission"
+                " have already been fetched."
             )
+            raise ClientException(msg)
         super().__setattr__(attribute, value)
 
     def _chunk(
@@ -783,8 +777,8 @@ class Submission(SubmissionListingMixin, UserContentMixin, FullnameMixin, Create
         :raises ClientException: If the submission has already been fetched, since fetch
             parameters only affect the initial fetch and would otherwise have no effect.
 
-        Fetch parameters must be added before the submission is fetched, i.e., before any
-        of its attributes are accessed. For example, to fetch a submission with the
+        Fetch parameters must be added before the submission is fetched, i.e., before
+        any of its attributes are accessed. For example, to fetch a submission with the
         ``rtjson`` attribute populated:
 
         .. code-block:: python

--- a/praw/models/reddit/submission.py
+++ b/praw/models/reddit/submission.py
@@ -11,7 +11,7 @@ from warnings import warn
 from prawcore import Conflict
 
 from praw.const import API_PATH
-from praw.exceptions import InvalidURL
+from praw.exceptions import ClientException, InvalidURL
 from praw.models.comment_forest import CommentForest
 from praw.models.listing.listing import Listing
 from praw.models.listing.mixins import SubmissionListingMixin
@@ -780,7 +780,12 @@ class Submission(SubmissionListingMixin, UserContentMixin, FullnameMixin, Create
         :param key: The key of the fetch parameter.
         :param value: The value of the fetch parameter.
 
-        For example, to fetch a submission with the ``rtjson`` attribute populated:
+        :raises ClientException: If the submission has already been fetched, since fetch
+            parameters only affect the initial fetch and would otherwise have no effect.
+
+        Fetch parameters must be added before the submission is fetched, i.e., before any
+        of its attributes are accessed. For example, to fetch a submission with the
+        ``rtjson`` attribute populated:
 
         .. code-block:: python
 
@@ -789,17 +794,12 @@ class Submission(SubmissionListingMixin, UserContentMixin, FullnameMixin, Create
             print(submission.rtjson)
 
         """
-        if (
-            hasattr(self, "_fetched")
-            and self._fetched
-            and hasattr(self, "_reddit")
-            and self._reddit.config.warn_additional_fetch_params
-        ):
-            warn(
-                f"This {self.__class__.__name__.lower()} has already been fetched, so"
-                " adding additional fetch parameters will not have any effect.",
-                stacklevel=2,
+        if getattr(self, "_fetched", False):
+            msg = (
+                f"Cannot add fetch parameters to this {self.__class__.__name__.lower()}"
+                " because it has already been fetched."
             )
+            raise ClientException(msg)
         self._additional_fetch_params[key] = value
 
     def crosspost(

--- a/tests/unit/models/reddit/test_submission.py
+++ b/tests/unit/models/reddit/test_submission.py
@@ -9,24 +9,20 @@ from ... import UnitTest
 
 
 class TestSubmission(UnitTest):
-    @pytest.mark.filterwarnings("error", category=UserWarning)
-    def test_additional_fetch_params_warning(self, reddit):
-        with pytest.raises(UserWarning) as excinfo:
-            submission = reddit.submission("1234")
-            submission._fetched = True
-            submission.add_fetch_param("foo", "bar")
-        assert (
-            excinfo.value.args[0] == "This submission has already been fetched, so"
-            " adding additional fetch parameters will not have any effect."
-        )
+    def test_additional_fetch_params__before_fetch(self, reddit):
+        submission = reddit.submission("1234")
+        submission.add_fetch_param("foo", "bar")
+        assert submission._additional_fetch_params == {"foo": "bar"}
 
-    @pytest.mark.filterwarnings("error", category=UserWarning)
-    def test_additional_fetch_params_warning__disabled(self, caplog, reddit):
-        reddit.config.warn_additional_fetch_params = False
+    def test_additional_fetch_params__raises_when_fetched(self, reddit):
         submission = reddit.submission("1234")
         submission._fetched = True
-        submission.additional_fetch_params = True
-        assert caplog.records == []
+        with pytest.raises(ClientException) as excinfo:
+            submission.add_fetch_param("foo", "bar")
+        assert str(excinfo.value) == (
+            "Cannot add fetch parameters to this submission because it has already been"
+            " fetched."
+        )
 
     @pytest.mark.filterwarnings("error", category=UserWarning)
     def test_comment_sort_warning(self, reddit):

--- a/tests/unit/models/reddit/test_submission.py
+++ b/tests/unit/models/reddit/test_submission.py
@@ -24,24 +24,30 @@ class TestSubmission(UnitTest):
             " fetched."
         )
 
-    @pytest.mark.filterwarnings("error", category=UserWarning)
-    def test_comment_sort_warning(self, reddit):
-        with pytest.raises(UserWarning) as excinfo:
-            submission = reddit.submission("1234")
-            submission._fetched = True
-            submission.comment_sort = "new"
-        assert (
-            excinfo.value.args[0] == "The comments for this submission have already"
-            " been fetched, so the updated comment_sort will not have any effect."
-        )
-
-    @pytest.mark.filterwarnings("error", category=UserWarning)
-    def test_comment_sort_warning__disabled(self, caplog, reddit):
-        reddit.config.warn_comment_sort = False
+    def test_comment_limit__raises_when_fetched(self, reddit):
         submission = reddit.submission("1234")
         submission._fetched = True
+        with pytest.raises(ClientException) as excinfo:
+            submission.comment_limit = 10
+        assert str(excinfo.value) == (
+            "Cannot update 'comment_limit' because the comments for this submission have"
+            " already been fetched."
+        )
+
+    def test_comment_sort__before_fetch(self, reddit):
+        submission = reddit.submission("1234")
         submission.comment_sort = "new"
-        assert caplog.records == []
+        assert submission.comment_sort == "new"
+
+    def test_comment_sort__raises_when_fetched(self, reddit):
+        submission = reddit.submission("1234")
+        submission._fetched = True
+        with pytest.raises(ClientException) as excinfo:
+            submission.comment_sort = "new"
+        assert str(excinfo.value) == (
+            "Cannot update 'comment_sort' because the comments for this submission have"
+            " already been fetched."
+        )
 
     def test_construct_failure(self, reddit):
         message = "Exactly one of 'id', 'url', or '_data' must be provided."


### PR DESCRIPTION
## Summary

Several `Submission` settings only influence the submission's *initial* fetch. Changing them after the submission (or its comments) has already been fetched is a silent no-op. Previously these cases logged warnings gated by configuration options that existed only to silence them. This makes them **raise `ClientException`** so the misuse fails fast, and removes the now-obsolete options.

Two related cases:

1. **`Submission.add_fetch_param`** — adds a query parameter for the initial fetch. Now raises if the submission is already fetched. Removes the `warn_additional_fetch_params` option.
2. **`Submission.comment_sort` / `comment_limit`** — control how comments are fetched. Setting either after the comments have been fetched now raises. Removes the `warn_comment_sort` option. (`comment_limit` previously had no guard at all, so this also closes that inconsistency.)

## Changes

- `add_fetch_param` raises `ClientException` when the submission is already fetched.
- `__setattr__` raises `ClientException` when `comment_sort` or `comment_limit` is set on an already-fetched submission.
- Removed the `warn_additional_fetch_params` and `warn_comment_sort` configuration options.
- Updated docstrings (`:raises:` / "before the submission is fetched" notes).
- Replaced the warning-based unit tests with exception-based ones (before-fetch succeeds, post-fetch raises). Verified `_fetch` updates state via `__dict__`/`del` (bypassing `__setattr__`), so internal fetching is unaffected.

## Breaking change

Code that modified any of these after a fetch previously got a (no-op) warning; it now raises `ClientException`. Such calls were already ineffective, so this surfaces a latent bug rather than changing working behavior. Targeted at the 8.0 release.

## Validation

- `pyright`: 0 errors
- `ruff`: passes
- unit tests: pass