### PR TITLE
Group Dependabot updates into one PR per ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
       - "Dependencies"
     cooldown:
       default-days: 1
+    groups:
+      github-actions:
+        patterns:
+          - "*"
   - package-ecosystem: uv
     directory: /
     schedule:
@@ -16,3 +20,7 @@ updates:
       - "Dependencies"
     cooldown:
       default-days: 1
+    groups:
+      python:
+        patterns:
+          - "*"


### PR DESCRIPTION
Collapse Dependabot version bumps into a single PR per ecosystem (one for github-actions, one for python) to cut down on PR volume.