### PR TITLE
Document that Redditor.overview matches the direct sort methods

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -35,7 +35,11 @@ praw follows `semantic versioning <https://semver.org/>`_.
   :class:`datetime.datetime` objects (``read_datetime`` is ``None`` for unread
   announcements).
 - :meth:`.Redditor.overview` to iterate over a Redditor's combined comments and
-  submissions, mirroring the user overview page on Reddit.
+  submissions, mirroring the user overview page on Reddit. It returns the same listing
+  as calling a sort method directly on a :class:`.Redditor`, so
+  ``redditor.overview.new()`` and ``redditor.new()`` yield the same items; use
+  ``redditor.comments`` or ``redditor.submissions`` to restrict the listing to a single
+  type.
 - An ``exception_handler`` keyword argument to :func:`.stream_generator` (and thus all
   ``stream`` methods) that is invoked with any exception raised while fetching items,
   allowing the stream to resume rather than terminate. Re-raise from the handler to stop

--- a/praw/models/listing/mixins/redditor.py
+++ b/praw/models/listing/mixins/redditor.py
@@ -43,6 +43,14 @@ class RedditorListingMixin(BaseListingMixin):
         The overview combines a Redditor's comments and submissions, mirroring the user
         overview page on Reddit.
 
+        .. note::
+
+            This is the same listing produced by calling a sort method directly on the
+            :class:`.Redditor` instance, so ``reddit.redditor("spez").overview.new()``
+            and ``reddit.redditor("spez").new()`` yield the same items. Use
+            :attr:`.comments` or :attr:`.submissions` to restrict the listing to a
+            single type.
+
         For example, to output the first line of all top items by u/spez try:
 
         .. code-block:: python


### PR DESCRIPTION
Clarifies that `redditor.overview.new()` and `redditor.new()` return the same listing — the Redditor's combined comments and submissions.

A user asked whether `redditor.overview.new()` differs from `redditor.new()`. It doesn't: a `Redditor` sets `_listing_use_sort`, so its base listing methods request the bare `/user/<name>/` endpoint (which Reddit serves as the overview), while `overview` requests `/user/<name>/overview` explicitly — the same listing. Verified live against u/spez, u/reddit, u/Lil_SpazJoekp, and u/bboe at `limit=1000`: identical items in identical order for every account.

This adds a `.. note::` to the `Redditor.overview` docstring and expands the changelog entry that introduced it, pointing users to `redditor.comments` / `redditor.submissions` for the single-type listings. Docs build clean under `-W -n`.