### PR TITLE
Document v8 keyword-only argument change in changelog

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -73,6 +73,12 @@ praw follows `semantic versioning <https://semver.org/>`_.
 
 **Changed**
 
+- Arguments deprecated for positional use in PRAW 7 are now keyword-only across most
+  methods, fulfilling the deprecation announced in 7.6.0. Notably, the ``time_filter``
+  argument to listing methods such as :meth:`.Subreddit.top` and
+  :meth:`.Subreddit.controversial` — shown positionally in older documentation (for
+  example ``subreddit.top("all")``) — must now be passed by keyword
+  (``subreddit.top(time_filter="all")``).
 - Bumped prawcore to 3.0.2.
 - Drop support for Python 3.8, which was end-of-life on 2024-10-07.
 - Drop support for Python 3.9, which was end-of-life on 2025-10-31.


### PR DESCRIPTION
## Summary

In PRAW 8.0.0, arguments that were deprecated for positional use in PRAW 7 became keyword-only across most methods, fulfilling the deprecation announced in 7.6.0. The 8.0.0 changelog lists a few specific keyword-only changes (e.g. `data` on `Objector.objectify`, `mark_read` on `subreddit.modmail`) but never states this general rule, and never mentions the most commonly-hit case: the `time_filter` argument on listing methods such as `Subreddit.top` and `Subreddit.controversial`.

Older documentation and examples show `time_filter` positionally (for example `subreddit.top("all")`), so users upgrading to 8.0.0 hit a `TypeError` with no changelog entry explaining the change. This adds a generic-plus-specific bullet to the 8.0.0 **Changed** section:

```
subreddit.top("all")              # used to work
subreddit.top(time_filter="all")  # now required
```

## Context

Reported on the Async PRAW side as praw-dev/asyncpraw#382. This is the sync PRAW counterpart of the same changelog gap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)