### PR TITLE
Rewind file streams before rate-limit retries

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,12 @@ praw follows `semantic versioning <https://semver.org/>`_.
  Unreleased
 ************
 
+**Fixed**
+
+- :meth:`.Reddit.post` rewinds seekable file objects before retrying a request after a
+  rate limit response. Previously the retry read from the exhausted stream, which could
+  upload empty or truncated file contents.
+
 ********************
  8.0.2 (2026/06/24)
 ********************

--- a/praw/reddit.py
+++ b/praw/reddit.py
@@ -811,10 +811,25 @@ class Reddit:
         if json is None:
             data = data or {}
 
-        attempts = 3
+        file_positions: dict[str, int] = {}
+        if files:
+            for name, file in files.items():
+                try:
+                    position = file.tell()
+                    file.seek(position)
+                except (AttributeError, OSError, ValueError):
+                    continue
+                file_positions[name] = position
+
+        max_attempts = 3
+        attempts = max_attempts
         last_exception: RedditAPIException | None = None
         while attempts > 0:
             attempts -= 1
+            if attempts < max_attempts - 1 and file_positions:
+                assert files is not None
+                for name, position in file_positions.items():
+                    files[name].seek(position)
             try:
                 return self._objectify_request(
                     data=data,

--- a/praw/reddit.py
+++ b/praw/reddit.py
@@ -807,6 +807,12 @@ class Reddit:
             provided, ``data`` should not be.
         :param params: The query parameters to add to the request (default: ``None``).
 
+        .. note::
+
+            This method automatically retries after a rate limit response. Only seekable
+            file objects are rewound between attempts; a non-seekable object may be
+            transmitted incompletely if a retry occurs.
+
         """
         if json is None:
             data = data or {}
@@ -821,12 +827,9 @@ class Reddit:
                     continue
                 file_positions[name] = position
 
-        max_attempts = 3
-        attempts = max_attempts
         last_exception: RedditAPIException | None = None
-        while attempts > 0:
-            attempts -= 1
-            if attempts < max_attempts - 1 and file_positions:
+        for attempt in range(3):
+            if attempt and file_positions:
                 assert files is not None
                 for name, position in file_positions.items():
                     files[name].seek(position)

--- a/tests/unit/test_reddit.py
+++ b/tests/unit/test_reddit.py
@@ -1,6 +1,7 @@
 import asyncio
 import configparser
 import types
+from io import BytesIO
 from unittest import mock
 from unittest.mock import MagicMock
 
@@ -11,7 +12,7 @@ from prawcore.exceptions import BadRequest
 
 from praw import Reddit, __version__
 from praw.config import Config
-from praw.exceptions import ClientException, RedditAPIException
+from praw.exceptions import ClientException, RedditAPIException, RedditErrorItem
 
 from . import UnitTest
 
@@ -191,6 +192,43 @@ class TestReddit(UnitTest):
             reddit.post("test")
         assert exception.value.items[0].message == "You are doing that too much. Try again in 6 seconds."
         mock_sleep.assert_not_called()
+
+    def test_post_ratelimit__rewinds_file_streams(self, reddit):
+        upload = BytesIO(b"prefixcomplete file contents")
+        upload.seek(len(b"prefix"))
+        bodies_read = []
+        rate_limit_exception = RedditAPIException([
+            RedditErrorItem(
+                "RATELIMIT",
+                field="ratelimit",
+                message="Try again shortly.",
+            )
+        ])
+
+        def objectify_request(*, files, **_):
+            body = files["file"].read()
+            bodies_read.append(body)
+            if len(bodies_read) == 1:
+                raise rate_limit_exception
+            return body
+
+        with (
+            mock.patch.object(
+                reddit,
+                "_objectify_request",
+                side_effect=objectify_request,
+            ),
+            mock.patch.object(
+                reddit,
+                "_handle_rate_limit",
+                return_value=0,
+            ),
+            mock.patch("time.sleep", return_value=None),
+        ):
+            result = reddit.post("test", files={"file": upload})
+
+        assert result == b"complete file contents"
+        assert bodies_read == [b"complete file contents", b"complete file contents"]
 
     @mock.patch(
         "praw.Reddit.request",


### PR DESCRIPTION
## Summary

Rewind seekable multipart file streams before retrying a POST request after a retryable RATELIMIT response.

Without rewinding, the first request consumes the stream and a retry may upload an empty or truncated file.

## Changes

- Record the initial position of seekable file streams passed to Reddit.post()
- Restore those positions before each retry
- Leave non-seekable streams unchanged
- Add a regression test covering a rate-limit retry with a partially advanced BytesIO stream

Fixes #2178

## Tests

- python -m pytest tests/unit/test_reddit.py -k post_ratelimit
- python -m pytest tests/unit/test_reddit.py