### PR TITLE
Resolve zizmor pedantic workflow findings

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,13 @@ updates:
       interval: monthly
     labels:
       - "Dependencies"
+    cooldown:
+      default-days: 1
   - package-ecosystem: uv
     directory: /
     schedule:
       interval: monthly
     labels:
       - "Dependencies"
+    cooldown:
+      default-days: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     secrets:
       NETWORK_TEST_CLIENT_ID: ${{ secrets.NETWORK_TEST_CLIENT_ID }}
       NETWORK_TEST_CLIENT_SECRET: ${{ secrets.NETWORK_TEST_CLIENT_SECRET }}
-    uses: praw-dev/.github/.github/workflows/ci.yml@aa63811572338b6343772c542574909f1cbd8d78 # v1.5.0
+    uses: praw-dev/.github/.github/workflows/ci.yml@ec3a733628adc5bd596def5294dae9fb4eb1e501 # v1.6.0
     with:
       min_python: "3.10"
       network_test: true
@@ -18,4 +18,5 @@ on:
   push:
     branches: ["main"]
   pull_request:
-permissions: read-all
+permissions:
+  contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,7 +6,7 @@ jobs:
     name: Lint workflows
     permissions:
       contents: read # required to check out the repository
-    uses: praw-dev/.github/.github/workflows/lint.yml@aa63811572338b6343772c542574909f1cbd8d78 # v1.5.0
+    uses: praw-dev/.github/.github/workflows/lint.yml@ec3a733628adc5bd596def5294dae9fb4eb1e501 # v1.6.0
 name: Lint workflows
 on:
   pull_request:

--- a/.github/workflows/pre-commit_autoupdate.yml
+++ b/.github/workflows/pre-commit_autoupdate.yml
@@ -4,7 +4,7 @@ jobs:
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-    uses: praw-dev/.github/.github/workflows/pre-commit_autoupdate.yml@aa63811572338b6343772c542574909f1cbd8d78 # v1.5.0
+    uses: praw-dev/.github/.github/workflows/pre-commit_autoupdate.yml@ec3a733628adc5bd596def5294dae9fb4eb1e501 # v1.6.0
 name: Update pre-commit hooks
 on:
   schedule:

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -4,7 +4,7 @@ jobs:
     secrets:
       APP_ID: ${{ secrets.APP_ID }}
       APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}
-    uses: praw-dev/.github/.github/workflows/prepare_release.yml@aa63811572338b6343772c542574909f1cbd8d78 # v1.5.0
+    uses: praw-dev/.github/.github/workflows/prepare_release.yml@ec3a733628adc5bd596def5294dae9fb4eb1e501 # v1.6.0
     with:
       package: praw
       version: ${{ inputs.version }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,9 +1,12 @@
+concurrency:
+  group: pypi-${{ github.ref }}
+  cancel-in-progress: false
 jobs:
   pypi-publish:
     environment: release
     name: Upload release to PyPI
     permissions:
-      id-token: write
+      id-token: write # required for PyPI trusted publishing
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -13,17 +13,18 @@ on:
     - cron: '36 1 * * 3'
   push:
     branches: [ "main" ]
-# Declare default permissions as read only.
-permissions: read-all
+concurrency:
+  group: scorecard-${{ github.ref }}
+  cancel-in-progress: true
+# No workflow-level permissions; the analysis job grants its own.
+permissions: {}
 jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
     permissions:
-      # Needed to upload the results to code-scanning dashboard.
-      security-events: write
-      # Needed to publish results and get a badge (see publish_results below).
-      id-token: write
+      security-events: write # upload results to the code-scanning dashboard
+      id-token: write # publish results and get a badge (see publish_results below)
       # Uncomment the permissions below if installing in a private repository.
       # contents: read
       # actions: read

--- a/.github/workflows/set_active_docs.yml
+++ b/.github/workflows/set_active_docs.yml
@@ -3,7 +3,7 @@ jobs:
     name: Set Active Docs
     secrets:
       READTHEDOCS_TOKEN: ${{ secrets.READTHEDOCS_TOKEN }}
-    uses: praw-dev/.github/.github/workflows/set_active_docs.yml@aa63811572338b6343772c542574909f1cbd8d78 # v1.5.0
+    uses: praw-dev/.github/.github/workflows/set_active_docs.yml@ec3a733628adc5bd596def5294dae9fb4eb1e501 # v1.6.0
 name: Set Active Docs
 on:
   release:

--- a/.github/workflows/stale_action.yml
+++ b/.github/workflows/stale_action.yml
@@ -4,7 +4,7 @@ jobs:
     permissions:
       issues: write # required to comment on and close stale issues
       pull-requests: write # required to comment on and close stale PRs
-    uses: praw-dev/.github/.github/workflows/stale_action.yml@aa63811572338b6343772c542574909f1cbd8d78 # v1.5.0
+    uses: praw-dev/.github/.github/workflows/stale_action.yml@ec3a733628adc5bd596def5294dae9fb4eb1e501 # v1.6.0
 name: Close stale issues and PRs
 on:
   schedule:

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -3,7 +3,7 @@ jobs:
     name: Tag Release
     permissions:
       contents: write # required to push the release tag
-    uses: praw-dev/.github/.github/workflows/tag_release.yml@aa63811572338b6343772c542574909f1cbd8d78 # v1.5.0
+    uses: praw-dev/.github/.github/workflows/tag_release.yml@ec3a733628adc5bd596def5294dae9fb4eb1e501 # v1.6.0
 name: Tag Release
 on:
   push:


### PR DESCRIPTION
Clears the remaining advisory [zizmor](https://docs.zizmor.sh/) `--pedantic` findings and bumps the `praw-dev/.github` reusable-workflow pins to v1.6.0.

## Changes

- **`ci.yml`** — workflow-level `read-all` → `contents: read` (`excessive-permissions`).
- **`scorecard.yml`** — `read-all` → `{}` (the analysis job keeps its own scoped grant), inline permission comments (`undocumented-permissions`), and a `concurrency:` group (`concurrency-limits`).
- **`pypi.yml`** — inline comment on `id-token: write` (`undocumented-permissions`) and a `concurrency:` group (`concurrency-limits`).
- **`dependabot.yml`** — add a 1-day `cooldown` (`dependabot-cooldown`).
- Bump all `praw-dev/.github` reusable-workflow pins to **v1.6.0**.

Verified: `zizmor --pedantic` reports no findings and `actionlint` passes.