### PR TITLE
Resolve all documentation cross-references (empty nitpick_ignore)

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -10,4 +10,5 @@ formats:
   - htmlzip
 sphinx:
   configuration: docs/conf.py
+  fail_on_warning: true
 version: 2

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,155 +1,19 @@
-# Makefile for Sphinx documentation
-#
+# Minimal makefile for Sphinx documentation
 
-# You can set these variables from the command line.
-SPHINXOPTS    =
-SPHINXBUILD   = sphinx-build
-PAPER         =
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
 BUILDDIR      = _build
 
-# Internal variables.
-PAPEROPT_a4     = -D latex_paper_size=a4
-PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
-# the i18n builder cannot share the environment and doctrees with the others
-I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
-
-.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext
-
-default: html
-
+# Put it first so that "make" without argument is like "make help".
 help:
-	@echo "Please use \`make <target>' where <target> is one of"
-	@echo "  html       to make standalone HTML files"
-	@echo "  dirhtml    to make HTML files named index.html in directories"
-	@echo "  singlehtml to make a single large HTML file"
-	@echo "  pickle     to make pickle files"
-	@echo "  json       to make JSON files"
-	@echo "  htmlhelp   to make HTML files and a HTML help project"
-	@echo "  qthelp     to make HTML files and a qthelp project"
-	@echo "  devhelp    to make HTML files and a Devhelp project"
-	@echo "  epub       to make an epub"
-	@echo "  latex      to make LaTeX files, you can set PAPER=a4 or PAPER=letter"
-	@echo "  latexpdf   to make LaTeX files and run them through pdflatex"
-	@echo "  text       to make text files"
-	@echo "  man        to make manual pages"
-	@echo "  texinfo    to make Texinfo files"
-	@echo "  info       to make Texinfo files and run them through makeinfo"
-	@echo "  gettext    to make PO message catalogs"
-	@echo "  changes    to make an overview of all changed/added/deprecated items"
-	@echo "  linkcheck  to check all external links for integrity"
-	@echo "  doctest    to run all doctests embedded in the documentation (if enabled)"
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-clean:
-	-rm -rf $(BUILDDIR)/*
+.PHONY: help Makefile
 
-html:
-	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
-	@echo
-	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."
-
-dirhtml:
-	$(SPHINXBUILD) -b dirhtml $(ALLSPHINXOPTS) $(BUILDDIR)/dirhtml
-	@echo
-	@echo "Build finished. The HTML pages are in $(BUILDDIR)/dirhtml."
-
-singlehtml:
-	$(SPHINXBUILD) -b singlehtml $(ALLSPHINXOPTS) $(BUILDDIR)/singlehtml
-	@echo
-	@echo "Build finished. The HTML page is in $(BUILDDIR)/singlehtml."
-
-pickle:
-	$(SPHINXBUILD) -b pickle $(ALLSPHINXOPTS) $(BUILDDIR)/pickle
-	@echo
-	@echo "Build finished; now you can process the pickle files."
-
-json:
-	$(SPHINXBUILD) -b json $(ALLSPHINXOPTS) $(BUILDDIR)/json
-	@echo
-	@echo "Build finished; now you can process the JSON files."
-
-htmlhelp:
-	$(SPHINXBUILD) -b htmlhelp $(ALLSPHINXOPTS) $(BUILDDIR)/htmlhelp
-	@echo
-	@echo "Build finished; now you can run HTML Help Workshop with the" \
-	      ".hhp project file in $(BUILDDIR)/htmlhelp."
-
-qthelp:
-	$(SPHINXBUILD) -b qthelp $(ALLSPHINXOPTS) $(BUILDDIR)/qthelp
-	@echo
-	@echo "Build finished; now you can run "qcollectiongenerator" with the" \
-	      ".qhcp project file in $(BUILDDIR)/qthelp, like this:"
-	@echo "# qcollectiongenerator $(BUILDDIR)/qthelp/PythonRedditAPIWrapper.qhcp"
-	@echo "To view the help file:"
-	@echo "# assistant -collectionFile $(BUILDDIR)/qthelp/PythonRedditAPIWrapper.qhc"
-
-devhelp:
-	$(SPHINXBUILD) -b devhelp $(ALLSPHINXOPTS) $(BUILDDIR)/devhelp
-	@echo
-	@echo "Build finished."
-	@echo "To view the help file:"
-	@echo "# mkdir -p $$HOME/.local/share/devhelp/PythonRedditAPIWrapper"
-	@echo "# ln -s $(BUILDDIR)/devhelp $$HOME/.local/share/devhelp/PythonRedditAPIWrapper"
-	@echo "# devhelp"
-
-epub:
-	$(SPHINXBUILD) -b epub $(ALLSPHINXOPTS) $(BUILDDIR)/epub
-	@echo
-	@echo "Build finished. The epub file is in $(BUILDDIR)/epub."
-
-latex:
-	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
-	@echo
-	@echo "Build finished; the LaTeX files are in $(BUILDDIR)/latex."
-	@echo "Run \`make' in that directory to run these through (pdf)latex" \
-	      "(use \`make latexpdf' here to do that automatically)."
-
-latexpdf:
-	$(SPHINXBUILD) -b latex $(ALLSPHINXOPTS) $(BUILDDIR)/latex
-	@echo "Running LaTeX files through pdflatex..."
-	$(MAKE) -C $(BUILDDIR)/latex all-pdf
-	@echo "pdflatex finished; the PDF files are in $(BUILDDIR)/latex."
-
-text:
-	$(SPHINXBUILD) -b text $(ALLSPHINXOPTS) $(BUILDDIR)/text
-	@echo
-	@echo "Build finished. The text files are in $(BUILDDIR)/text."
-
-man:
-	$(SPHINXBUILD) -b man $(ALLSPHINXOPTS) $(BUILDDIR)/man
-	@echo
-	@echo "Build finished. The manual pages are in $(BUILDDIR)/man."
-
-texinfo:
-	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
-	@echo
-	@echo "Build finished. The Texinfo files are in $(BUILDDIR)/texinfo."
-	@echo "Run \`make' in that directory to run these through makeinfo" \
-	      "(use \`make info' here to do that automatically)."
-
-info:
-	$(SPHINXBUILD) -b texinfo $(ALLSPHINXOPTS) $(BUILDDIR)/texinfo
-	@echo "Running Texinfo files through makeinfo..."
-	make -C $(BUILDDIR)/texinfo info
-	@echo "makeinfo finished; the Info files are in $(BUILDDIR)/texinfo."
-
-gettext:
-	$(SPHINXBUILD) -b gettext $(I18NSPHINXOPTS) $(BUILDDIR)/locale
-	@echo
-	@echo "Build finished. The message catalogs are in $(BUILDDIR)/locale."
-
-changes:
-	$(SPHINXBUILD) -b changes $(ALLSPHINXOPTS) $(BUILDDIR)/changes
-	@echo
-	@echo "The overview file is in $(BUILDDIR)/changes."
-
-linkcheck:
-	$(SPHINXBUILD) -b linkcheck $(ALLSPHINXOPTS) $(BUILDDIR)/linkcheck
-	@echo
-	@echo "Link check complete; look for any errors in the above output " \
-	      "or in $(BUILDDIR)/linkcheck/output.txt."
-
-doctest:
-	$(SPHINXBUILD) -b doctest $(ALLSPHINXOPTS) $(BUILDDIR)/doctest
-	@echo "Testing of doctests in the sources finished, look at the " \
-	      "results in $(BUILDDIR)/doctest/output.txt."
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/code_overview/other.rst
+++ b/docs/code_overview/other.rst
@@ -143,6 +143,7 @@ them bound to an attribute of one of the PRAW models.
     other/fullnamemixin
     other/inboxablemixin
     other/listinggenerator
+    other/listinggeneratorkwargs
     other/mod_action
     other/moderatedlist
     other/modmail

--- a/docs/code_overview/other/listinggeneratorkwargs.rst
+++ b/docs/code_overview/other/listinggeneratorkwargs.rst
@@ -1,0 +1,5 @@
+########################
+ ListingGeneratorKwargs
+########################
+
+.. autoclass:: praw.models.listing.generator.ListingGeneratorKwargs

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,17 +19,12 @@ html_css_files = ["praw8_migration.css"]
 html_static_path = ["_static"]
 html_theme = "furo"
 htmlhelp_basename = "PRAW"
-intersphinx_mapping = {"python": ("https://docs.python.org/3", None)}
+intersphinx_mapping = {
+    "prawcore": ("https://prawcore.readthedocs.io/en/stable/", None),
+    "python": ("https://docs.python.org/3", None),
+}
 master_doc = "index"
-nitpick_ignore = [
-    ("py:class", "IO"),
-    ("py:class", "ListingGeneratorKwargs"),
-    ("py:class", "datetime"),
-    ("py:class", "prawcore.requestor.Requestor"),
-    ("py:class", "prawcore.auth.BaseAuthorizer"),
-    ("py:class", "praw.models.listing.generator.ListingGeneratorKwargs"),
-    ("py:class", "praw.models.redditors.PartialRedditor"),
-]
+nitpick_ignore = []
 nitpicky = True
 project = "PRAW"
 pygments_style = "sphinx"

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -18,19 +18,13 @@ extensions = [
 html_css_files = ["praw8_migration.css"]
 html_static_path = ["_static"]
 html_theme = "furo"
-htmlhelp_basename = "PRAW"
 intersphinx_mapping = {
     "prawcore": ("https://prawcore.readthedocs.io/en/stable/", None),
     "python": ("https://docs.python.org/3", None),
 }
-master_doc = "index"
-nitpick_ignore = []
 nitpicky = True
 project = "PRAW"
-pygments_style = "sphinx"
 release = __version__
-source_suffix = ".rst"
-suppress_warnings = ["image.nonlocal_uri"]
 version = ".".join(__version__.split(".", 2)[:2])
 
 

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,190 +1,35 @@
 @ECHO OFF
 
+pushd %~dp0
+
 REM Command file for Sphinx documentation
 
 if "%SPHINXBUILD%" == "" (
 	set SPHINXBUILD=sphinx-build
 )
+set SOURCEDIR=.
 set BUILDDIR=_build
-set ALLSPHINXOPTS=-d %BUILDDIR%/doctrees %SPHINXOPTS% .
-set I18NSPHINXOPTS=%SPHINXOPTS% .
-if NOT "%PAPER%" == "" (
-	set ALLSPHINXOPTS=-D latex_paper_size=%PAPER% %ALLSPHINXOPTS%
-	set I18NSPHINXOPTS=-D latex_paper_size=%PAPER% %I18NSPHINXOPTS%
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
 )
 
 if "%1" == "" goto help
 
-if "%1" == "help" (
-	:help
-	echo.Please use `make ^<target^>` where ^<target^> is one of
-	echo.  html       to make standalone HTML files
-	echo.  dirhtml    to make HTML files named index.html in directories
-	echo.  singlehtml to make a single large HTML file
-	echo.  pickle     to make pickle files
-	echo.  json       to make JSON files
-	echo.  htmlhelp   to make HTML files and a HTML help project
-	echo.  qthelp     to make HTML files and a qthelp project
-	echo.  devhelp    to make HTML files and a Devhelp project
-	echo.  epub       to make an epub
-	echo.  latex      to make LaTeX files, you can set PAPER=a4 or PAPER=letter
-	echo.  text       to make text files
-	echo.  man        to make manual pages
-	echo.  texinfo    to make Texinfo files
-	echo.  gettext    to make PO message catalogs
-	echo.  changes    to make an overview over all changed/added/deprecated items
-	echo.  linkcheck  to check all external links for integrity
-	echo.  doctest    to run all doctests embedded in the documentation if enabled
-	goto end
-)
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
 
-if "%1" == "clean" (
-	for /d %%i in (%BUILDDIR%\*) do rmdir /q /s %%i
-	del /q /s %BUILDDIR%\*
-	goto end
-)
-
-if "%1" == "html" (
-	%SPHINXBUILD% -b html %ALLSPHINXOPTS% %BUILDDIR%/html
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Build finished. The HTML pages are in %BUILDDIR%/html.
-	goto end
-)
-
-if "%1" == "dirhtml" (
-	%SPHINXBUILD% -b dirhtml %ALLSPHINXOPTS% %BUILDDIR%/dirhtml
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Build finished. The HTML pages are in %BUILDDIR%/dirhtml.
-	goto end
-)
-
-if "%1" == "singlehtml" (
-	%SPHINXBUILD% -b singlehtml %ALLSPHINXOPTS% %BUILDDIR%/singlehtml
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Build finished. The HTML pages are in %BUILDDIR%/singlehtml.
-	goto end
-)
-
-if "%1" == "pickle" (
-	%SPHINXBUILD% -b pickle %ALLSPHINXOPTS% %BUILDDIR%/pickle
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Build finished; now you can process the pickle files.
-	goto end
-)
-
-if "%1" == "json" (
-	%SPHINXBUILD% -b json %ALLSPHINXOPTS% %BUILDDIR%/json
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Build finished; now you can process the JSON files.
-	goto end
-)
-
-if "%1" == "htmlhelp" (
-	%SPHINXBUILD% -b htmlhelp %ALLSPHINXOPTS% %BUILDDIR%/htmlhelp
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Build finished; now you can run HTML Help Workshop with the ^
-.hhp project file in %BUILDDIR%/htmlhelp.
-	goto end
-)
-
-if "%1" == "qthelp" (
-	%SPHINXBUILD% -b qthelp %ALLSPHINXOPTS% %BUILDDIR%/qthelp
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Build finished; now you can run "qcollectiongenerator" with the ^
-.qhcp project file in %BUILDDIR%/qthelp, like this:
-	echo.^> qcollectiongenerator %BUILDDIR%\qthelp\PythonRedditAPIWrapper.qhcp
-	echo.To view the help file:
-	echo.^> assistant -collectionFile %BUILDDIR%\qthelp\PythonRedditAPIWrapper.ghc
-	goto end
-)
-
-if "%1" == "devhelp" (
-	%SPHINXBUILD% -b devhelp %ALLSPHINXOPTS% %BUILDDIR%/devhelp
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Build finished.
-	goto end
-)
-
-if "%1" == "epub" (
-	%SPHINXBUILD% -b epub %ALLSPHINXOPTS% %BUILDDIR%/epub
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Build finished. The epub file is in %BUILDDIR%/epub.
-	goto end
-)
-
-if "%1" == "latex" (
-	%SPHINXBUILD% -b latex %ALLSPHINXOPTS% %BUILDDIR%/latex
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Build finished; the LaTeX files are in %BUILDDIR%/latex.
-	goto end
-)
-
-if "%1" == "text" (
-	%SPHINXBUILD% -b text %ALLSPHINXOPTS% %BUILDDIR%/text
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Build finished. The text files are in %BUILDDIR%/text.
-	goto end
-)
-
-if "%1" == "man" (
-	%SPHINXBUILD% -b man %ALLSPHINXOPTS% %BUILDDIR%/man
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Build finished. The manual pages are in %BUILDDIR%/man.
-	goto end
-)
-
-if "%1" == "texinfo" (
-	%SPHINXBUILD% -b texinfo %ALLSPHINXOPTS% %BUILDDIR%/texinfo
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Build finished. The Texinfo files are in %BUILDDIR%/texinfo.
-	goto end
-)
-
-if "%1" == "gettext" (
-	%SPHINXBUILD% -b gettext %I18NSPHINXOPTS% %BUILDDIR%/locale
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Build finished. The message catalogs are in %BUILDDIR%/locale.
-	goto end
-)
-
-if "%1" == "changes" (
-	%SPHINXBUILD% -b changes %ALLSPHINXOPTS% %BUILDDIR%/changes
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.The overview file is in %BUILDDIR%/changes.
-	goto end
-)
-
-if "%1" == "linkcheck" (
-	%SPHINXBUILD% -b linkcheck %ALLSPHINXOPTS% %BUILDDIR%/linkcheck
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Link check complete; look for any errors in the above output ^
-or in %BUILDDIR%/linkcheck/output.txt.
-	goto end
-)
-
-if "%1" == "doctest" (
-	%SPHINXBUILD% -b doctest %ALLSPHINXOPTS% %BUILDDIR%/doctest
-	if errorlevel 1 exit /b 1
-	echo.
-	echo.Testing of doctests in the sources finished, look at the ^
-results in %BUILDDIR%/doctest/output.txt.
-	goto end
-)
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
 
 :end
+popd

--- a/praw/models/reddit/collections.py
+++ b/praw/models/reddit/collections.py
@@ -14,8 +14,8 @@ from praw.models.reddit.subreddit import Subreddit
 from praw.util.cache import cachedproperty
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Iterator
-    from datetime import datetime
 
     import praw
     from praw import models
@@ -455,7 +455,7 @@ class Collection(CreatedMixin, RedditBase):
         return cast("models.Subreddit", next(self._reddit.info(fullnames=[self.subreddit_id])))
 
     @property
-    def updated_datetime(self) -> datetime:
+    def updated_datetime(self) -> datetime.datetime:
         """Return the last update time as a timezone-aware :class:`datetime.datetime`.
 
         The returned object is localized to the system's timezone.

--- a/praw/models/reddit/mixins/created.py
+++ b/praw/models/reddit/mixins/created.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Callable
-    from datetime import datetime
 
 
 class CreatedMixin:
@@ -18,10 +18,10 @@ class CreatedMixin:
 
     if TYPE_CHECKING:
         # Provided by the host class (:class:`.PRAWBase`).
-        _to_local_datetime: Callable[[float], datetime]
+        _to_local_datetime: Callable[[float], datetime.datetime]
 
     @property
-    def created_datetime(self) -> datetime:
+    def created_datetime(self) -> datetime.datetime:
         """Return the creation time as a timezone-aware :class:`datetime.datetime`.
 
         The returned object is localized to the system's timezone.

--- a/praw/models/reddit/mixins/editable.py
+++ b/praw/models/reddit/mixins/editable.py
@@ -7,8 +7,8 @@ from typing import TYPE_CHECKING
 from praw.const import API_PATH
 
 if TYPE_CHECKING:
+    import datetime
     from collections.abc import Callable
-    from datetime import datetime
 
     from typing_extensions import Self
 
@@ -21,14 +21,14 @@ class EditableMixin:
     if TYPE_CHECKING:
         # Provided by the host class (:class:`.RedditBase`).
         _reddit: praw.Reddit
-        _to_local_datetime: Callable[[float], datetime]
+        _to_local_datetime: Callable[[float], datetime.datetime]
         edited: bool | float
 
         @property
         def fullname(self) -> str: ...  # noqa: D102
 
     @property
-    def edited_datetime(self) -> datetime | None:
+    def edited_datetime(self) -> datetime.datetime | None:
         """Return the last edit time as a timezone-aware :class:`datetime.datetime`.
 
         Returns ``None`` if the object has never been edited. The returned object is

--- a/praw/models/reddit/poll.py
+++ b/praw/models/reddit/poll.py
@@ -8,7 +8,7 @@ from praw.models.base import DynamicAttributes, PRAWBase
 from praw.util import cachedproperty
 
 if TYPE_CHECKING:
-    from datetime import datetime
+    import datetime
 
 
 class PollOption(DynamicAttributes, PRAWBase):
@@ -97,7 +97,7 @@ class PollData(DynamicAttributes, PRAWBase):
         return self.option(self._user_selection)
 
     @property
-    def voting_end_datetime(self) -> datetime:
+    def voting_end_datetime(self) -> datetime.datetime:
         """Return the poll's closing time as a timezone-aware :class:`datetime.datetime`.
 
         The returned object is localized to the system's timezone.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -184,8 +184,9 @@ envlist = ["py310", "py311", "py312", "py313", "py314", "docs", "pre-commit", "t
 minversion = "4.22"
 
 [tool.tox.env.docs]
+base_python = ["py314"]
 commands = [
-  ["sphinx-build", "--keep-going", "docs/", "{env_tmp_dir}/html"]
+  ["sphinx-build", "-W", "--keep-going", "-n", "docs/", "{env_tmp_dir}/html"]
 ]
 dependency_groups = ["docs"]
 description = "build docs with sphinx"


### PR DESCRIPTION
Two related documentation changes.

## Resolve all cross-references (empty `nitpick_ignore`)

Now that prawcore publishes documentation at https://prawcore.readthedocs.io/, wire it up and eliminate **every** `nitpick_ignore` entry so the docs build fully nitpicky with no suppressions:

- **prawcore intersphinx** — `prawcore.requestor.Requestor` and `prawcore.auth.BaseAuthorizer` now render as real cross-references.
- **Dead entries** — remove `IO` and `praw.models.redditors.PartialRedditor` (no longer unresolved).
- **datetime** — annotate the `*_datetime` properties with the canonical `datetime.datetime` so they resolve against the Python inventory.
- **ListingGeneratorKwargs** — document the `TypedDict` so the `Unpack[...]` annotations resolve (44 references) and readers can see the accepted `**generator_kwargs`.

## Modernize docs tooling and drop vestigial config

- Replace the legacy `Makefile`/`make.bat` (which still carried the old `PythonRedditAPIWrapper` project name) with the modern minimal sphinx-quickstart templates.
- Remove default/unused `conf.py` settings (`htmlhelp_basename`, `master_doc`, `nitpick_ignore`, `pygments_style`, `source_suffix`, `suppress_warnings`).
- Enable `fail_on_warning` in the Read the Docs config so the published build enforces the same strictness as the local nitpicky build.

Verified: strict `sphinx-build -W -n` passes with zero suppressions, `make html` works, pyright 0 errors, ruff + docstrfmt clean, affected unit tests pass.