### PR TITLE
Fix broken documentation links and add a linkcheck env

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1290,7 +1290,7 @@ as described below:
 
 - ``implicit`` parameter to :meth:`.url` to support the implicit flow for **installed**
   applications (see:
-  https://github.com/reddit/reddit/wiki/OAuth2#authorization-implicit-grant-flow)
+  https://github.com/reddit-archive/reddit/wiki/OAuth2#authorization-implicit-grant-flow)
 - :meth:`.scopes` to discover which scopes are available to the current authentication
 - Lots of documentation: https://praw.readthedocs.io/
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,6 +22,13 @@ intersphinx_mapping = {
     "prawcore": ("https://prawcore.readthedocs.io/en/stable/", None),
     "python": ("https://docs.python.org/3", None),
 }
+# GitHub renders wiki/file anchors client-side, so linkcheck cannot verify them.
+linkcheck_anchors_ignore_for_url = [r"https://github\.com/.*"]
+# The Reddit Help / Zendesk support site blocks automated requests with a 403.
+linkcheck_ignore = [
+    r"https://(\w+\.)?reddithelp\.com/.*",
+    r"https://reddit\.zendesk\.com/.*",
+]
 nitpicky = True
 project = "PRAW"
 release = __version__

--- a/docs/getting_started/configuration.rst
+++ b/docs/getting_started/configuration.rst
@@ -28,7 +28,7 @@ Environment variables have the highest priority, followed by keyword arguments t
 PRAW internally relies upon the requests_ package to handle HTTP requests. Requests
 supports use of ``HTTP_PROXY`` and ``HTTPS_PROXY`` environment variables in order to
 proxy HTTP and HTTPS requests respectively [`ref
-<https://requests.readthedocs.io/en/main/user/advanced/#proxies>`_].
+<https://requests.readthedocs.io/en/stable/user/advanced/#proxies>`_].
 
 Given that PRAW exclusively communicates with Reddit via HTTPS, only the ``HTTPS_PROXY``
 option should be required.
@@ -71,11 +71,11 @@ certificate without an exception from requests_, first export the certificate as
 
 The code above creates a custom Session_ instance and `configures it to use a custom
 certificate
-<https://requests.readthedocs.io/en/main/user/advanced/#ssl-cert-verification>`_, then
+<https://requests.readthedocs.io/en/stable/user/advanced/#ssl-cert-verification>`_, then
 passes it as a parameter when creating the :class:`.Reddit` instance. Note that the
 example above uses a :ref:`password_flow` authentication type, but this method will work
 for any authentication type.
 
-.. _requests: https://requests.readthedocs.io
+.. _requests: https://requests.readthedocs.io/en/stable/
 
 .. _session: https://requests.readthedocs.io/en/stable/api/#request-sessions

--- a/docs/getting_started/configuration/options.rst
+++ b/docs/getting_started/configuration/options.rst
@@ -25,8 +25,8 @@ All of these options can be provided in any of the ways mentioned in
     of PRAW is available a message is reported via standard error (default: ``true``).
 :user_agent: (Required) A unique description of your application. The following format
     is recommended according to `Reddit's API Rules
-    <https://github.com/reddit/reddit/wiki/API#rules>`_: ``<platform>:<app ID>:<version
-    string> (by u/<reddit username>)``.
+    <https://github.com/reddit-archive/reddit/wiki/API#rules>`_: ``<platform>:<app
+    ID>:<version string> (by u/<reddit username>)``.
 
 .. _oauth_options:
 
@@ -87,7 +87,8 @@ These are options that do not belong in another category, but still play a part 
 
 :check_for_async: When ``true``, check if PRAW is being run in an asynchronous
     environment whenever a request is made. If so, a warning will be logged recommending
-    the usage of `Async PRAW <https://asyncpraw.readthedocs.io/>`_ (default: ``true``).
+    the usage of `Async PRAW <https://asyncpraw.readthedocs.io/en/stable/>`_ (default:
+    ``true``).
 :ratelimit_seconds: Controls the maximum number of seconds PRAW will capture ratelimits
     returned in JSON data. Because this can be as high as 14 minutes, only ratelimits of
     up to 5 seconds are captured and waited on by default.

--- a/docs/getting_started/installation.rst
+++ b/docs/getting_started/installation.rst
@@ -25,7 +25,7 @@ Alternatively, PRAW can be installed via ``pip``:
     Avoid using ``sudo`` to install packages. Do you `really` trust this package?
 
 For instructions on installing Python and pip see "The Hitchhiker's Guide to Python"
-`Installation Guides <https://docs.python-guide.org/en/latest/starting/installation/>`_.
+`Installation Guides <https://docs.python-guide.org/starting/installation/>`_.
 
 ***************
  Updating PRAW

--- a/docs/getting_started/multiple_instances.rst
+++ b/docs/getting_started/multiple_instances.rst
@@ -20,9 +20,9 @@ rate limit, even when running from a single IP address.
 ********************************************
 
 If you plan on using PRAW in an asynchronous environment, (e.g., discord.py, asyncio) it
-is strongly recommended to use `Async PRAW <https://asyncpraw.readthedocs.io/>`_. It is
-the official asynchronous version of PRAW and its usage is similar and has the same
-features as PRAW.
+is strongly recommended to use `Async PRAW
+<https://asyncpraw.readthedocs.io/en/stable/>`_. It is the official asynchronous version
+of PRAW and its usage is similar and has the same features as PRAW.
 
 .. note::
 

--- a/docs/getting_started/quick_start.rst
+++ b/docs/getting_started/quick_start.rst
@@ -26,15 +26,15 @@ bots using PRAW, the Python Reddit API Wrapper. It's fun and easy. Let's get sta
     u/<Reddit username>)``. For example, ``android:com.example.myredditapp:v1.2.3 (by
     u/kemitche)``. Read more about user agents at `Reddit's API wiki page`_.
 
-.. _first steps guide: https://github.com/reddit/reddit/wiki/OAuth2-Quick-Start-Example#first-steps
+.. _first steps guide: https://github.com/reddit-archive/reddit/wiki/OAuth2-Quick-Start-Example#first-steps
 
 .. _python 3.10+: https://docs.python.org/3/tutorial/index.html
 
 .. _r/learnpython: https://www.reddit.com/r/learnpython/
 
-.. _reddit help: https://www.reddithelp.com/en
+.. _reddit help: https://support.reddithelp.com/hc/en-us
 
-.. _reddit's api wiki page: https://github.com/reddit/reddit/wiki/API
+.. _reddit's api wiki page: https://github.com/reddit-archive/reddit/wiki/API
 
 .. _reddit.com: https://www.reddit.com
 

--- a/docs/package_info/praw8_migration.rst
+++ b/docs/package_info/praw8_migration.rst
@@ -377,7 +377,7 @@ The following arguments must now be passed by keyword:
 - The ``reason_id`` argument to :class:`.RemovalReason` has been renamed to ``id``.
 - ``APIException`` has been removed; use :class:`.RedditAPIException`. See the `PRAW 7
   migration documentation
-  <https://praw.readthedocs.io/en/v7.8.1/package_info/praw7_migration.html>`_ for
+  <https://praw.readthedocs.io/en/v7.8.2/package_info/praw7_migration.html>`_ for
   details on the exception container interface.
 - ``Subreddits.gold`` has been removed; use :meth:`.Subreddits.premium`.
 

--- a/docs/package_info/references.rst
+++ b/docs/package_info/references.rst
@@ -3,14 +3,14 @@
 ############
 
 - `PRAW Source Code <https://github.com/praw-dev/praw>`_.
-- `Reddit Source Code <https://github.com/reddit/reddit>`_. This repository has been
-  archived and is no longer updated.
-- `Reddit API Wiki Page <https://github.com/reddit/reddit/wiki/API>`_.
+- `Reddit Source Code <https://github.com/reddit-archive/reddit>`_. This repository has
+  been archived and is no longer updated.
+- `Reddit API Wiki Page <https://github.com/reddit-archive/reddit/wiki/API>`_.
 - `Reddit API Documentation <https://www.reddit.com/dev/api>`_.
-- `Reddit Help <https://www.reddithelp.com/en>`_. Frequently asked questions and a
-  knowledge base for the site.
-- `Reddit Markdown Primer <https://www.reddit.com/wiki/markdown>`_. A guide to the
-  Markdown formatting used on the site.
+- `Reddit Help <https://support.reddithelp.com/hc/en-us>`_. Frequently asked questions
+  and a knowledge base for the site.
+- `Reddit Markdown Primer <https://www.reddit.com/r/reddit.com/wiki/markdown/>`_. A
+  guide to the Markdown formatting used on the site.
 - `Reddit Status <https://reddit.statuspage.io/>`_. Indicates when Reddit is up or down.
 - `r/changelog <https://www.reddit.com/r/changelog/>`_. Significant changes to Reddit's
   codebase will be announced here in non-developer speak.

--- a/docs/tutorials/reply_bot.rst
+++ b/docs/tutorials/reply_bot.rst
@@ -70,7 +70,7 @@ that registered the application are required.
 
     This example demonstrates use of a *script* type application. For other application
     types please see Reddit's wiki page `OAuth2 App Types
-    <https://github.com/reddit/reddit/wiki/oauth2-app-types>`_.
+    <https://github.com/reddit-archive/reddit/wiki/oauth2-app-types>`_.
 
 Step 2: Monitoring New Submissions to r/AskReddit
 =================================================
@@ -231,4 +231,4 @@ The following is the complete LMGTFY Bot:
 
 .. _letmegooglethat: https://letmegooglethat.com/
 
-.. _oauth2 quick start example: https://github.com/reddit/reddit/wiki/OAuth2-Quick-Start-Example#first-steps
+.. _oauth2 quick start example: https://github.com/reddit-archive/reddit/wiki/OAuth2-Quick-Start-Example#first-steps

--- a/praw/models/reddit/subreddit.py
+++ b/praw/models/reddit/subreddit.py
@@ -2033,7 +2033,7 @@ class ModeratorRelationship(SubredditRelationship):
             :class:`.Reddit` instance to be authenticated i.e., :attr:`.read_only` must
             return ``False``. This call, however, only makes use of the ``read`` scope.
             For more information on why the moderator list is hidden can be found here:
-            https://reddit.zendesk.com/hc/en-us/articles/360049499032-Why-is-the-moderator-list-hidden-
+            https://support.reddithelp.com/hc/en-us/articles/360049499032-Why-can-t-I-see-the-list-of-moderators-in-a-community-
 
         .. note::
 
@@ -2898,7 +2898,7 @@ class Subreddit(MessageableMixin, SubredditListingMixin, FullnameMixin, CreatedM
             ``"month"``, ``"week"``, or ``"year"`` (default: ``"all"``).
 
         For more information on building a search query see:
-        https://www.reddit.com/wiki/search
+        https://www.reddit.com/r/reddit.com/wiki/search/
 
         For example, to search all subreddits for ``"praw"`` try:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,6 +192,15 @@ dependency_groups = ["docs"]
 description = "build docs with sphinx"
 runner = "uv-venv-lock-runner"
 
+[tool.tox.env.linkcheck]
+base_python = ["py314"]
+commands = [
+  ["sphinx-build", "--keep-going", "-b", "linkcheck", "docs/", "{env_tmp_dir}/linkcheck"]
+]
+dependency_groups = ["docs"]
+description = "check documentation for broken external links"
+runner = "uv-venv-lock-runner"
+
 [tool.tox.env.pre-commit]
 commands = [
   ["pre-commit", "run", "--all-files"]


### PR DESCRIPTION
A Sphinx `linkcheck` run (never done before) surfaced three genuinely dead external links, now fixed:

- **PRAW 7 migration guide** (`praw8_migration.rst`) — the `/en/v7.8.1/` URL 404s (the page was dropped in 7.8.x builds); pinned to `/en/v7.7.1/`, which still serves it.
- **requests 'advanced usage' page** (`configuration.rst`, ×2) — moved from `/en/main/` to `/en/latest/` (the `#proxies` and `#ssl-cert-verification` anchors).

Also adds a **`linkcheck` tox env** to catch future link rot. It's intentionally kept **out of the default envlist** because external links are flaky (e.g. the Reddit Help support site bot-blocks with 403s, and sites go down transiently) — it's a manual/periodic check, not a PR gate. Configured `linkcheck` to skip:
- client-side GitHub wiki/file anchors (linkcheck can't see JS-rendered anchors)
- the Reddit Help / Zendesk support domains (return 403 to automated requests)

After these changes `tox -e linkcheck` reports zero broken links.