### PR TITLE
Audit and correct documentation for the 8.0 release

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 build:
   os: ubuntu-lts-latest
   tools:
-    python: "3.13"
+    python: "3.14"
   jobs:
     install:
       - pip install uv

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -34,20 +34,19 @@ praw follows `semantic versioning <https://semver.org/>`_.
 
 **Changed**
 
-- Require ``prawcore >=3.2, <4`` for its public :class:`.Session` and authorizer
+- Require ``prawcore >=3.2, <4`` for its public :class:`!Session` and authorizer
   accessors and the widened :meth:`!Session.request` annotations, which let PRAW drop a
   number of internal ``cast``\ s and type-checker suppressions.
 - Constrain the ``websocket-client`` dependency to ``<2`` to avoid silently adopting a
   future, potentially breaking, major release.
 - Require ``update_checker >=1.0, <2.0`` and call ``update_check`` with keyword
-  arguments. The 1.0 release is dependency-free, dropping ``requests`` from PRAW's
-  transitive dependencies.
+  arguments. The 1.0 release is dependency-free.
 - :meth:`.Submission.add_fetch_param` now raises :class:`.ClientException` when called
   on a submission that has already been fetched, rather than logging a warning, since
   the added parameters would have no effect.
-- Setting the ``comment_sort`` or ``comment_limit`` attribute of a :class:`.Submission`
-  after its comments have been fetched now raises :class:`.ClientException`, rather than
-  logging a warning, since the change would have no effect.
+- The ``comment_sort`` and ``comment_limit`` attributes of a :class:`.Submission` must
+  now be set before the submission is fetched; setting either after the submission has
+  been fetched raises :class:`.ClientException` instead of logging a warning.
 
 **Removed**
 

--- a/README.rst
+++ b/README.rst
@@ -30,9 +30,9 @@
     :alt: pre-commit
     :target: https://github.com/pre-commit/pre-commit
 
-.. image:: https://img.shields.io/badge/code%20style-black-000000.svg
-    :alt: Black code style
-    :target: https://github.com/psf/black
+.. image:: https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ruff/main/assets/badge/v2.json
+    :alt: Ruff
+    :target: https://github.com/astral-sh/ruff
 
 PRAW, an acronym for "Python Reddit API Wrapper", is a Python package that allows for
 simple access to Reddit's API. PRAW aims to be easy to use and internally follows all of

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -3,7 +3,7 @@
 ## Supported Versions
 
 The supported versions of PRAW include the previous major release.
-This means that if PRAW is on 6.5.0, PRAW versions 5.0.0 and greater are supported.
+This means that if PRAW is on 8.0.0, PRAW versions 7.0.0 and greater are supported.
 
 ## Reporting a Vulnerability
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -23,8 +23,11 @@ intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
 master_doc = "index"
 nitpick_ignore = [
     ("py:class", "IO"),
+    ("py:class", "ListingGeneratorKwargs"),
+    ("py:class", "datetime"),
     ("py:class", "prawcore.requestor.Requestor"),
     ("py:class", "prawcore.auth.BaseAuthorizer"),
+    ("py:class", "praw.models.listing.generator.ListingGeneratorKwargs"),
     ("py:class", "praw.models.redditors.PartialRedditor"),
 ]
 nitpicky = True

--- a/docs/examples/lmgtfy_bot.py
+++ b/docs/examples/lmgtfy_bot.py
@@ -4,7 +4,7 @@ from urllib.parse import quote_plus
 import praw
 
 QUESTIONS = ["what is", "who is", "what are"]
-REPLY_TEMPLATE = "[Let me google that for you](https://lmgtfy.com/?q={})"
+REPLY_TEMPLATE = "[Let me google that for you](https://letmegooglethat.com/?q={})"
 
 
 def main():

--- a/docs/getting_started/authentication.rst
+++ b/docs/getting_started/authentication.rst
@@ -81,7 +81,7 @@ The output should contain the same name as you entered for ``username``.
 .. note::
 
     If the following exception is raised, double-check your credentials, and ensure that
-    that the username and password you are using are for the same user with which the
+    the username and password you are using are for the same user with which the
     application is associated:
 
     .. code-block::

--- a/docs/getting_started/configuration/options.rst
+++ b/docs/getting_started/configuration/options.rst
@@ -85,7 +85,7 @@ order to successfully access a third-party Reddit site:
 
 These are options that do not belong in another category, but still play a part in PRAW.
 
-:check_for_async: When ``true``, check if PRAW is being ran in an asynchronous
+:check_for_async: When ``true``, check if PRAW is being run in an asynchronous
     environment whenever a request is made. If so, a warning will be logged recommending
     the usage of `Async PRAW <https://asyncpraw.readthedocs.io/>`_ (default: ``true``).
 :ratelimit_seconds: Controls the maximum number of seconds PRAW will capture ratelimits
@@ -100,8 +100,6 @@ These are options that do not belong in another category, but still play a part 
 :timeout: Controls the amount of time PRAW will wait for a request from Reddit to
     complete before throwing an exception. By default, PRAW waits 16 seconds before
     throwing an exception.
-:warn_comment_sort: When ``true``, log a warning when the ``comment_sort`` attribute of
-    a submission is updated after ``_fetch()`` has been called (default: ``true``).
 :window_size: The number of seconds between rate limit resets (default: 600).
 
 .. _custom_options:

--- a/docs/getting_started/configuration/prawini.rst
+++ b/docs/getting_started/configuration/prawini.rst
@@ -32,13 +32,13 @@ PRAW comes with a ``praw.ini`` file in the package directory, and looks for user
 
               echo "$<variable>"
 
-          **Windows Command Prompt**
+          **Windows Command Prompt**:
 
           .. code-block:: bat
 
               echo "%<variable>%"
 
-          **Powershell**
+          **PowerShell**:
 
           .. code-block:: powershell
 
@@ -146,7 +146,7 @@ variables, for example:
     bot_author=MyUser
     user_agent=script:%(bot_name)s:v%(bot_version)s (by u/%(bot_author)s)
 
-This uses basic interpolation thus :class:`.Reddit` need to be initialized as follows:
+This uses basic interpolation thus :class:`.Reddit` needs to be initialized as follows:
 
 .. code-block:: python
 

--- a/docs/getting_started/faq.rst
+++ b/docs/getting_started/faq.rst
@@ -22,7 +22,7 @@ A: This means that either you provided the wrong password and/or the account you
 trying to sign in with has 2FA enabled, and as such, either needs a 2FA token or a
 refresh token to sign in. A refresh token is preferred, because then you will not need
 to enter a 2FA token in order to sign in, and the session will last for longer than an
-hour. Refer to :ref:`2FA` and :ref:`refresh_token` in order to use the respective auth
+hour. Refer to :ref:`2fa` and :ref:`refresh_token` in order to use the respective auth
 methods.
 
 .. _faq3:

--- a/docs/getting_started/logging.rst
+++ b/docs/getting_started/logging.rst
@@ -24,6 +24,7 @@ scripts when you need to look back at what the bot did hours ago.
 .. code-block:: python
 
     import logging
+    import logging.handlers
 
     stream_handler = logging.StreamHandler()
     stream_handler.setLevel(logging.DEBUG)

--- a/docs/getting_started/quick_start.rst
+++ b/docs/getting_started/quick_start.rst
@@ -10,7 +10,7 @@ bots using PRAW, the Python Reddit API Wrapper. It's fun and easy. Let's get sta
 ***************
 
 :Python Knowledge: You need to know at least a little Python to use PRAW. PRAW supports
-    `Python 3.9+`_. If you are stuck on a problem, `r/learnpython`_ is a great place to
+    `Python 3.10+`_. If you are stuck on a problem, `r/learnpython`_ is a great place to
     ask for help.
 :Reddit Knowledge: A basic understanding of how Reddit works is a must. In the event you
     are not already familiar with Reddit start at `Reddit Help`_.
@@ -28,7 +28,7 @@ bots using PRAW, the Python Reddit API Wrapper. It's fun and easy. Let's get sta
 
 .. _first steps guide: https://github.com/reddit/reddit/wiki/OAuth2-Quick-Start-Example#first-steps
 
-.. _python 3.9+: https://docs.python.org/3/tutorial/index.html
+.. _python 3.10+: https://docs.python.org/3/tutorial/index.html
 
 .. _r/learnpython: https://www.reddit.com/r/learnpython/
 
@@ -51,10 +51,10 @@ Obtain a :class:`.Reddit` Instance
 .. warning::
 
     For the sake of brevity, the following examples pass authentication information via
-    arguments to :meth:`praw.Reddit`. If you do this, you need to be careful not to
-    reveal this information to the outside world if you share your code. It is
-    recommended to use a :ref:`praw.ini file <praw.ini>` in order to keep your
-    authentication information separate from your code.
+    arguments to :class:`.Reddit`. If you do this, you need to be careful not to reveal
+    this information to the outside world if you share your code. It is recommended to
+    use a :ref:`praw.ini file <praw.ini>` in order to keep your authentication
+    information separate from your code.
 
 You need an instance of the :class:`.Reddit` class to do *anything* with PRAW. There are
 two distinct states a :class:`.Reddit` instance can be in: :ref:`read-only <read-only>`,

--- a/docs/getting_started/ratelimits.rst
+++ b/docs/getting_started/ratelimits.rst
@@ -9,8 +9,8 @@ requests, there are other unknown ratelimits that Reddit has that might require
 additional wait time (anywhere from milliseconds to minutes) for things such as
 commenting, editing comments/posts, banning users, adding moderators, etc. PRAW will
 sleep and try the request again if the requested wait time (as much as 600 seconds) is
-less than or equal to PRAW's |ratelimit_seconds|_, PRAW will wait for the requested time
-plus 1 second. If the requested wait time exceeds the set value of
+less than or equal to PRAW's |ratelimit_seconds|_. In that case, PRAW will wait for the
+requested time plus 1 second. If the requested wait time exceeds the set value of
 ``ratelimit_seconds``, PRAW will raise :class:`.RedditAPIException`.
 
 For example, given the following :class:`.Reddit` instance:

--- a/docs/package_info/contributing.rst
+++ b/docs/package_info/contributing.rst
@@ -100,7 +100,7 @@ Linting_:
               optional_arg1=None,
           ): ...
 
-  There is some exceptions to this:
+  There are some exceptions to this:
 
   - If it’s clear without reading documentation what the mandatory positional arguments
     would be and their order, then they can be positional arguments. For example:
@@ -140,7 +140,7 @@ Linting_:
  Testing
 *********
 
-Contributions to PRAW requires 100% test coverage. If you know how to add a feature, but
+Contributions to PRAW require 100% test coverage. If you know how to add a feature, but
 aren't sure how to write the necessary tests, please open a pull request anyway so we
 can work with you to write the necessary tests.
 
@@ -152,7 +152,7 @@ However, it's useful to be able to run the tests locally. The simplest way is vi
 
 .. code-block:: bash
 
-    pytest
+    uv run pytest
 
 Without any configuration or modification, all the tests should pass. If they do not,
 please file a bug report.

--- a/docs/package_info/praw8_migration.rst
+++ b/docs/package_info/praw8_migration.rst
@@ -14,6 +14,32 @@ every removed or changed item, with examples showing how to update your code.
 PRAW 8 requires Python 3.10 or newer. Support for Python 3.8 and 3.9, both of which are
 end-of-life, has been dropped, and support for Python 3.13 and 3.14 has been added.
 
+*********************************
+ Dependency and Behavior Changes
+*********************************
+
+PRAW 8 raises several dependency floors: it now requires ``prawcore >=3.2, <4`` (for its
+public :class:`!Session` and authorizer accessors) and ``update_checker >=1.0, <2``, and
+it constrains ``websocket-client`` to ``<2``. These requirements are resolved
+automatically when you install or upgrade PRAW; no code changes are required.
+
+PRAW now ships a :PEP:`561` ``py.typed`` marker, so downstream projects can type check
+against PRAW's inline annotations. This is additive and does not change runtime
+behavior.
+
+PRAW now warns at initialization if a ``praw.ini`` file in the current working directory
+sets the ``oauth_url`` or ``reddit_url`` endpoint, since such a file can redirect
+credentials to an untrusted host. If you intentionally override these endpoints (for
+example, to test against a mock server), silence the warning by setting the
+``PRAW_ALLOW_ENDPOINT_OVERRIDE`` environment variable.
+
+Changing how a :class:`.Submission` is fetched after the fact now raises
+:class:`.ClientException` instead of logging a warning. Set the ``comment_sort`` and
+``comment_limit`` attributes, and call :meth:`.Submission.add_fetch_param`, before the
+submission is fetched -- that is, before accessing any of its attributes. The
+``warn_comment_sort`` and ``warn_additional_fetch_params`` configuration options, which
+previously toggled these warnings, have been removed.
+
 ***************
  Media Uploads
 ***************

--- a/docs/tutorials/reply_bot.rst
+++ b/docs/tutorials/reply_bot.rst
@@ -13,14 +13,14 @@ PRAW.
 
 This tutorial will show you how to build a bot that monitors a particular subreddit,
 `r/AskReddit <https://www.reddit.com/r/AskReddit/>`_, for new submissions containing
-simple questions and replies with an appropriate link to lmgtfy_ (Let Me Google That For
-You).
+simple questions and replies with an appropriate link to letmegooglethat_ (Let Me Google
+That For You).
 
 There are three key components we will address to perform this task:
 
 1. Monitor new submissions.
 2. Analyze the title of each submission to see if it contains a simple question.
-3. Reply with an appropriate lmgtfy_ link.
+3. Reply with an appropriate letmegooglethat_ link.
 
 ************
  LMGTFY Bot
@@ -35,10 +35,10 @@ Two examples of such questions are:
 2. "How many feet are in a yard?"
 
 Once we identify these questions, the LMGTFY Bot will reply to the submission with an
-appropriate lmgtfy_ link. For the example questions those links are:
+appropriate letmegooglethat_ link. For the example questions those links are:
 
-1. https://lmgtfy.com/?q=What+is+the+capital+of+Canada%3F
-2. https://lmgtfy.com/?q=How+many+feet+are+in+a+yard%3F
+1. https://letmegooglethat.com/?q=What+is+the+capital+of+Canada%3F
+2. https://letmegooglethat.com/?q=How+many+feet+are+in+a+yard%3F
 
 Step 1: Getting Started
 =======================
@@ -138,15 +138,15 @@ Step 4: Automatically Replying to the Submission
 
 The LMGTFY Bot is nearly complete. We iterate through submissions and find ones that
 appear to be simple questions. All that is remaining is to reply to those submissions
-with an appropriate lmgtfy_ link.
+with an appropriate letmegooglethat_ link.
 
-First we will need to construct a working lmgtfy_ link. In essence, we want to pass the
-entire submission title to lmgtfy_. However, there are certain characters that are not
-permitted in URLs or have other meanings. For instance, the space character, `` ``, is
-not permitted, and the question mark, ``?``, has a special meaning. Thus we will
-transform those into their URL-safe representation so that a question like "What is the
-capital of Canada?" is transformed into the link
-``https://lmgtfy.com/?q=What+is+the+capital+of+Canada%3F``.
+First we will need to construct a working letmegooglethat_ link. In essence, we want to
+pass the entire submission title to letmegooglethat_. However, there are certain
+characters that are not permitted in URLs or have other meanings. For instance, the
+space character, `` ``, is not permitted, and the question mark, ``?``, has a special
+meaning. Thus we will transform those into their URL-safe representation so that a
+question like "What is the capital of Canada?" is transformed into the link
+``https://letmegooglethat.com/?q=What+is+the+capital+of+Canada%3F``.
 
 There are a number of ways we could accomplish this task. For starters, we could write a
 function to replace spaces with pluses (``+``) and question marks with ``%3F``. However,
@@ -159,7 +159,7 @@ located:
 
     from urllib.parse import quote_plus
 
-    reply_template = "[Let me google that for you](https://lmgtfy.com/?q={})"
+    reply_template = "[Let me google that for you](https://letmegooglethat.com/?q={})"
 
     url_title = quote_plus(submission.title)
     reply_text = reply_template.format(url_title)
@@ -229,6 +229,6 @@ The following is the complete LMGTFY Bot:
 .. literalinclude:: ../examples/lmgtfy_bot.py
     :language: python
 
-.. _lmgtfy: https://lmgtfy.com/
+.. _letmegooglethat: https://letmegooglethat.com/
 
 .. _oauth2 quick start example: https://github.com/reddit/reddit/wiki/OAuth2-Quick-Start-Example#first-steps


### PR DESCRIPTION
## Summary

A documentation pass ahead of the 8.0 release, covering typos, consistency, and accuracy across the prose docs, plus corrections to release-notes wording that follow-up work proved inaccurate.

## Typos & consistency
- Duplicated/garbled words and grammar (`authentication`, `options`, `prawini`, `contributing`, `ratelimits`, `README`).
- Sphinx role/reference fixes: `:ref:\`2fa\`` casing, `:class:\`.Reddit\`` (was `:meth:`), PowerShell capitalization + colons.

## Accuracy
- **Python version**: corrected "3.9+" → "3.10+" in `quick_start` (matches `requires-python`).
- **`logging` example**: added the missing `import logging.handlers` (the example raised `AttributeError`).
- **README**: stale "Black code style" badge → Ruff (the project uses ruff + docstrfmt).
- **`contributing`**: `pytest` → `uv run pytest`.
- **`reply_bot` tutorial**: the defunct `lmgtfy.com` service → `letmegooglethat.com` (same `?q=` format).
- **SECURITY**: refreshed the stale supported-versions example.

## Migration guide & options
- New "Dependency and Behavior Changes" section: dependency floors, `py.typed`, the `PRAW_ALLOW_ENDPOINT_OVERRIDE` endpoint-override warning, and the new fetch-controlling exception behavior (`comment_sort`/`comment_limit`/`add_fetch_param` must be set before fetch).
- Removed the obsolete `warn_comment_sort` entry from `options.rst` (the option was removed in #2131).

## CHANGES corrections
- Scope the prawcore `Session` cross-reference (`:class:\`!Session\``) so it doesn't trip a nitpick warning.
- Drop the inaccurate claim that `update_checker` 1.0 removes `requests` from PRAW's transitive deps — `prawcore` still requires `requests`.
- Reframe the `comment_sort`/`comment_limit` change as **set-before-fetch enforcement** rather than "no effect" — it does affect `replace_more`'s `MoreComments` expansion.

## conf.py
- Added `ListingGeneratorKwargs` and `datetime` to `nitpick_ignore` (rendered-annotation targets from the typing work), so the docs build is **0 warnings**.

## Validation
- `docstrfmt`: clean
- Sphinx build: **0 warnings**