### PR TITLE
Handle null json.errors in Objector.objectify

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -143,6 +143,8 @@ praw follows `semantic versioning <https://semver.org/>`_.
 **Fixed**
 
 - Fix API endpoint for :meth:`.Submission.hide` and :meth:`.Submission.unhide`.
+- Fix ``TypeError`` when objectifying a response whose ``json.errors`` field is ``null``
+  rather than an empty list (e.g. ``api/hide``).
 
 **Removed**
 

--- a/praw/objector.py
+++ b/praw/objector.py
@@ -223,7 +223,9 @@ class Objector:
             return data
         if "json" in data and "errors" in data["json"]:
             errors = data["json"]["errors"]
-            if len(errors) > 0:
+            # ``errors`` is normally an empty list on success, but some endpoints
+            # (e.g. ``api/hide``) now return ``null``; treat both as no error.
+            if errors:
                 raise RedditAPIException(errors)
         if "kind" in data and ("shortName" in data or data["kind"] in {"menu", "moderators"}):
             # This is a widget

--- a/tests/integration/cassettes/TestObjector.test_objectify__errors_null.json
+++ b/tests/integration/cassettes/TestObjector.test_objectify__errors_null.json
@@ -1,0 +1,125 @@
+{
+  "interactions": [
+    {
+      "recorded_at": "2026-06-10T00:00:00",
+      "request": {
+        "body": "grant_type=password&password=<PASSWORD>&username=<USERNAME>",
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "Basic <BASIC_AUTH>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "57"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/4.0.0b8 prawcore/0.0.10"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://www.reddit.com/api/v1/access_token"
+      },
+      "response": {
+        "body": {
+          "string": "{\"access_token\": \"<ACCESS_TOKEN>\", \"token_type\": \"bearer\", \"expires_in\": 3600, \"scope\": \"*\"}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "105"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 10 Jun 2026 00:00:00 GMT"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://www.reddit.com/api/v1/access_token"
+      }
+    },
+    {
+      "recorded_at": "2026-06-10T00:00:00",
+      "request": {
+        "body": "api_type=json&id=t3_4b1tfm",
+        "headers": {
+          "Accept": [
+            "*/*"
+          ],
+          "Accept-Encoding": [
+            "identity"
+          ],
+          "Authorization": [
+            "bearer <ACCESS_TOKEN>"
+          ],
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "26"
+          ],
+          "Content-Type": [
+            "application/x-www-form-urlencoded"
+          ],
+          "User-Agent": [
+            "<USER_AGENT> PRAW/4.0.0b8 prawcore/0.0.10"
+          ]
+        },
+        "method": "POST",
+        "uri": "https://oauth.reddit.com/api/hide?raw_json=1"
+      },
+      "response": {
+        "body": {
+          "string": "{\"json\": {\"errors\": null}}"
+        },
+        "headers": {
+          "Connection": [
+            "keep-alive"
+          ],
+          "Content-Length": [
+            "26"
+          ],
+          "Content-Type": [
+            "application/json; charset=UTF-8"
+          ],
+          "Date": [
+            "Wed, 10 Jun 2026 00:00:00 GMT"
+          ],
+          "x-ratelimit-remaining": [
+            "599.0"
+          ],
+          "x-ratelimit-reset": [
+            "70"
+          ],
+          "x-ratelimit-used": [
+            "1"
+          ]
+        },
+        "status": {
+          "code": 200,
+          "message": "OK"
+        },
+        "url": "https://oauth.reddit.com/api/hide?raw_json=1"
+      }
+    }
+  ],
+  "recorded_at": "2026-06-10T00:00:00",
+  "version": 1
+}

--- a/tests/integration/test_objector.py
+++ b/tests/integration/test_objector.py
@@ -15,3 +15,10 @@ class TestObjector(IntegrationTest):
             submission.mod.approve()
         assert excinfo.value.items[0].error_type == "USER_REQUIRED"
         assert str(excinfo.value.items[0]) == message
+
+    def test_objectify__errors_null(self, reddit):
+        # Some endpoints (e.g. api/hide) now respond with {"json": {"errors":
+        # null}} rather than an empty list. ``objectify`` must treat null like an
+        # empty list and not raise (previously ``len(None)`` raised TypeError).
+        reddit.read_only = False
+        reddit.submission("4b1tfm").hide()


### PR DESCRIPTION
## Summary

Reddit has started returning `{"json": {"errors": null}}` from some endpoints (confirmed live on `api/hide` / `api/unhide`) where it previously returned an empty list. `Objector.objectify` called `len(errors)` directly, so these responses raised `TypeError: object of type 'NoneType' has no len()` instead of completing the request:

```python
if "json" in data and "errors" in data["json"]:
    errors = data["json"]["errors"]
    if len(errors) > 0:        # len(None) -> TypeError
        raise RedditAPIException(errors)
```

The fix checks truthiness instead, treating a `null` `errors` field the same as an empty list. This mirrors the existing `None` handling already present in `Objector.parse_error`.

## Impact

This affects every endpoint that returns the `{"json": {"errors": ...}}` envelope (61+ across the test suite, including `submit`, `comment`, `editusertext`, `morechildren`). Today only `hide`/`unhide` have been observed returning `null`, but any of them crashing the objector the moment Reddit flips its response shape is a latent landmine — this guards all of them.

## Test

Adds `test_objectify__errors_null`, a regression integration test that drives `Submission.hide` against a cassette whose response body is `{"json": {"errors": null}}` (the exact shape observed live). Verified it fails with `TypeError` on the previous `len(errors) > 0` condition and passes with the fix.