### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     secrets:
       NETWORK_TEST_CLIENT_ID: ${{ secrets.NETWORK_TEST_CLIENT_ID }}
       NETWORK_TEST_CLIENT_SECRET: ${{ secrets.NETWORK_TEST_CLIENT_SECRET }}
-    uses: praw-dev/.github/.github/workflows/ci.yml@9ff8957d0cab4cf8c9d7cb5592aedb3d456cc058 # v1.4.0
+    uses: praw-dev/.github/.github/workflows/ci.yml@aa63811572338b6343772c542574909f1cbd8d78 # v1.5.0
     with:
       min_python: "3.10"
       network_test: true

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,15 @@
+concurrency:
+  group: lint-${{ github.ref }}
+  cancel-in-progress: true
+jobs:
+  lint:
+    name: Lint workflows
+    permissions:
+      contents: read # required to check out the repository
+    uses: praw-dev/.github/.github/workflows/lint.yml@aa63811572338b6343772c542574909f1cbd8d78 # v1.5.0
+name: Lint workflows
+on:
+  pull_request:
+  push:
+    branches: ["main"]
+permissions: {}

--- a/.github/workflows/pre-commit_autoupdate.yml
+++ b/.github/workflows/pre-commit_autoupdate.yml
@@ -4,7 +4,7 @@ jobs:
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-    uses: praw-dev/.github/.github/workflows/pre-commit_autoupdate.yml@9ff8957d0cab4cf8c9d7cb5592aedb3d456cc058 # v1.4.0
+    uses: praw-dev/.github/.github/workflows/pre-commit_autoupdate.yml@aa63811572338b6343772c542574909f1cbd8d78 # v1.5.0
 name: Update pre-commit hooks
 on:
   schedule:

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -4,7 +4,7 @@ jobs:
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-    uses: praw-dev/.github/.github/workflows/prepare_release.yml@9ff8957d0cab4cf8c9d7cb5592aedb3d456cc058 # v1.4.0
+    uses: praw-dev/.github/.github/workflows/prepare_release.yml@aa63811572338b6343772c542574909f1cbd8d78 # v1.5.0
     with:
       package: praw
       version: ${{ inputs.version }}

--- a/.github/workflows/set_active_docs.yml
+++ b/.github/workflows/set_active_docs.yml
@@ -3,7 +3,7 @@ jobs:
     name: Set Active Docs
     secrets:
       READTHEDOCS_TOKEN: ${{ secrets.READTHEDOCS_TOKEN }}
-    uses: praw-dev/.github/.github/workflows/set_active_docs.yml@9ff8957d0cab4cf8c9d7cb5592aedb3d456cc058 # v1.4.0
+    uses: praw-dev/.github/.github/workflows/set_active_docs.yml@aa63811572338b6343772c542574909f1cbd8d78 # v1.5.0
 name: Set Active Docs
 on:
   release:

--- a/.github/workflows/stale_action.yml
+++ b/.github/workflows/stale_action.yml
@@ -1,12 +1,13 @@
 jobs:
   stale_action:
     name: Close stale issues and PRs
+    permissions:
+      issues: write # required to comment on and close stale issues
+      pull-requests: write # required to comment on and close stale PRs
     uses: praw-dev/.github/.github/workflows/stale_action.yml@9ff8957d0cab4cf8c9d7cb5592aedb3d456cc058 # v1.4.0
 name: Close stale issues and PRs
 on:
   schedule:
     - cron: 0 */6 * * *
   workflow_dispatch:
-permissions:
-  issues: write
-  pull-requests: write
+permissions: {}

--- a/.github/workflows/stale_action.yml
+++ b/.github/workflows/stale_action.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       issues: write # required to comment on and close stale issues
       pull-requests: write # required to comment on and close stale PRs
-    uses: praw-dev/.github/.github/workflows/stale_action.yml@9ff8957d0cab4cf8c9d7cb5592aedb3d456cc058 # v1.4.0
+    uses: praw-dev/.github/.github/workflows/stale_action.yml@aa63811572338b6343772c542574909f1cbd8d78 # v1.5.0
 name: Close stale issues and PRs
 on:
   schedule:

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -1,10 +1,11 @@
 jobs:
   tag_release:
     name: Tag Release
+    permissions:
+      contents: write # required to push the release tag
     uses: praw-dev/.github/.github/workflows/tag_release.yml@20f00d1404e64813b40e0cff3a70dc9cd8b8b34e # v1.3.3
 name: Tag Release
 on:
   push:
     branches: [ main, release_test ]
-permissions:
-  contents: write
+permissions: {}

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -3,7 +3,7 @@ jobs:
     name: Tag Release
     permissions:
       contents: write # required to push the release tag
-    uses: praw-dev/.github/.github/workflows/tag_release.yml@20f00d1404e64813b40e0cff3a70dc9cd8b8b34e # v1.3.3
+    uses: praw-dev/.github/.github/workflows/tag_release.yml@aa63811572338b6343772c542574909f1cbd8d78 # v1.5.0
 name: Tag Release
 on:
   push:


### PR DESCRIPTION
Hardens this repo's GitHub Actions workflows, part of an org-wide pass driven by [zizmor](https://docs.zizmor.sh/).

## Changes

- **Scope `GITHUB_TOKEN` permissions to the job level** in `stale_action.yml` and `tag_release.yml`, with a deny-all `permissions: {}` default at the top level. Resolves zizmor's high-severity `excessive-permissions` findings and documents each scope; no change to the effective granted permissions.
- **Add `lint.yml`** — a thin caller of the new reusable `actionlint` + `zizmor` workflow in `praw-dev/.github` (pinned to v1.5.0), so workflow files are linted on every push/PR.